### PR TITLE
- change the suggested repo for the aoetools package to be server:/ltsp

### DIFF
--- a/doc/docbook/kiwi-doc-pxe.xml
+++ b/doc/docbook/kiwi-doc-pxe.xml
@@ -648,7 +648,7 @@ NBD-Write-Port-Number;/dev/NBD-Write-Device
               install the <package>aoetools</package> and
                 <package>vblade</package> packages from here first:
                 <ulink
-                url="http://download.opensuse.org/repositories/system:/aoetools"
+                url="http://download.opensuse.org/repositories/server:/ltsp"
               />. Once installed the following example shows how to
               export the local <filename class="devicefile"
                 >/dev/sdb1</filename> partition via AoE:</para>


### PR DESCRIPTION
the previously suggested project system:/aoetools does not appear to
  be maintained
