### PR TITLE
- include new EC2 region (US-West2), update the EC2 kernel IDs to the new

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -109,7 +109,7 @@ my @changedFiles;
 while (<$chld_out>) {
 	my $fname = basename($_);
 	chomp $fname;
-	if ($fname =~ /.*\.pm|\.pl|\.t/x) {
+	if ($fname =~ /.*\.pm$|\.pl$|\.t$/x) {
 		push @changedFiles, $_;
 		if (! grep { /^$fname$/x } @kiwiModules) {
 			print "Comitting new module '$fname'. Registration required. Add ";

--- a/doc/docbook/kiwi-doc-ec2.xml
+++ b/doc/docbook/kiwi-doc-ec2.xml
@@ -274,63 +274,75 @@
             <tbody>
               <row>
                 <entry>AP-Northeast</entry>
-                <entry>aki-d209a2d3</entry>
+                <entry>aki-ec5df7ed</entry>
                 <entry>x86</entry>
-                <entry><filename>ec2-public-images-ap-northeast-1/pv-grub-hd0-V1.01-i386.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-ap-northeast-1/pv-grub-hd0-V1.02-i386.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>AP-Northeast</entry>
-                <entry>aki-d409a2d5</entry>
+                <entry>aki-ee5df7ef</entry>
                 <entry>x86-64</entry>
-                <entry><filename>ec2-public-images-ap-northeast-1/pv-grub-hd0-V1.01-x86_64.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-ap-northeast-1/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>AP-Southeast</entry>
-                <entry>aki-13d5aa41</entry>
+                <entry>aki-a4225af6</entry>
                 <entry>x86</entry>
-                <entry><filename>ec2-public-images-ap-southeast-1/pv-grub-hd0-V1.01-i386.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-ap-southeast-1/pv-grub-hd0-V1.02-i386.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>AP-Southeast</entry>
-                <entry>aki-11d5aa43</entry>
+                <entry>aki-aa225af8</entry>
                 <entry>x86-64</entry>
-                <entry><filename>ec2-public-images-ap-southeast-1/pv-grub-hd0-V1.01-x86_64.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-ap-southeast-1/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>EU-West</entry>
-                <entry>aki-4deec439</entry>
+                <entry>aki-64695810</entry>
                 <entry>x86</entry>
-                <entry><filename>ec2-public-images-eu/pv-grub-hd0-V1.01-i386.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-eu/pv-grub-hd0-V1.02-i386.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>EU-West</entry>
-                <entry>aki-4feec43b</entry>
+                <entry>aki-62695816</entry>
                 <entry>x86-64</entry>
-                <entry><filename>ec2-public-images-eu/pv-grub-hd0-V1.01-x86_64.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-eu/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>US-East</entry>
-                <entry>aki-407d9529</entry>
+                <entry>aki-805ea7e9</entry>
                 <entry>x86</entry>
-                <entry><filename>ec2-public-images/pv-grub-hd0-V1.01-i386.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images/pv-grub-hd0-V1.02-i386.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>US-East</entry>
-                <entry>aki-427d952b</entry>
+                <entry>aki-825ea7eb</entry>
                 <entry>x86-64</entry>
-                <entry><filename>ec2-public-images/pv-grub-hd0-V1.01-x86_64.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>US-West</entry>
-                <entry>aki-99a0f1dc</entry>
+                <entry>aki-83396bc6</entry>
                 <entry>x86</entry>
-                <entry><filename>ec2-public-images-us-west-1/pv-grub-hd0-V1.01-x86_64.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-us-west-1/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
               </row>
               <row>
                 <entry>US-West</entry>
-                <entry>aki-9ba0f1de</entry>
+                <entry>aki-8d396bc8</entry>
                 <entry>x86-64</entry>
-                <entry><filename>ec2-public-images-us-west-1/pv-grub-hd0-V1.01-x86_64.gz.manifest.xml</filename></entry>
+                <entry><filename>ec2-public-images-us-west-1/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
+              </row>
+              <row>
+                <entry>US-West2</entry>
+                <entry>aki-c2e26ff2</entry>
+                <entry>x86</entry>
+                <entry><filename>ec2-public-images-us-west-2/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
+              </row>
+              <row>
+                <entry>US-West2</entry>
+                <entry>aki-98e26fa8</entry>
+                <entry>x86-64</entry>
+                <entry><filename>ec2-public-images-us-west-2/pv-grub-hd0-V1.02-x86_64.gz.manifest.xml</filename></entry>
               </row>
             </tbody>
           </tgroup>
@@ -355,7 +367,7 @@
         for the <sgmltag class="element">ec2region</sgmltag> element are
         <emphasis>AP-Northeast</emphasis>, <emphasis>AP-Southeast</emphasis>,
         <emphasis>EU-West</emphasis>, <emphasis>US-East</emphasis>,
-        and <emphasis>US-West</emphasis>.</para>
+        <emphasis>US-West</emphasis>, and <emphasis>US-West2</emphasis>.</para>
 
       <para>Public images in EC2 already have the boot kernel information
         embedded. If you build a generic image with EC2 by not specifying

--- a/modules/KIWIEC2Region.txt
+++ b/modules/KIWIEC2Region.txt
@@ -1,13 +1,15 @@
 # /.../
 # Ec2 region table for correct Amazon kernel (aki) assignment
 # ----
-AP-Northeast-i386=aki-d209a2d3
-AP-Northeast-x86_64=aki-d409a2d5
-AP-Southeast-i386=aki-13d5aa41
-AP-Southeast-x86_64=aki-11d5aa43
-EU-West-i386=aki-4deec439
-EU-West-x86_64=aki-4feec43b
-US-East-i386=aki-407d9529
-US-East-x86_64=aki-427d952b
-US-West-i386=aki-99a0f1dc
-US-West-x86_64=aki-9ba0f1de
+AP-Northeast-i386=aki-ec5df7ed
+AP-Northeast-x86_64=aki-ee5df7ef
+AP-Southeast-i386=aki-a4225af6
+AP-Southeast-x86_64=aki-aa225af8
+EU-West-i386=aki-64695810
+EU-West-x86_64=aki-62695816
+US-East-i386=aki-805ea7e9
+US-East-x86_64=aki-825ea7eb
+US-West-i386=aki-83396bc6
+US-West-x86_64=aki-8d396bc8
+US-West2-i386=aki-c2e26ff2
+US-West2-x86_64=aki-98e26fa8

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -292,7 +292,8 @@ div {
 		db:para [
 			"Specify the region/availability zone in EC2 for this image.\x{a}"~
 			"Values are limited to the EC2 recognized zones:\x{a}"~
-			"AP-Northeast, AP-Southeast, EU-West, US-East, and US-West"
+			"AP-Northeast, AP-Southeast, EU-West, US-East, US-West,\x{a}"~
+            "and US-West2"
 		]
 		]
 		element ec2region {

--- a/modules/KIWIXMLValidator.pm
+++ b/modules/KIWIXMLValidator.pm
@@ -313,7 +313,7 @@ sub __checkEC2Regions {
 	}
 	my @regions = $ec2ConfNodes[0] -> getElementsByTagName('ec2region');
 	my @supportedRegions =
-                      qw /AP-Northeast AP-Southeast EU-West US-East US-West/;
+              qw /AP-Northeast AP-Southeast EU-West US-East US-West US-West2/;
 	my @selectedRegions = ();
 	for my $region (@regions) {
 		my $regionStr = $region -> textContent();

--- a/tests/unit/lib/Test/kiwiXMLValidator.pm
+++ b/tests/unit/lib/Test/kiwiXMLValidator.pm
@@ -347,7 +347,7 @@ sub test_ec2Regions {
 		my $msg = $kiwi -> getMessage();
 		my $expectedMsg;
 		my @supportedRegions=
-                     qw /AP-Northeast AP-Southeast EU-West US-East US-West/;
+              qw /AP-Northeast AP-Southeast EU-West US-East US-West US-West2/;
 		if ( $iConfFile =~ 'ec2RegionInvalid_1.xml' ) {
 			$expectedMsg = 'Specified region EU-West not unique';
 		} else {


### PR DESCRIPTION
- include new EC2 region (US-West2), update the EC2 kernel IDs to the newly released v1.02 IDs, update code and docs, also fix the regular expression in hook to properly deal with .txt extension, i.e. ignore those files

OK,

Lets see if this works now. Have the '-' to start the commit message, ran a compile on the Validator module, generated the docs. I think I remembered everything. You should just be able to pull this, fingers crossed.

New EC2 region was announced overnight, got the updated kernel IDs from Chris Thiel. He submitted those into the Studio infrastructure yesterday.
