### PR TITLE
- add collection of perlcritic exceptions to the statistics collector

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -21,7 +21,7 @@ my @kiwiModules = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 					KIWIXMLValidator.t ktLog.pm ktTestCase.pm
 					kiwiCommandLine.pm kiwiLocator.pm kiwiImageCreator.pm
 					kiwiRuntimeChecker.pm kiwiXML.pm kiwiXMLInfo.pm
-					kiwiXMLValidator.pm);
+					kiwiXMLValidator.pm collector.pl);
 
 # List of modules not clean to level 1 (brutal) of perlcritic
 my @notClean1 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
@@ -38,7 +38,7 @@ my @notClean1 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 					KIWIXMLValidator.t ktLog.pm ktTestCase.pm
 					kiwiCommandLine.pm kiwiLocator.pm kiwiImageCreator.pm
 					kiwiRuntimeChecker.pm kiwiXML.pm kiwiXMLInfo.pm
-					kiwiXMLValidator.pm);
+					kiwiXMLValidator.pm collector.pl);
 
 # List of modules not clean to level 2 (cruel) of perlcritic
 my @notClean2 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
@@ -55,7 +55,7 @@ my @notClean2 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 					KIWIXMLValidator.t ktTestCase.pm
 					kiwiCommandLine.pm kiwiLocator.pm kiwiImageCreator.pm
 					kiwiRuntimeChecker.pm kiwiXML.pm kiwiXMLInfo.pm
-					kiwiXMLValidator.pm);
+					kiwiXMLValidator.pm collector.pl);
 
 # List of modules not clean to level 3 (harsh) of perlcritic
 my @notClean3 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
@@ -71,7 +71,7 @@ my @notClean3 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 					KIWILocator.t KIWIRuntimeChecker.t KIWIXML.t KIWIXMLInfo.t
 					KIWIXMLValidator.t kiwiCommandLine.pm kiwiLocator.pm
 					kiwiImageCreator.pm kiwiRuntimeChecker.pm kiwiXML.pm
-					kiwiXMLInfo.pm kiwiXMLValidator.pm);
+					kiwiXMLInfo.pm kiwiXMLValidator.pm collector.pl);
 
 # List of modules not clean to level 4 (stern) of perlcritic
 my @notClean4 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
@@ -87,7 +87,7 @@ my @notClean4 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 					KIWILocator.t KIWIRuntimeChecker.t KIWIXML.t KIWIXMLInfo.t
 					KIWIXMLValidator.t kiwiCommandLine.pm kiwiLocator.pm
 					kiwiImageCreator.pm kiwiRuntimeChecker.pm kiwiXML.pm
-					kiwiXMLInfo.pm kiwiXMLValidator.pm);
+					kiwiXMLInfo.pm kiwiXMLValidator.pm collector.pl);
 
 # List of modules not clean to level 5 (gentel) of perlcritic
 my @notClean5 = qw (KIWIArchList.pm KIWIBoot.pm

--- a/tests/qa/stats/collector.pl
+++ b/tests/qa/stats/collector.pl
@@ -49,25 +49,22 @@ push @modules, glob "$FindBin::Bin/../../unit/*.t";
 push @modules, glob "$FindBin::Bin/../../unit/lib/Test/*.pm";
 push @modules, glob "$FindBin::Bin/../../unit/lib/Common/*.pm";
 
-# Read existing stats since I cannot figure out how to just overwrite the
-# first line :(
-open($STATS, '<', $statsFileName) ||
+open($STATS, '+<', $statsFileName) ||
   die "Could not open '$statsFileName'\n";
-my (@lines) = <$STATS>;
-close $STATS;
-
-open($STATS, '>', $statsFileName) || die "Could not open '$statsFileName'\n";
+# Mark time when the statistics should be collected again
 print $STATS "#NEXT_SCAN:$nextScan\n";
-shift @lines;
-print $STATS @lines;
+# Write new data at the end
+seek $STATS, 0, 2;
 print $STATS "DATE:$curTime\n";
 # Collect statistics
-my $numFiles  = 0;
-my $numTFiles = 0;
-my $totalCCN  = 0.0;
-my $totalTCCN = 0.0;
-my $totalLOC  = 0;
-my $totalTLOC = 0;
+my $critExcept  = 0;
+my $critExceptT = 0;
+my $numFiles    = 0;
+my $numTFiles   = 0;
+my $totalCCN    = 0.0;
+my $totalTCCN   = 0.0;
+my $totalLOC    = 0;
+my $totalTLOC   = 0;
 my $chld_in;
 my $chld_out;
 for my $fl (@modules) {
@@ -80,8 +77,9 @@ for my $fl (@modules) {
     }
     my $fname = basename($fl);
     print $STATS "\tFILE:$fname\n";
-    my $res = open2($chld_out, $chld_in, 'perlcritic', '--statistics-only',
+    my $pid = open2($chld_out, $chld_in, 'perlcritic', '--statistics-only',
                     '-severity', '1', "$fl");
+    waitpid( $pid, 0 );
     while (<$chld_out>) {
         # Extract line of code info an process
         if ($_ =~ /\s*(\d*)\s*lines of Perl code.$/) {
@@ -113,18 +111,45 @@ for my $fl (@modules) {
             print $STATS "\t\t$levelID:$violations\n";
         }
     }
+    # Count the lines of code marked as critic exception
+    my $MOD;
+    open ($MOD, '<', $fl) || die "Could not open $fl for stats collection";
+    my @lines = <$MOD>;
+    close $MOD;
+    my $exceptCnt = 0;
+    my $exceptBlk;
+    for my $ln (@lines) {
+        if ($ln =~ /^\s*## no critic\s*$/) {
+            # Beginning of a critic exception block
+            $exceptBlk = 1;
+            next;
+        }
+        if ($ln =~ /^\s*## use critic\s*$/) {
+            # End of a critic exception block
+            $exceptBlk = undef;
+            next;
+        }
+        if ($exceptBlk or $ln =~ /\s*.*;\s*## no critic\s*$/) {
+            $exceptCnt += 1;
+        }
+    }
+    if ($isTest) {
+        $critExceptT += $exceptCnt;
+    } else {
+        $critExcept += $exceptCnt;
+    }
+    print $STATS "\t\tCEC:$exceptCnt\n";
 }
 # Write out summary data
 print $STATS "TOTAL_LOC:$totalLOC\n";
 print $STATS "NUMBER_FILES:$numFiles\n";
 my $avg = $totalCCN / $numFiles;
 print $STATS "AVG_CCN:$avg\n";
+print $STATS "CRITIC_EXCEPT_LOC:$critExcept\n";
 print $STATS "TOTAL_TEST_LOC:$totalTLOC\n";
 print $STATS "NUMBER_TEST_FILES:$numTFiles\n";
 $avg = $totalTCCN / $numTFiles;
 print $STATS "AVG_TEST_CCN:$avg\n";
-# Update the scan time
-#seek $STATS, 0, 0;
-#print $STATS "#NEXT_SCAN:$nextScan\n";
+print $STATS "CRITIC_EXCEPT_TEST_LOC:$critExceptT\n";
 close $STATS;
 

--- a/tests/qa/stats/data/codeStats.txt
+++ b/tests/qa/stats/data/codeStats.txt
@@ -1,4 +1,9 @@
 #NEXT_SCAN:1321824390
+
+LOC -> Lines Of Code
+CCN -> McCabe a.k.a Cyclomatic complexity number
+VIOL? -> Number of perlcritic violation at this level
+CEC -> Lines Of Code excempt from perlcritic examination
 DATE:1320614790
 	FILE:KIWIArch.pm
 		LOC:64
@@ -8,6 +13,7 @@ DATE:1320614790
 		VIOL3:4
 		VIOL2:6
 		VIOL1:9
+        CEC:0
 	FILE:KIWIArchList.pm
 		LOC:122
 		CCN:4.57
@@ -16,6 +22,7 @@ DATE:1320614790
 		VIOL3:5
 		VIOL2:8
 		VIOL1:24
+        CEC:0
 	FILE:KIWIBoot.pm
 		LOC:168
 		CCN:18.66
@@ -23,6 +30,7 @@ DATE:1320614790
 		VIOL4:32
 		VIOL3:229
 		VIOL2:642
+        CEC:0
 	FILE:KIWICache.pm
 		LOC:320
 		CCN:11.40
@@ -31,6 +39,7 @@ DATE:1320614790
 		VIOL3:10
 		VIOL2:28
 		VIOL1:61
+        CEC:0
 	FILE:KIWICollect.pm
 		LOC:555
 		CCN:14.53
@@ -39,6 +48,7 @@ DATE:1320614790
 		VIOL3:131
 		VIOL2:205
 		VIOL1:703
+        CEC:0
 	FILE:KIWICommandLine.pm
 		LOC:813
 		CCN:1.71
@@ -47,6 +57,7 @@ DATE:1320614790
 		VIOL3:10
 		VIOL2:26
 		VIOL1:121
+        CEC:0
 	FILE:KIWIConfigure.pm
 		LOC:422
 		CCN:9.86
@@ -55,6 +66,7 @@ DATE:1320614790
 		VIOL3:10
 		VIOL2:45
 		VIOL1:116
+        CEC:0
 	FILE:KIWIGlobals.pm
 		LOC:474
 		CCN:9.90
@@ -63,6 +75,7 @@ DATE:1320614790
 		VIOL3:11
 		VIOL2:59
 		VIOL1:99
+        CEC:0
 	FILE:KIWIImage.pm
 		LOC:321
 		CCN:12.09
@@ -71,6 +84,7 @@ DATE:1320614790
 		VIOL3:102
 		VIOL2:389
 		VIOL1:780
+        CEC:0
 	FILE:KIWIImageCreator.pm
 		LOC:50
 		CCN:9.05
@@ -79,6 +93,7 @@ DATE:1320614790
 		VIOL3:29
 		VIOL2:56
 		VIOL1:134
+        CEC:0
 	FILE:KIWIImageFormat.pm
 		LOC:758
 		CCN:8.86
@@ -87,6 +102,7 @@ DATE:1320614790
 		VIOL3:22
 		VIOL2:101
 		VIOL1:279
+        CEC:0
 	FILE:KIWIIsoLinux.pm
 		LOC:795
 		CCN:5.12
@@ -95,6 +111,7 @@ DATE:1320614790
 		VIOL3:25
 		VIOL2:96
 		VIOL1:234
+        CEC:0
 	FILE:KIWILocator.pm
 		LOC:139
 		CCN:6.40
@@ -103,6 +120,7 @@ DATE:1320614790
 		VIOL3:2
 		VIOL2:9
 		VIOL1:18
+        CEC:0
 	FILE:KIWILog.pm
 		LOC:705
 		CCN:4.29
@@ -111,6 +129,7 @@ DATE:1320614790
 		VIOL3:13
 		VIOL2:58
 		VIOL1:156
+        CEC:0
 	FILE:KIWIManager.pm
 		LOC:998
 		CCN:11.69
@@ -118,6 +137,7 @@ DATE:1320614790
 		VIOL4:23
 		VIOL3:47
 		VIOL2:115
+        CEC:0
 	FILE:KIWIMigrate.pm
 		LOC:375
 		CCN:16.77
@@ -126,6 +146,7 @@ DATE:1320614790
 		VIOL3:67
 		VIOL2:172
 		VIOL1:905
+        CEC:0
 	FILE:KIWIOverlay.pm
 		LOC:199
 		CCN:4.33
@@ -134,6 +155,7 @@ DATE:1320614790
 		VIOL3:3
 		VIOL2:17
 		VIOL1:34
+        CEC:0
 	FILE:KIWIProductData.pm
 		LOC:287
 		CCN:5.86
@@ -142,6 +164,7 @@ DATE:1320614790
 		VIOL3:6
 		VIOL2:12
 		VIOL1:68
+        CEC:0
 	FILE:KIWIQX.pm
 		LOC:53
 		CCN:3.50
@@ -150,6 +173,7 @@ DATE:1320614790
 		VIOL3:17
 		VIOL2:21
 		VIOL1:8
+        CEC:0
 	FILE:KIWIRepoMetaHandler.pm
 		LOC:246
 		CCN:5.25
@@ -158,6 +182,7 @@ DATE:1320614790
 		VIOL3:11
 		VIOL2:13
 		VIOL1:55
+        CEC:0
 	FILE:KIWIRoot.pm
 		LOC:18
 		CCN:8.39
@@ -166,6 +191,7 @@ DATE:1320614790
 		VIOL3:33
 		VIOL2:95
 		VIOL1:176
+        CEC:0
 	FILE:KIWIRuntimeChecker.pm
 		LOC:297
 		CCN:6.45
@@ -174,6 +200,7 @@ DATE:1320614790
 		VIOL3:7
 		VIOL2:21
 		VIOL1:42
+        CEC:0
 	FILE:KIWISatSolver.pm
 		LOC:247
 		CCN:3.85
@@ -182,6 +209,7 @@ DATE:1320614790
 		VIOL3:11
 		VIOL2:14
 		VIOL1:39
+        CEC:0
 	FILE:KIWISatSolverLegacy.pm
 		LOC:212
 		CCN:3.31
@@ -190,6 +218,7 @@ DATE:1320614790
 		VIOL3:10
 		VIOL2:13
 		VIOL1:27
+        CEC:0
 	FILE:KIWISharedMem.pm
 		LOC:116
 		CCN:2.20
@@ -198,6 +227,7 @@ DATE:1320614790
 		VIOL3:1
 		VIOL2:19
 		VIOL1:8
+        CEC:0
 	FILE:KIWISocket.pm
 		LOC:89
 		CCN:2.57
@@ -205,6 +235,7 @@ DATE:1320614790
 		VIOL4:4
 		VIOL2:7
 		VIOL1:14
+        CEC:0
 	FILE:KIWIURL.pm
 		LOC:464
 		CCN:7.86
@@ -213,6 +244,7 @@ DATE:1320614790
 		VIOL3:42
 		VIOL2:115
 		VIOL1:69
+        CEC:0
 	FILE:KIWIUtil.pm
 		LOC:315
 		CCN:5.54
@@ -221,6 +253,7 @@ DATE:1320614790
 		VIOL3:60
 		VIOL2:96
 		VIOL1:75
+        CEC:0
 	FILE:KIWIXML.pm
 		LOC:659
 		CCN:6.24
@@ -228,6 +261,8 @@ DATE:1320614790
 		VIOL4:43
 		VIOL3:75
 		VIOL2:223
+        VIOL1:861
+        CEC:0
 	FILE:KIWIXMLInfo.pm
 		LOC:488
 		CCN:10.89
@@ -236,6 +271,7 @@ DATE:1320614790
 		VIOL3:24
 		VIOL2:50
 		VIOL1:76
+        CEC:0
 	FILE:KIWIXMLValidator.pm
 		LOC:721
 		CCN:6.33
@@ -244,6 +280,7 @@ DATE:1320614790
 		VIOL3:22
 		VIOL2:57
 		VIOL1:123
+        CEC:0
 	FILE:kiwi.pl
 		LOC:449
 		CCN:20.85
@@ -252,65 +289,76 @@ DATE:1320614790
 		VIOL3:30
 		VIOL2:79
 		VIOL1:525
+        CEC:0
 	FILE:KIWICommandLine.t
 		LOC:10
 		VIOL4:3
 		VIOL3:1
 		VIOL2:4
 		VIOL1:1
+        CEC:0
 	FILE:KIWIImageCreator.t
 		LOC:10
 		VIOL4:3
 		VIOL3:1
 		VIOL2:4
 		VIOL1:1
+        CEC:0
 	FILE:KIWILocator.t
 		LOC:8
 		VIOL4:2
 		VIOL2:4
 		VIOL1:1
+        CEC:0
 	FILE:KIWIRuntimeChecker.t
 		LOC:10
 		VIOL4:3
 		VIOL3:1
 		VIOL2:4
 		VIOL1:1
+        CEC:0
 	FILE:KIWIXML.t
 		LOC:10
 		VIOL4:3
 		VIOL3:1
 		VIOL2:4
 		VIOL1:1
+        CEC:0
 	FILE:KIWIXMLInfo.t
 		LOC:10
 		VIOL4:3
 		VIOL3:1
 		VIOL2:4
 		VIOL1:1
+        CEC:0
 	FILE:KIWIXMLValidator.t
 		LOC:10
 		VIOL4:3
 		VIOL3:1
 		VIOL2:4
 		VIOL1:1
+        CEC:0
 	FILE:kiwiCommandLine.pm
 		LOC:943
 		CCN:1.05
 		VIOL4:60
 		VIOL2:16
 		VIOL1:179
+        CEC:0
 	FILE:kiwiImageCreator.pm
 		LOC:164
 		CCN:1.44
 		VIOL4:16
 		VIOL2:6
 		VIOL1:39
+        CEC:0
 	FILE:kiwiLocator.pm
 		LOC:249
 		CCN:1.19
 		VIOL4:17
 		VIOL2:4
 		VIOL1:51
+        CEC:0
 	FILE:kiwiRuntimeChecker.pm
 		LOC:401
 		CCN:2.41
@@ -318,18 +366,21 @@ DATE:1320614790
 		VIOL3:2
 		VIOL2:8
 		VIOL1:76
+        CEC:0
 	FILE:kiwiXML.pm
 		LOC:95
 		CCN:1.00
 		VIOL4:10
 		VIOL2:4
 		VIOL1:19
+        CEC:0
 	FILE:kiwiXMLInfo.pm
 		LOC:320
 		CCN:1.12
 		VIOL4:20
 		VIOL2:6
 		VIOL1:58
+        CEC:0
 	FILE:kiwiXMLValidator.pm
 		LOC:564
 		CCN:2.63
@@ -337,12 +388,14 @@ DATE:1320614790
 		VIOL3:20
 		VIOL2:38
 		VIOL1:124
+        CEC:0
 	FILE:ktLog.pm
 		LOC:239
 		CCN:1.67
 		VIOL4:2
 		VIOL2:16
 		VIOL1:31
+        CEC:0
 	FILE:ktTestCase.pm
 		LOC:73
 		CCN:2.14
@@ -351,9 +404,12 @@ DATE:1320614790
 		VIOL3:2
 		VIOL2:11
 		VIOL1:8
+        CEC:0
 TOTAL_LOC:11939
 NUMBER_FILES:32
 AVG_CCN:7.86625
+CRITIC_EXCEPT_LOC:0
 TOTAL_TEST_LOC:3116
 NUMBER_TEST_FILES:16
 AVG_TEST_CCN:0.915625
+CRITIC_EXCEPT_TEST_LOC:0

--- a/tests/qa/stats/docstats.xsl
+++ b/tests/qa/stats/docstats.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  version="1.0">
+  
+  <xsl:output method="text"/>
+  
+  <xsl:key name="elements" match="*" use="local-name()"/>
+  
+  <xsl:template match="*"/>
+  
+  
+  <xsl:template match="/">
+    <xsl:text>Summary of elements:&#10;</xsl:text>
+    <xsl:for-each select="//*[generate-id(.) = 
+                              generate-id(key('elements',local-name())[1])]">
+      <xsl:sort select="local-name()"/>
+      <xsl:for-each select="key('elements',local-name())">
+        <xsl:if test="position() = 1">
+          <xsl:text>Element </xsl:text>
+          <xsl:value-of select="local-name()"/>
+          <xsl:text> = </xsl:text>
+          <xsl:value-of select="count(//*[name() = name(current())])"/>
+          <xsl:text>&#10;</xsl:text>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:for-each>
+    <xsl:text>&#10;Total: </xsl:text>
+    <xsl:value-of select="count(//*)"/>
+    <xsl:text> elements&#10;</xsl:text>
+  </xsl:template>
+  
+</xsl:stylesheet>


### PR DESCRIPTION
- change collector such that only the next scan time is written and
  not he whole "old" content that does not change. New data is added to the
  file at the end
- add the doc stats collector provided by Thomas, this is not yet integrated,
  but I thought we shouldn't loose the code
- register the collector code in the hook
