### PR TITLE
- integrate unit test run into the pre-commit hook

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -85,7 +85,6 @@ my @notClean4 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 					KIWIURL.pm KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm
 					KIWIXMLValidator.pm KIWICommandLine.t KIWIImageCreator.t
 					KIWILocator.t KIWIRuntimeChecker.t KIWIXML.t KIWIXMLInfo.t
-					KIWIXMLValidator.t kiwiCommandLine.pm kiwiLocator.pm
 					kiwiImageCreator.pm kiwiRuntimeChecker.pm kiwiXML.pm
 					kiwiXMLInfo.pm kiwiXMLValidator.pm);
 
@@ -94,8 +93,7 @@ my @notClean5 = qw (KIWIArchList.pm KIWIBoot.pm
 					KIWIGlobals.pm KIWIImageFormat.pm KIWIIsoLinux.pm
 					KIWILog.pm KIWIManager.pm KIWIMigrate.pm
 					KIWIProductData.pm KIWIRepoMetaHandler.pm
-					KIWIRoot.pm KIWISatSolverLegacy.pm
-					KIWISharedMem.pm);
+					KIWIRoot.pm KIWISatSolverLegacy.pm);
 
 my ($chld_in, $chld_out);
 my $pid = open2(
@@ -129,17 +127,17 @@ my $pathEnv = "$modulesDir:$testInclDir";
 
 my @failedToBuild;
 for my $path (@changedFiles) {
-    my $result = system "env PERL5LIB=$pathEnv perl -wc $path";
-    if ($result != 0) {
-        push @failedToBuild, $path;
-    }
-    if (scalar @failedToBuild) {
-        print {*STDERR} 'Build failure detected for the following files:';
-        for my $fl (@failedToBuild) {
-            print {*STDERR} "\t$fl";
-        }
-        exit 1;
-    }
+	my $result = system "env PERL5LIB=$pathEnv perl -wc $path";
+	if ($result != 0) {
+		push @failedToBuild, $path;
+	}
+	if (scalar @failedToBuild) {
+		print {*STDERR} 'Build failure detected for the following files:';
+		for my $fl (@failedToBuild) {
+			print {*STDERR} "\t$fl";
+		}
+		exit 1;
+	}
 }
 
 my @criticLevelFiles = (\@notClean1, \@notClean2, \@notClean3, \@notClean4,
@@ -176,4 +174,16 @@ for my $path (@changedFiles) {
 			exit 1;
 		}
 	}
+}
+
+# Run tests as needed
+my $cmd = './tests/runTests';
+for my $path (@changedFiles) {
+	chomp $path;
+	$cmd .= " $path";
+}
+
+my $status = system $cmd;
+if ($status) {
+	exit 1;
 }

--- a/modules/KIWISharedMem.pm
+++ b/modules/KIWISharedMem.pm
@@ -25,7 +25,7 @@ use Carp qw (cluck);
 use IPC::SysV qw(IPC_PRIVATE IPC_RMID IPC_CREAT S_IRWXU);
 use IPC::Semaphore;
 use KIWIQX;
-sub MAXBUF() { 2000 }
+sub MAXBUF { 2000 }
 
 #==========================================
 # Constructor
@@ -56,18 +56,18 @@ sub new {
 	if (! defined $key) {
 		$kiwi -> error  ("shmget: $!");
 		$kiwi -> failed ();
-		return undef;
+		return;
 	}
 	my $sem = IPC::Semaphore -> new (IPC_PRIVATE, 1, S_IRWXU | IPC_CREAT);
 	if (! defined $sem) {
 		$kiwi -> error  ("IPC::Semaphore->new: $!");
 		$kiwi -> failed ();
-		return undef;
+		return;
 	}
 	if (! $sem -> setval (0,1)) {
 		$kiwi -> error  ("sem setval: $!");
 		$kiwi -> failed ();
-		return undef;
+		return;
 	}
 	#==========================================
 	# Store object data
@@ -106,7 +106,7 @@ sub peek {
 	if (! shmread($this->{SHMKEY}, $buff, 0, MAXBUF)) {
 		$kiwi -> error  ("shmread: $!");
 		$kiwi -> failed ();
-		return undef;
+		return;
 	}
 	substr($buff, index($buff, "\0")) = '';
 	return $buff;
@@ -131,7 +131,7 @@ sub poke {
 	if (! shmwrite($this->{SHMKEY}, $msg, 0, MAXBUF)) {
 		$kiwi -> error  ("shmwrite: $!");
 		$kiwi -> failed ();
-		return undef;
+		return;
 	}
 	return $this;
 }
@@ -145,7 +145,7 @@ sub lock {
 	if (! $this->{SEMA}->op(0,-1,0)) {
 		$kiwi -> error  ("semop: $!");
 		$kiwi -> failed ();
-		return undef;
+		return;
 	}
 	return $this;
 }
@@ -159,7 +159,7 @@ sub unlock {
 	if (! $this->{SEMA}->op(0,1,0)) {
 		$kiwi -> error  ("semop: $!");
 		$kiwi -> failed ();
-		return undef;
+		return;
 	}
 	return $this;
 }

--- a/tests/runTests
+++ b/tests/runTests
@@ -92,6 +92,9 @@ sub runTests {
 					my $testNameNoEx = (split /\./x, $test)[0];
 					unlink "$FindBin::Bin/.timestamps/$testNameNoEx.ts";
 				}
+				chomp $test;
+				my $cmd = "touch $FindBin::Bin/.timestamps/$test" . 's';
+				$result = system $cmd;
 			}
 			if (@testFailed) {
 				print {*STDERR} "Following tests failed:\n";

--- a/tests/unit/KIWIXMLValidator.t
+++ b/tests/unit/KIWIXMLValidator.t
@@ -4,7 +4,7 @@
 # PROJECT       : OpenSUSE Build-Service
 # COPYRIGHT     : (c) 2011 Novell Inc.
 #               :
-# AUTHOR        : Robert Schweikert <rschweikert@novell.com>
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
 #               :
 # BELONGS TO    : Operating System images
 #               :
@@ -12,6 +12,8 @@
 #               :
 # STATUS        : Development
 #----------------
+package KIWIXMLValidator;
+
 use strict;
 use warnings;
 use FindBin;
@@ -24,7 +26,9 @@ use lib "$FindBin::Bin/lib";
 use lib "$FindBin::Bin/../../modules";
 
 use KIWIGlobals;
-our $global  = new KIWIGlobals();
+our $global  = KIWIGlobals -> new();
 
 my $runner = Test::Unit::HarnessUnit->new();
 $runner->start( 'Test::kiwiXMLValidator' );
+
+1;

--- a/tests/unit/lib/Test/kiwiCommandLine.pm
+++ b/tests/unit/lib/Test/kiwiCommandLine.pm
@@ -4,7 +4,7 @@
 # PROJECT       : OpenSUSE Build-Service
 # COPYRIGHT     : (c) 2011 Novell Inc.
 #               :
-# AUTHOR        : Robert Schweikert <rschweikert@novell.com>
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
 #               :
 # BELONGS TO    : Operating System images
 #               :
@@ -34,7 +34,7 @@ sub new {
 	# Construct new test case
 	# ---
 	my $this = shift -> SUPER::new(@_);
-	$this -> {kiwi} = new Common::ktLog();
+	$this -> {kiwi} = Common::ktLog -> new();
 
 	return $this;
 }
@@ -49,7 +49,7 @@ sub test_ctor {
 	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
-	my $cmd = new KIWICommandLine($kiwi);
+	my $cmd = KIWICommandLine -> new($kiwi);
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
@@ -58,6 +58,8 @@ sub test_ctor {
 	$this -> assert_str_equals('No state set', $state);
 	# Test this condition last to get potential error messages
 	$this -> assert_not_null($cmd);
+
+	return;
 }
 
 #==========================================
@@ -82,6 +84,8 @@ sub test_cmdAddPackages_improperArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -105,6 +109,8 @@ sub test_cmdAddPackages_noArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -133,6 +139,8 @@ sub test_cmdAddPackages_valid {
 	# Make sure we get our data back
 	$addlPckgs = $cmd -> getAdditionalPackages();
 	$this -> assert_array_equal(\@packages, $addlPckgs);
+
+	return;
 }
 
 #==========================================
@@ -157,6 +165,8 @@ sub test_cmdAddPatterns_improperArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -180,6 +190,8 @@ sub test_cmdAddPatterns_noArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -208,6 +220,8 @@ sub test_cmdAddPatterns_valid {
 	# Make sure we get our data back
 	$addlPatterns = $cmd -> getAdditionalPatterns();
 	$this -> assert_array_equal(\@patterns, $addlPatterns);
+
+	return;
 }
 
 #==========================================
@@ -233,6 +247,8 @@ sub test_cmdAddRepos_improperAlias {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -258,6 +274,8 @@ sub test_cmdAddRepos_improperPrio {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -282,6 +300,8 @@ sub test_cmdAddRepos_improperRepo {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -307,6 +327,8 @@ sub test_cmdAddRepos_improperTypes {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -333,6 +355,8 @@ sub test_cmdAddRepos_mismatchRepoAli {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -357,6 +381,8 @@ sub test_cmdAddRepos_mismatchRepoAli_empty {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	$this -> assert_not_null($res);
+
+	return;
 }
 
 #==========================================
@@ -383,6 +409,8 @@ sub test_cmdAddRepos_mismatchRepoPrio {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -407,6 +435,8 @@ sub test_cmdAddRepos_mismatchRepoPrio_empty {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	$this -> assert_not_null($res);
+
+	return;
 }
 
 #==========================================
@@ -432,6 +462,8 @@ sub test_cmdAddRepos_mismatchRepoTypes {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -458,6 +490,8 @@ sub test_cmdAddRepos_noRepo {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -482,6 +516,8 @@ sub test_cmdAddRepos_noTypes {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -506,6 +542,8 @@ sub test_cmdAddRepos_unssupType {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -537,6 +575,8 @@ sub test_cmdAddRepos_valid {
 	$this -> assert_array_equal(\@alias, $repoInfo{repositoryAlia});
 	$this -> assert_array_equal(\@prios, $repoInfo{repositoryPriorities});
 	$this -> assert_array_equal(\@types, $repoInfo{repositoryTypes});
+
+	return;
 }
 
 #==========================================
@@ -564,6 +604,8 @@ sub test_cmdBuildTypeUsage {
 	# Make sure we can get our data back
 	my $cmdT = $cmd -> getBuildType();
 	$this -> assert_str_equals('reiserfs', $cmdT);
+
+	return;
 }
 
 #==========================================
@@ -590,6 +632,8 @@ sub test_cmdCacheDirUsage_relPath {
 	# Make sure we get the proper value back
 	my $dir = $cmd -> getCacheDir();
 	$this -> assert_str_equals('/var/cache/kiwi/image/tmp', $dir);
+
+	return;
 }
 
 #==========================================
@@ -613,6 +657,8 @@ sub test_cmdCacheDirUsage_noArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -637,6 +683,8 @@ sub test_cmdCacheDirUsage_valid {
 	# Make sure we get our data back
 	my $dir = $cmd -> getCacheDir();
 	$this -> assert_str_equals('/tmp', $dir);
+
+	return;
 }
 
 #==========================================
@@ -666,6 +714,8 @@ sub test_cmdCacheDirUsage_noDirWrite {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -692,6 +742,8 @@ sub test_cmdConfDirUsage_noArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -715,6 +767,8 @@ sub test_cmdConfDirUsage_noDirExist {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -743,6 +797,8 @@ sub test_cmdConfDirUsage_noDirRead {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -767,6 +823,8 @@ sub test_cmdConfDirUsage_valid {
 	# Make sure we get our data back
 	my $dir = $cmd -> getConfigDir();
 	$this -> assert_str_equals('/tmp', $dir);
+
+	return;
 }
 
 #==========================================
@@ -790,6 +848,8 @@ sub test_cmdIgnoreRepoUsage {
 	$cmd -> setIgnoreRepos(1);
 	$ignore = $cmd -> getIgnoreRepos();
 	$this -> assert_equals(1, $ignore);
+
+	return;
 }
 
 #==========================================
@@ -817,6 +877,8 @@ sub test_cmdIgnoreRepoUsage_conflict {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -840,6 +902,8 @@ sub test_cmdImageArchUsage_invalidArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -866,6 +930,8 @@ sub test_cmdImageArchUsage_noArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -890,6 +956,8 @@ sub test_cmdImageArchUsage_valid {
 	# Make sure we get our value back
 	my $arch = $cmd -> getImageArchitecture();
 	$this -> assert_str_equals('s390x', $arch);
+
+	return;
 }
 
 #==========================================
@@ -916,6 +984,8 @@ sub test_cmdLogFileUsage_noArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -944,6 +1014,8 @@ sub test_cmdLogFileUsagee_noWrite {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -968,6 +1040,8 @@ sub test_cmdLogFileUsage_valid {
 	# Make sure we get our data back
 	my $logFile = $cmd -> getLogFile();
 	$this -> assert_str_equals('/tmp/cmdlTestLog.log', $logFile);
+
+	return;
 }
 
 #==========================================
@@ -994,6 +1068,8 @@ sub test_cmdPackageMgrUsage_improper {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1016,6 +1092,8 @@ sub test_cmdPackageMgrUsage_noSupport {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1039,6 +1117,8 @@ sub test_cmdPackageMgrUsage_valid {
 	$this -> assert_not_null($res);
 	my $pckMgr = $cmd -> getPackageManager();
 	$this -> assert_str_equals('zypper', $pckMgr);
+
+	return;
 }
 
 #==========================================
@@ -1063,6 +1143,8 @@ sub test_cmdPckgsRemove_improperArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1086,6 +1168,8 @@ sub test_cmdPckgsRemove_noArg {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1114,6 +1198,8 @@ sub test_cmdPckgsRemove_valid {
 	# Make sure we get our data back
 	$rmPckgs = $cmd -> getPackagesToRemove();
 	$this -> assert_array_equal(\@packages, $rmPckgs);
+
+	return;
 }
 
 #==========================================
@@ -1140,6 +1226,8 @@ sub test_cmdProfileUsage_invalid {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1165,6 +1253,8 @@ sub test_cmdProfileUsage_improper {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1191,6 +1281,8 @@ sub test_cmdProfileUsage_valid {
 	# Make sure we can get our data back
 	my @cmdProfs = @{$cmd -> getBuildProfiles()};
 	$this -> assert_array_equal(\@profiles, \@cmdProfs);
+
+	return;
 }
 
 #==========================================
@@ -1215,6 +1307,8 @@ sub test_cmdRecycleRoot_delayedSet {
 	$cmd -> setRootTargetDir('/tmp');
 	$recycle = $cmd -> getRecycleRootDir();
 	$this -> assert_str_equals('/tmp', $recycle);
+
+	return;
 }
 
 #==========================================
@@ -1233,6 +1327,8 @@ sub test_cmdRecycleRoot_immediateSet {
 	$cmd -> setRootRecycle();
 	my $recycle = $cmd -> getRecycleRootDir();
 	$this -> assert_str_equals('/tmp', $recycle);
+
+	return;
 }
 
 #==========================================
@@ -1257,6 +1353,8 @@ sub test_cmdReplaceRepo_conflict {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1279,6 +1377,8 @@ sub test_cmdReplaceRepo_noAlias {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	$this -> assert_not_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1304,6 +1404,8 @@ sub test_cmdReplaceRepo_noPrio {
 	# Verify the default priority
 	my %repoInfo = %{$cmd -> getReplacementRepo()};
 	$this -> assert_equals(10, $repoInfo{repositoryPriority});
+
+	return;
 }
 
 #==========================================
@@ -1330,6 +1432,8 @@ sub test_cmdReplaceRepo_noRepo {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1352,6 +1456,8 @@ sub test_cmdReplaceRepo_unsupRepoType {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1379,6 +1485,8 @@ sub test_cmdReplaceRepo_valid {
 	$this -> assert_str_equals('alias', $repoInfo{repositoryAlias});
 	$this -> assert_equals(1, $repoInfo{repositoryPriority});
 	$this -> assert_str_equals('yast2', $repoInfo{repositoryType});
+
+	return;
 }
 
 #==========================================
@@ -1404,7 +1512,9 @@ sub test_cmdRootTargetDir_noArgs {
 	$this -> assert_str_equals('error', $msgT);
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
-	$this -> assert_null($res); 
+	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -1429,6 +1539,8 @@ sub test_cmdRootTargetDir_absPath {
 	# Check we get the expected result
 	my $rootTgt = $cmd -> getRootTargetDir();
 	$this -> assert_str_equals('/tmp', $rootTgt);
+
+	return;
 }
 
 #==========================================
@@ -1456,6 +1568,8 @@ sub test_cmdRootTargetDir_relPath {
 	# Check we get the expected result
 	my $rootTgt = $cmd -> getRootTargetDir();
 	$this -> assert_str_equals($tgtPath, $rootTgt);
+
+	return;
 }
 
 #==========================================
@@ -1469,7 +1583,7 @@ sub __getCmdObj {
 	# Helper method to create a CommandLine object;
 	# ---
 	my $this = shift;
-	my $cmd = new KIWICommandLine($this -> {kiwi});
+	my $cmd = KIWICommandLine -> new($this -> {kiwi});
 	return $cmd;
 }
 

--- a/tests/unit/lib/Test/kiwiLocator.pm
+++ b/tests/unit/lib/Test/kiwiLocator.pm
@@ -33,7 +33,7 @@ sub new {
 	# ---
 	my $this = shift -> SUPER::new(@_);
 	$this -> {dataDir} = $this -> getDataDir() . '/kiwiLocator/';
-	$this -> {kiwi} = new Common::ktLog();
+	$this -> {kiwi} = Common::ktLog -> new();
 
 	return $this;
 }
@@ -48,7 +48,7 @@ sub test_ctor {
 	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
-	my $locator = new KIWILocator ( $kiwi );
+	my $locator = KIWILocator -> new( $kiwi );
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
@@ -57,6 +57,8 @@ sub test_ctor {
 	$this -> assert_str_equals('No state set', $state);
 	# Test this condition last to get potential error messages
 	$this -> assert_not_null($locator);
+
+	return;
 }
 
 #==========================================
@@ -65,27 +67,29 @@ sub test_ctor {
 sub test_createTmpDirInTmp {
 	# ...
 	# Test the createTmpDirectory method for the most simplistic case
-    # where a temporary directory is created in /tmp, i.e. there is
-    # no preset root directory.
-    # ---
+	# where a temporary directory is created in /tmp, i.e. there is
+	# no preset root directory.
+	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
 	my $locator = $this -> __getLocator();
-    my $cmdL = $this -> __getCommandLine();
-    $cmdL -> setForceNewRoot(0);
-    my $newTmpDir = $locator -> createTmpDirectory( undef, undef, $cmdL);
+	my $cmdL = $this -> __getCommandLine();
+	$cmdL -> setForceNewRoot(0);
+	my $newTmpDir = $locator -> createTmpDirectory( undef, undef, $cmdL);
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('none', $msgT);
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
-    if (! -d $newTmpDir) {
-        my $err = 'Temp dir "' . $newTmpDir . '" was reported to be created,';
-        $err .= ' but does not exists';
-        $this -> assert_null($err);
-    }
-    rmdir $newTmpDir;
+	if (! -d $newTmpDir) {
+		my $err = 'Temp dir "' . $newTmpDir . '" was reported to be created,';
+		$err .= ' but does not exists';
+		$this -> assert_null($err);
+	}
+	rmdir $newTmpDir;
+
+	return;
 }
 
 #==========================================
@@ -94,27 +98,29 @@ sub test_createTmpDirInTmp {
 sub test_createTmpDirSpecifiedDir {
 	# ...
 	# Test the createTmpDirectory method using a specified directory
-    # ---
+	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
 	my $locator = $this -> __getLocator();
-    my $cmdL = $this -> __getCommandLine();
-    $cmdL -> setForceNewRoot(0);
-    my $tmpDir = $this -> createTestTmpDir();
-    my $newTmpDir = $locator -> createTmpDirectory( undef, $tmpDir, $cmdL);
+	my $cmdL = $this -> __getCommandLine();
+	$cmdL -> setForceNewRoot(0);
+	my $tmpDir = $this -> createTestTmpDir();
+	my $newTmpDir = $locator -> createTmpDirectory( undef, $tmpDir, $cmdL);
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('none', $msgT);
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
-    $this -> assert_str_equals($tmpDir, $newTmpDir);
-    if (! -d $tmpDir) {
-        my $err = 'Temp dir "' . $tmpDir . '" was reported to be created,';
-        $err .= ' but does not exists';
-        $this -> assert_null($err);
-    }
-    $this -> removeTestTmpDir();
+	$this -> assert_str_equals($tmpDir, $newTmpDir);
+	if (! -d $tmpDir) {
+		my $err = 'Temp dir "' . $tmpDir . '" was reported to be created,';
+		$err .= ' but does not exists';
+		$this -> assert_null($err);
+	}
+	$this -> removeTestTmpDir();
+
+	return;
 }
 
 #==========================================
@@ -123,31 +129,33 @@ sub test_createTmpDirSpecifiedDir {
 sub test_createTmpDirSpecifiedDirOK {
 	# ...
 	# Test the createTmpDirectory method using a specified directory
-    # that is not empty but is OK to be removed
-    # ---
+	# that is not empty but is OK to be removed
+	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
 	my $locator = $this -> __getLocator();
-    my $cmdL = $this -> __getCommandLine();
-    $cmdL -> setForceNewRoot(1);
-    my $tmpDir = $this -> createTestTmpDir();
-    mkdir "$tmpDir/kiwi";
-    my $newTmpDir = $locator -> createTmpDirectory( undef, $tmpDir, $cmdL);
+	my $cmdL = $this -> __getCommandLine();
+	$cmdL -> setForceNewRoot(1);
+	my $tmpDir = $this -> createTestTmpDir();
+	mkdir "$tmpDir/kiwi";
+	my $newTmpDir = $locator -> createTmpDirectory( undef, $tmpDir, $cmdL);
 	my $msg = $kiwi -> getMessage();
-    my $expected = "Removing old root directory '$tmpDir'";
+	my $expected = "Removing old root directory '$tmpDir'";
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('info', $msgT);
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('completed', $state);
-    $this -> assert_str_equals($tmpDir, $newTmpDir);
-    if (! -d $tmpDir) {
-        my $err = 'Temp dir "' . $tmpDir . '" was reported to be created,';
-        $err .= ' but does not exists';
-        $this -> assert_null($err);
-    }
-    rmdir "$tmpDir/kiwi";
-    $this -> removeTestTmpDir();
+	$this -> assert_str_equals($tmpDir, $newTmpDir);
+	if (! -d $tmpDir) {
+		my $err = 'Temp dir "' . $tmpDir . '" was reported to be created,';
+		$err .= ' but does not exists';
+		$this -> assert_null($err);
+	}
+	rmdir "$tmpDir/kiwi";
+	$this -> removeTestTmpDir();
+
+	return;
 }
 
 #==========================================
@@ -156,30 +164,32 @@ sub test_createTmpDirSpecifiedDirOK {
 sub test_createTmpDirSpecifiedDirNotOK {
 	# ...
 	# Test the createTmpDirectory method using a specified directory
-    # that is not empty and is not OK to be removed, i.e. it contains
-    # base-system sub directory
-    # ---
+	# that is not empty and is not OK to be removed, i.e. it contains
+	# base-system sub directory
+	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
 	my $locator = $this -> __getLocator();
-    my $cmdL = $this -> __getCommandLine();
-    $cmdL -> setForceNewRoot(1);
-    my $tmpDir = $this -> createTestTmpDir();
-    mkdir "$tmpDir/base-system";
-    my $newTmpDir = $locator -> createTmpDirectory( undef, $tmpDir, $cmdL);
+	my $cmdL = $this -> __getCommandLine();
+	$cmdL -> setForceNewRoot(1);
+	my $tmpDir = $this -> createTestTmpDir();
+	mkdir "$tmpDir/base-system";
+	my $newTmpDir = $locator -> createTmpDirectory( undef, $tmpDir, $cmdL);
 	my $infoMsg = $kiwi -> getInfoMessage();
-    my $expected = "Removing old root directory '$tmpDir'";
+	my $expected = "Removing old root directory '$tmpDir'";
 	$this -> assert_str_equals($expected, $infoMsg);
-    my $errMsg = $kiwi -> getErrorMessage();
-    $expected = "Mount point '$tmpDir/base-system' exists";
+	my $errMsg = $kiwi -> getErrorMessage();
+	$expected = "Mount point '$tmpDir/base-system' exists";
 	$this -> assert_str_equals($expected, $errMsg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('failed', $state);
-    $this -> assert_null($newTmpDir);
-    rmdir "$tmpDir/base-system";
-    $this -> removeTestTmpDir();
+	$this -> assert_null($newTmpDir);
+	rmdir "$tmpDir/base-system";
+	$this -> removeTestTmpDir();
+
+	return;
 }
 
 #==========================================
@@ -207,6 +217,8 @@ sub test_getControlFileMultiConfig {
 	$this -> assert_str_equals('failed', $state);
 	# Test this condition last to get potential error messages
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -231,6 +243,8 @@ sub test_getControlFileNoConfigFile {
 	$this -> assert_str_equals('failed', $state);
 	# Test this condition last to get potential error messages
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -255,6 +269,8 @@ sub test_getControlFileNoDir {
 	$this -> assert_str_equals('failed', $state);
 	# Test this condition last to get potential error messages
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -278,6 +294,8 @@ sub test_getControlFileNoErrorConfigXML {
 	$this -> assert_not_null($res);
 	my $configFilePath = $this -> {dataDir} . '/config.xml';
 	$this -> assert_str_equals($configFilePath, $res);
+
+	return;
 }
 
 #==========================================
@@ -303,6 +321,8 @@ sub test_getControlFileNoErrorKiwiExt {
 	$this -> assert_not_null($res);
 	my $configFilePath = $this -> {dataDir} . 'sglConf/config_one.kiwi';
 	$this -> assert_str_equals($configFilePath, $res);
+
+	return;
 }
 
 #==========================================
@@ -324,6 +344,8 @@ sub test_getDefCacheDir {
 	$this -> assert_str_equals('No state set', $state);
 	# Make sure directory has expected path
 	$this -> assert_str_equals($cacheDir, '/var/cache/kiwi/image');
+
+	return;
 }
 
 #==========================================
@@ -345,6 +367,8 @@ sub test_getExecPathNoExec {
 	$this -> assert_str_equals('No state set', $state);
 	# Test this condition last to get potential error messages
 	$this -> assert_null($res);
+
+	return;
 }
 
 #==========================================
@@ -372,6 +396,8 @@ sub test_getExecPerl {
 	$this -> assert_not_null($res);
 	my $perlPath = '/usr/bin/perl';
 	$this -> assert_str_equals($perlPath, $res);
+
+	return;
 }
 
 #==========================================
@@ -385,7 +411,7 @@ sub __getCommandLine {
 	# Helper method to create a KIWICommandLine object
 	# ---
 	my $this = shift;
-	my $cmdL = new KIWICommandLine ( $this -> {kiwi} );
+	my $cmdL = KIWICommandLine -> new( $this -> {kiwi} );
 	return $cmdL;
 }
 
@@ -397,7 +423,7 @@ sub __getLocator {
 	# Helper method to create a KIWILocator object
 	# ---
 	my $this = shift;
-	my $locator = new KIWILocator ( $this -> {kiwi} );
+	my $locator = KIWILocator -> new( $this -> {kiwi} );
 	return $locator;
 }
 


### PR DESCRIPTION
- if a file is changed that has an associated unit test and the
  test has not been executed after the changes were made the test is
  run prior to commit
- fix the runTest code to generate a timestamp file when a test is run and
  it succeeds
- clean up kiwiCommandLine.pm, kiwiLocator.pm, and KIWIXMLValidator.t to
  critic level 4
  - clean up used to test new hook functionality
- clean up KIWISharedMem.pm to critic level 5
  - clean up used to test new hook functionality
