### PR TITLE
Fix rpm url

### DIFF
--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -17,7 +17,7 @@
 
 # needsrootforbuild
 
-Url:            http://kiwi.berlios.de
+Url:            http://github.com/openSUSE/kiwi
 Name:           kiwi
 BuildRequires:  perl-Config-IniFiles perl-XML-LibXML perl-libwww-perl
 BuildRequires:  module-init-tools screen zlib-devel


### PR DESCRIPTION
Fix the URL in the rpm, points to github now.
