### PR TITLE
- modify Makefile to create timestamp files when tests are run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# test timestamp files
+*.ts
+tests/.timestamps

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,12 @@ test:
 	# Run unit tests...
 	#--------------------------------------------
 	tests/unit/cleanup.sh
+	if test ! -d tests/.timestamps; then \
+		mkdir tests/.timestamps; \
+	fi
+	for i in `find -name "*.t" | cut -d/ -f4`;do \
+		touch tests/.timestamps/$$i's';\
+	done
 	cd tests/unit && /usr/bin/prove -f .
 	rm -f .revision
 
@@ -172,6 +178,10 @@ test:
 	# Run specific unit test
 	#--------------------------------------------
 	tests/unit/cleanup.sh
+	if test ! -d tests/.timestamps; then \
+		mkdir tests/.timestamps; \
+	fi
+	touch tests/.timestamps/$@s
 	cd tests/unit && /usr/bin/prove -f $@
 
 clean:

--- a/tests/runTests
+++ b/tests/runTests
@@ -1,0 +1,114 @@
+#!/usr/bin/perl
+
+#================
+# FILE          : runTests
+#----------------
+# PROJECT       : OpenSUSE Build-Service
+# COPYRIGHT     : (c) 2011 Novell Inc.
+#               :
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : Test execution engine
+#               : When given filenames as arguments such as modules/KIWIXML.pm
+#               : looks for a trigger file with the base name plus the trig
+#               : extension, i.e. KIWIXML.trig. If the file is found the tests
+#               : listed inside the trigger file are executed if the timestamp
+#               : file KIWIXML.ts in tests/.timestamps does not exist or is
+#               : older than the timestamp of the file.
+#               :
+#               : If no arguments are given checks all the tests in tests/unit
+#               : for the same condition.
+#               :
+#               : Intended use is for delegation of test running by the
+#               : pre-commit hook. To run all the tests use 'make test'
+#               : command.
+#               :
+# STATUS        : Development
+#----------------
+use strict;
+use warnings;
+
+use File::Basename;
+use FindBin;
+
+sub runTests {
+	#...
+	# Run a test if a trigger file exists and the test execution timestamp
+	# is older than the modification timestamp of the file being evaluated
+	# ---
+	my @checkFiles = @_;
+
+	my $trigDir = "$FindBin::Bin/triggers";
+	my @triggers = glob "$trigDir/*.trig";
+	my @timestamps = glob "$FindBin::Bin/.timestamps/*.ts";
+
+	# Examine the arguments
+	for my $checkF (@checkFiles) {
+		# Extract the filename without extension
+		my $fname = (split /\./x, basename($checkF) )[0];
+		# Get the modification time of the file is a corresponding test
+		# trigger exists
+		if ( grep { /$fname.trig/x } @triggers ) {
+			my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,
+				$atime,$mtime,$ctime,$blksize,$blocks) = stat $checkF;
+			my $lastMod = $mtime;
+			# Figure out what tests to potentiallly run for this file
+			my $trigFile = (grep { /$fname.trig/x } @triggers)[0];
+			my $TRIG;
+			if (! open $TRIG, '<', $trigFile) {
+				print {*STDERR} "ERROR: Could not open $trigFile\n";
+				exit 1;
+			}
+			my @tests = <$TRIG>;
+			close $TRIG;
+			# Get the creation time for the timestamp file if it exists
+			# and generate of list of tests to run
+			my @testsToRun;
+			for my $test (@tests) {
+				my $testNameNoEx = (split /\./x, $test)[0];
+				my $ts;
+				if ( grep { /$testNameNoEx.ts/x } @timestamps) {
+					my $tsFile = (grep { /$testNameNoEx.ts/x } @timestamps)[0];
+					($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,
+					$atime,$mtime,$ctime,$blksize,$blocks) = stat $tsFile;
+					$ts = $ctime;
+				} else {
+					$ts = 0;
+				}
+				# File modified since the tast has been run last
+				if ($lastMod > $ts) {
+					push @testsToRun , $test;
+				}
+			}
+			# Run tests and collect failures
+			my @testFailed;
+			for my $test (@testsToRun) {
+				my $result = system "cd tests/unit && /usr/bin/prove -f $test";
+				if ($result != 0) {
+					push @testFailed, $test;
+					# Remove the timestamp file if the test fails
+					my $testNameNoEx = (split /\./x, $test)[0];
+					unlink "$FindBin::Bin/.timestamps/$testNameNoE.ts";
+				}
+			}
+			if (@testFailed) {
+				print {*STDERR} "Following tests failed:\n";
+				for my $t (@testFailed) {
+					print {*STDERR} "\t$t";
+				}
+				exit 1;
+			}
+		}
+	}
+	return;
+}
+
+if (! @ARGV) {
+	my @testsToRun = glob "$FindBin::Bin/unit/*.t";
+	runTests(@testsToRun);
+}
+else {
+	runTests(@ARGV);
+}

--- a/tests/triggers/KIWICommandLine.trig
+++ b/tests/triggers/KIWICommandLine.trig
@@ -1,0 +1,1 @@
+KIWICommandLine.t

--- a/tests/triggers/KIWIImageCreator.trig
+++ b/tests/triggers/KIWIImageCreator.trig
@@ -1,0 +1,1 @@
+KIWIImageCreator.t

--- a/tests/triggers/KIWILocator.trig
+++ b/tests/triggers/KIWILocator.trig
@@ -1,0 +1,1 @@
+KIWILocator.t

--- a/tests/triggers/KIWIRuntimeChecker.trig
+++ b/tests/triggers/KIWIRuntimeChecker.trig
@@ -1,0 +1,1 @@
+KIWIRuntimeChecker.t

--- a/tests/triggers/KIWIXML.trig
+++ b/tests/triggers/KIWIXML.trig
@@ -1,0 +1,1 @@
+KIWIXML.t

--- a/tests/triggers/KIWIXMLInfo.trig
+++ b/tests/triggers/KIWIXMLInfo.trig
@@ -1,0 +1,1 @@
+KIWIXMLInfo.t

--- a/tests/triggers/KIWIXMLValidator.trig
+++ b/tests/triggers/KIWIXMLValidator.trig
@@ -1,0 +1,1 @@
+KIWIXMLValidator.t

--- a/tests/triggers/kiwiCommandLine.trig
+++ b/tests/triggers/kiwiCommandLine.trig
@@ -1,0 +1,1 @@
+KIWICommandLine.t

--- a/tests/triggers/kiwiImageCreator.trig
+++ b/tests/triggers/kiwiImageCreator.trig
@@ -1,0 +1,1 @@
+KIWIImageCreator.t

--- a/tests/triggers/kiwiLocator.trig
+++ b/tests/triggers/kiwiLocator.trig
@@ -1,0 +1,1 @@
+KIWILocator.t

--- a/tests/triggers/kiwiRuntimeChecker.trig
+++ b/tests/triggers/kiwiRuntimeChecker.trig
@@ -1,0 +1,1 @@
+KIWIRuntimeChecker.t

--- a/tests/triggers/kiwiXML.trig
+++ b/tests/triggers/kiwiXML.trig
@@ -1,0 +1,1 @@
+KIWIXML.t

--- a/tests/triggers/kiwiXMLInfo.trig
+++ b/tests/triggers/kiwiXMLInfo.trig
@@ -1,0 +1,1 @@
+KIWIXMLInfo.t

--- a/tests/triggers/kiwiXMLValidator.trig
+++ b/tests/triggers/kiwiXMLValidator.trig
@@ -1,0 +1,1 @@
+KIWIXMLValidator.t

--- a/tests/triggers/ktLog.trig
+++ b/tests/triggers/ktLog.trig
@@ -1,0 +1,7 @@
+KIWICommandLine.t
+KIWIImageCreator.t
+KIWILocator.t
+KIWIRuntimeChecker.t
+KIWIXMLInfo.t
+KIWIXML.t
+KIWIXMLValidator.t

--- a/tests/triggers/ktTestCase.trig
+++ b/tests/triggers/ktTestCase.trig
@@ -1,0 +1,7 @@
+KIWICommandLine.t
+KIWIImageCreator.t
+KIWILocator.t
+KIWIRuntimeChecker.t
+KIWIXMLInfo.t
+KIWIXML.t
+KIWIXMLValidator.t


### PR DESCRIPTION
- add .gitignore file to ignore timestamp files and timestamp directory
- implement trigger files
  - each trigger file contains a list of tests that should be run when
    the module with the equivalent name is changed. For example if KIWIXML.pm
    changes, the tests listed in KIWIXML.trig will be run
- implement runTests
  - contains the logic to execute tests as needed based on the trigger files
    and dependent on the timestamps
  - this script needs to be integrated into the pre-commit hook to assure the
    appropriate tests get run prior to commit
