### PR TITLE
- fix the OpenNebula example cloud node setup to ensure the cloud admin

### DIFF
--- a/doc/examples/extras/suse-12.1/suse-nebula-cloud/cloud_cloud/root/usr/share/firstboot/scripts/cloudNodeConfig
+++ b/doc/examples/extras/suse-12.1/suse-nebula-cloud/cloud_cloud/root/usr/share/firstboot/scripts/cloudNodeConfig
@@ -100,7 +100,7 @@ def configureNode(confSettings):
     fst = open('/etc/fstab', 'a')
     fst.write(confSettings['serverIP'])
     fst.write(':/var/lib/one')
-    fst.write('\t/var/lib/one\tnfs\tdefaults\t1 1\n')
+    fst.write('\t/var/lib/one\tnfs\tdefaults,comment=systemd.automount\t1 1\n')
     fst.close()
             
     return 1


### PR DESCRIPTION
home directory gets properly nfs mounted on reboot for 12.1 using systemd
