### PR TITLE
- fix gpg signature import

### DIFF
--- a/modules/KIWIManager.pm
+++ b/modules/KIWIManager.pm
@@ -2483,19 +2483,21 @@ sub setupPackageKeys {
 	# check build key and gpg
 	#------------------------------------------	
 	$kiwi -> info ("Importing build keys...");
-	if (! -x "/usr/lib/rpm/gnupg/dumpsigs") {
+	my $dumsigsExec = '/usr/lib/rpm/gnupg/dumpsigs';
+	my $keyringFile = '/usr/lib/rpm/gnupg/pubring.gpg';
+	if (! -x $dumsigsExec) {
 		$kiwi -> skipped ();
 		$kiwi -> warning ("Can't find dumpsigs on host system");
 		$kiwi -> skipped ();
 		return $this;
 	}
-	if (! -f "/usr/lib/rpm/gnupg/pubring.gpg") {
+	if (! -f $keyringFile) {
 		$kiwi -> skipped ();
 		$kiwi -> warning ("Can't find build keys on host system");
 		$kiwi -> skipped ();
 		return $this;
 	}
-	my $dump = "/usr/lib/rpm/gnupg/dumpsigs";
+	my $dump = $dumsigsExec . ' ' . $keyringFile;
 	my $sigs = "$root/rpm-sigs";
 	$data = qxx ("mkdir -p $sigs && cd $sigs && $dump 2>&1");
 	$code = $? >> 8;


### PR DESCRIPTION
The failure is triggered by a behavior changes of /usr/lib/rpm/gnupg/dumpsigs
  on openSUSE 12.1. The updated implementation must be called with a comand
  line argument, i.e. the gpg file. Previous implementations (checked
  openSUSE 11.4 and SLES 11 SP1) of dumpsigs also accept this commandline
  argument, thus the change is backward compatible.
