### PR TITLE
- properly handle specification of "scsi" controller type for VMWare ima...

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -80,7 +80,7 @@ my @notClean4 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 					KIWIImage.pm KIWIIsoLinux.pm
 					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
 					KIWIProductData.pm KIWIQX.pm KIWIRepoMetaHandler.pm
-					KIWIRoot.pm KIWIRuntimeChecker.pm KIWISatSolverLegacy.pm
+					KIWIRoot.pm KIWISatSolverLegacy.pm
 					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
 					KIWIURL.pm KIWIUtil.pm KIWIXMLInfo.pm KIWIXML.pm
 					KIWIXMLValidator.pm KIWICommandLine.t KIWIImageCreator.t

--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -309,6 +309,12 @@ sub createVMDK {
 	$kiwi -> info ("Creating $format image...");
 	$target  =~ s/\.raw$/\.$format/;
 	$convert = "convert -f raw $source -O $format";
+	if (defined $vmwc{vmware_disktype} ) {
+		my $diskType = $vmwc{vmware_disktype};
+		if ($diskType eq 'scsi') {
+			$convert .= ' -o scsi';
+		}
+	}
 	$status = qxx ("qemu-img $convert $target 2>&1");
 	$result = $? >> 8;
 	if ($result != 0) {
@@ -327,7 +333,6 @@ sub createVMDK {
 sub createVHD {
 	my $this   = shift;
 	my $kiwi   = $this->{kiwi};
-	my %vmwc   = %{$this->{vmwref}};
 	my $source = $this->{image};
 	my $target = $source;
 	my $convert;


### PR DESCRIPTION
...ges

This requires the "-o scsi" option to be present for the qemu-img command
  on the build machine.
- implement new check in RuntimeChecker to verify that qemu-img supports proper
  option if controller="scsi" is specified and a vmdk image is being built
- clean KIWIRuntimeChecker to critic level 4
