### PR TITLE
add git pre-commit hook and clean URL module to level 5 (still needs a fi

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,129 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use File::Basename;
+use IPC::Open2;
+
+# The known Perl modules
+my @kiwiModules = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
+					KIWICollect.pm KIWICommandLine.pm KIWIConfigure.pm
+					KIWIGlobals.pm KIWIImageCreator.pm KIWIImageFormat.pm
+					KIWIImage.pm KIWIIsoLinux.pm KIWILocator.pm
+					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
+					KIWIProductData.pm KIWIQX.pm KIWIRepoMetaHandler.pm
+					KIWIRoot.pm KIWIRuntimeChecker.pm KIWISatSolverLegacy.pm
+					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
+					KIWIURL.pm KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm
+					KIWIXMLValidator.pm);
+
+# List of modules not clean to level 1 (brutal) of perlcritic
+my @notClean1 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
+					KIWICollect.pm KIWICommandLine.pm KIWIConfigure.pm
+					KIWIGlobals.pm KIWIImageCreator.pm KIWIImageFormat.pm
+					KIWIImage.pm KIWIIsoLinux.pm KIWILocator.pm
+					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
+					KIWIProductData.pm KIWIQX.pm KIWIRepoMetaHandler.pm
+					KIWIRoot.pm KIWIRuntimeChecker.pm KIWISatSolverLegacy.pm
+					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
+					KIWIURL.pm KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm
+					KIWIXMLValidator.pm);
+# List of modules not clean to level 2 (cruel) of perlcritic
+my @notClean2 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
+					KIWICollect.pm KIWICommandLine.pm KIWIConfigure.pm
+					KIWIGlobals.pm KIWIImageCreator.pm KIWIImageFormat.pm
+					KIWIImage.pm KIWIIsoLinux.pm KIWILocator.pm
+					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
+					KIWIProductData.pm KIWIQX.pm KIWIRepoMetaHandler.pm
+					KIWIRoot.pm KIWIRuntimeChecker.pm KIWISatSolverLegacy.pm
+					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
+					KIWIURL.pm KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm
+					KIWIXMLValidator.pm);
+# List of modules not clean to level 3 (harsh) of perlcritic
+my @notClean3 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
+					KIWICollect.pm KIWICommandLine.pm KIWIConfigure.pm
+					KIWIGlobals.pm KIWIImageCreator.pm KIWIImageFormat.pm
+					KIWIImage.pm KIWIIsoLinux.pm KIWILocator.pm
+					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
+					KIWIProductData.pm KIWIQX.pm KIWIRepoMetaHandler.pm
+					KIWIRoot.pm KIWIRuntimeChecker.pm KIWISatSolverLegacy.pm
+					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
+					KIWIURL.pm KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm
+					KIWIXMLValidator.pm);
+# List of modules not clean to level 4 (stern) of perlcritic
+my @notClean4 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
+					KIWICollect.pm KIWICommandLine.pm KIWIConfigure.pm
+					KIWIGlobals.pm KIWIImageCreator.pm KIWIImageFormat.pm
+					KIWIImage.pm KIWIIsoLinux.pm
+					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
+					KIWIProductData.pm KIWIQX.pm KIWIRepoMetaHandler.pm
+					KIWIRoot.pm KIWIRuntimeChecker.pm KIWISatSolverLegacy.pm
+					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
+					KIWIURL.pm KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm
+					KIWIXMLValidator.pm);
+# List of modules not clean to level 5 (gentel) of perlcritic
+my @notClean5 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
+					KIWICollect.pm KIWICommandLine.pm KIWIConfigure.pm
+					KIWIGlobals.pm KIWIImageCreator.pm KIWIImageFormat.pm
+					KIWIImage.pm KIWIIsoLinux.pm
+					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
+					KIWIProductData.pm KIWIQX.pm KIWIRepoMetaHandler.pm
+					KIWIRoot.pm KIWIRuntimeChecker.pm KIWISatSolverLegacy.pm
+					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
+					KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm);
+
+my ($chld_in, $chld_out);
+my $pid = open2($chld_out, $chld_in, 'git', 'diff-index', '--name-only', 
+				'HEAD');
+waitpid( $pid, 0 );
+
+my @changedFiles;
+# Verify that all Perl modules are known
+while (<$chld_out>) {
+	my $fname = basename($_);
+	chomp $fname;
+	if ($fname =~ /.*\.pm/x) {
+		push @changedFiles, $fname;
+		if (! grep { /^$fname$/x } @kiwiModules) {
+			print "Comitting new module '$fname'. Registration required. Add ";
+			print "your module to the\ngit_hooks/pre-commit file in the ";
+			print '@kiwiModules list as well as the notCleanX list';
+			print "\n";
+			exit 1;
+		}
+	}
+}
+
+my @criticLevelFiles = (\@notClean1, \@notClean2, \@notClean3, \@notClean4,
+						\@notClean5);
+
+# Verify the changed file against the strictest perlcritic level possible
+# for this file based on the known "goodness" level. Default is level 5
+my $defSeverity = 5;
+VERIFY:
+for my $fname (@changedFiles) {
+	my $listed;
+	for my $level (0..4) {
+		if (! grep { /^$fname$/x } @{ $criticLevelFiles[$level] } ) {
+			my $severity = int $level + 1;
+			my $cmd = "perlcritic --quiet --severity $severity modules/$fname";
+			my $status = system $cmd;
+			if ($status) {
+				print STDOUT "Failed verification for: $fname\n";
+				exit 1;
+			}
+			next VERIFY;
+		} elsif (grep { /^$fname$/x } @{ $criticLevelFiles[$level] } ) {
+			$listed = 1;
+		}
+	}
+	if (! $listed) {
+		my $cmd = "perlcritic --quiet --severity $defSeverity modules/$fname";
+		my $status = system $cmd;
+		if ($status) {
+			print STDOUT "Failed verification for: $fname\n";
+			exit 1;
+		}
+	}
+}

--- a/modules/KIWILocator.pm
+++ b/modules/KIWILocator.pm
@@ -27,7 +27,7 @@ use KIWIQX;
 # Exports
 #------------------------------------------
 our @ISA    = qw (Exporter);
-our @EXPORT = qw (createTmpDirectory getExecPath getControlFile );
+our @EXPORT_OK = qw (createTmpDirectory getExecPath getControlFile );
 
 #==========================================
 # Constructor
@@ -50,7 +50,7 @@ sub new {
 	# Constructor setup
 	#------------------------------------------
 	if (! defined $kiwi) {
-		$kiwi = new KIWILog("tiny");
+		$kiwi = KIWILog -> new("tiny");
 	}
 	#==========================================
 	# Store object data
@@ -91,7 +91,7 @@ sub createTmpDirectory {
 					$kiwi -> failed();
 					$kiwi -> error  ("Mount point '$root/base-system' exists");
 					$kiwi -> failed();
-					return undef;
+					return;
 				}
 				qxx ("rm -R $root");
 				$kiwi -> done();
@@ -110,10 +110,10 @@ sub createTmpDirectory {
 		if ($kiwi -> trace()) {
 			$main::BT[$main::TL] = eval { Carp::longmess ($main::TT.$main::TL++) };
 		}
-		return undef;
+		return;
 	}
 	if ( $rootError ) {
-		return undef;
+		return;
 	}
 	return $root;
 }
@@ -138,7 +138,7 @@ sub getControlFile {
 		$msg .= ' as the configuration base.';
 		$kiwi -> error ($msg);
 		$kiwi -> failed();
-		return undef;
+		return;
 	}
 	foreach my $search (@subdirs) {
 		$config = $dir.$search.$this->{configName};
@@ -169,7 +169,7 @@ sub getControlFile {
 		$kiwi -> error ( "Could not locate a configuration file in $dir");
 		$kiwi -> failed();
 	}
-	return undef;
+	return;
 }
 
 #============================================
@@ -196,7 +196,7 @@ sub getExecPath {
 		if ($kiwi) {
 			$kiwi -> loginfo ("warning: $execName not found\n");
 		}
-		return undef;
+		return;
 	}
 	return $execPath;
 }

--- a/modules/KIWIURL.pm
+++ b/modules/KIWIURL.pm
@@ -243,7 +243,7 @@ sub systemPath {
 	# normalize URL data
 	#------------------------------------------
 	if ((! defined $module) || ($module !~ /^system:\/\//)) {
-		return undef;
+		return;
 	}
 	$module =~ s/system:\/\///;
 	$path = $this -> dirPath ("dir://".$prefix."/".$module);
@@ -271,11 +271,11 @@ sub thisPath {
 	# normalize URL data
 	#------------------------------------------
 	if ((! defined $module) || ($module !~ /^this:\/\//)) {
-		return undef;
+		return;
 	}
 	$module =~ s/this:\/\///;
 	if ((! defined $module) || ($module eq "/")) {
-		return undef;
+		return;
 	}
 	my $thisPath;
 	my $lookup;
@@ -305,10 +305,12 @@ sub thisPath {
 	# extra path expansion by lookup file
 	#------------------------------------------
 	if (defined $lookup) {
-		if (! open FD,$lookup) {
-			return undef;
+        my $FD;
+		if (! open $FD, '<', $lookup) {
+			return;
 		}
-		$thisPath = <FD>; close FD;
+		$thisPath = <$FD>;
+        close $FD;
 		$thisPath = $thisPath."/".$module;
 	}
 	#==========================================
@@ -334,7 +336,7 @@ sub dirPath {
 	# normalize URL data
 	#------------------------------------------
 	if ((! defined $module) || ($module !~ /^dir:\/\//)) {
-		return undef;
+		return;
 	}
 	$module =~ s/dir:\/\///;
 	if ($module !~ /^\//) {
@@ -345,7 +347,7 @@ sub dirPath {
 	if (! -e $module_test) {
 		$kiwi -> warning ("dir path: $module_test doesn't exist: $!");
 		$kiwi -> skipped ();
-		return undef;
+		return;
 	}
 	return $module;
 }
@@ -373,7 +375,7 @@ sub smbPath {
 	# normalize URL data
 	#------------------------------------------
 	if ((! defined $module) || ($module !~ /^smb:\/\//)) {
-		return undef;
+		return;
 	}
 	$module =~ s/^smb://;
 	#==========================================
@@ -387,7 +389,7 @@ sub smbPath {
 	if ($result != 0) {
 		$kiwi -> warning ("Couldn't create tmp dir for smb mount: $tmpdir: $!");
 		$kiwi -> skipped ();
-		return undef;
+		return;
 	}
 	if (($user) && ($pwd)) {
 		$status = qxx (
@@ -400,7 +402,7 @@ sub smbPath {
 	if ($result != 0) {
 		$kiwi -> warning ("Failed to mount share $module: $status");
 		$kiwi -> skipped ();
-		return undef;
+		return;
 	}
 	#==========================================
 	# add mount to mount list of root obj
@@ -427,11 +429,11 @@ sub obsPath {
 	# normalize URL data
 	#------------------------------------------
 	if ((! defined $module) || ($module !~ /^obs:\/\//)) {
-		return undef;
+		return;
 	}
 	$module =~ s/obs:\/\///;
 	if ((! defined $module) || ($module eq "/")) {
-		return undef;
+		return;
 	}
 	if (defined $boot) {
 		$module = "this://images/$module"
@@ -467,7 +469,7 @@ sub isoPath {
 		($module !~ /^iso:\/\//) && 
 		($module !~ /^file:\/\//))
 	) {
-		return undef;
+		return;
 	}
 	$module =~ s/^iso:\/\///;
 	$module =~ s/^file:\/\///;
@@ -481,7 +483,7 @@ sub isoPath {
 		} elsif ($module =~ /url=dir:\/\/(.*)/) {
 			$path = $1;
 		} else {
-			return undef;
+			return;
 		}
 		$module = $path."/".$file;
 	}
@@ -500,7 +502,7 @@ sub isoPath {
 	if (! -e $module_test) {
 		$kiwi -> warning ("ISO path: $module_test doesn't exist: $!");
 		$kiwi -> skipped ();
-		return undef;
+		return;
 	}
 	my $name   = basename ($module);
 	my $tmpdir = "/tmp/kiwimount-$name";
@@ -515,14 +517,14 @@ sub isoPath {
 	if ($result != 0) {
 		$kiwi -> warning ("Couldn't create tmp dir for iso mount: $status: $!");
 		$kiwi -> skipped ();
-		return undef;
+		return;
 	}
 	$status = qxx ("mount -o loop $module $tmpdir 2>&1");
 	$result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> warning ("Failed to loop mount ISO path: $status");
 		$kiwi -> skipped ();
-		return undef;
+		return;
 	}
 	#==========================================
 	# add loop mount to mount list of root obj
@@ -563,26 +565,27 @@ sub openSUSEpath {
 	# normalize URL data
 	#------------------------------------------
 	if ((! defined $module) || ($module !~ /^opensuse:\/\//)) {
-		return undef;
+		return;
 	}
 	$module =~ s/opensuse:\/\///;
 	$module =~ s/\/$//;
 	$module =~ s/^\///;
 	if ((! defined $module) || ($module eq "")) {
-		return undef;
+		return;
 	}
 	#==========================================
 	# Create URL list from URI table
 	#------------------------------------------
-	if (! open $FD, $uriTable) {
-		return undef;
+	if (! open $FD, '<', $uriTable) {
+		return;
 	}
 	while (my $match =<$FD>) {
 		chomp $match;
 		my @list = split (/\|/,$match);
 		my $repo = $module;
 		my $match= '$repo =~ '.$list[1];
-		eval $match;
+        # Violates "expression eval rule FIXME
+		eval $match; ## no critic
 		$matches{$repo} = $list[0];
 	}
 	close $FD;
@@ -632,7 +635,7 @@ sub openSUSEpath {
 		$kiwi -> warning ("Couldn't resolve opensuse URL: $origurl");
 		$kiwi -> skipped ();
 	}
-	return undef;
+	return;
 }
 
 #==========================================
@@ -651,7 +654,7 @@ sub plainPath {
 	# normalize URL data
 	#------------------------------------------
 	if ((! defined $module) || ($module !~ /^plain:\/\//)) {
-		return undef;
+		return;
 	}
 	$module =~ s/^plain:\/\///;
 	$kiwi -> loginfo (
@@ -680,7 +683,7 @@ sub urlResponse {
 	if ($@) {
 		# host can't be resolved, network timeout
 		if ($@ eq "alarm\n") {
-			return undef;
+			return;
 		}
 	}
 	return $response;


### PR DESCRIPTION
Hi,

This implements the hook stuff I mentioned in the message to the list. Also cleans up URL and Locator. Anyway, you can play around with it to see if you like this.

It takes a little longer to run "git commit" as it takes a while for perlcritic to slug through the code being checked in. However, I think this relatively short delay is well worth it as we can catch a lot of subtle stuff with perlcritic that otherwise might manifest itself as stupid runtime bugs.

For now I have implemented the hook code such that we can clean stuff up all the way to level 1 of perlcritic. However, in the long run I think this is not necessary as perlcritic at some points starts complaining about stupid stuff.

I think this is a good start. as we get more comfortable with things and move up the later we can see what level makes sense for us. I think if we get everything to level 3 "clean" it would be great.

I do not know how to set up git such that the hook automatically gets linked/installed when someone clones the repo. The other thing that is missing is a BuildRequires: or Recommends: for perlcritic in the spec file.

Play around with this and let me know what you think.

Later,
Robert
