### PR TITLE
Rpm incompat 12 1

### DIFF
--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -486,7 +486,7 @@ sub getImageSizeAdditiveBytes {
 		my $byte = int $size;
 		my $unit = $node -> getElementsByTagName ("size")
 			-> get_node(1) -> getAttribute("unit");
-		if ($unit eq "M") {
+		if (! $unit || $unit eq "M") {
 			return $byte * 1024 * 1024;
 		}
 		if ($unit eq "G") {
@@ -2053,7 +2053,7 @@ sub addDrivers {
 	my $kiwi  = $this->{kiwi};
 	my $nodes = $this->{driversNodeList};
 	my $nodeNumber = -1;
-    for (my $i=1;$i<= $nodes->size();$i++) {
+	for (my $i=1;$i<= $nodes->size();$i++) {
 		my $node = $nodes -> get_node($i);
 		if (! $this -> __requestedProfile ($node)) {
 			next;


### PR DESCRIPTION
...ystem

Run an rpm query on a file (first file found in /bin in the unpacked root
  tree) in the target system, if the query fails the rpm versions between
  build and target system are incompatible, rebuild the rpmdb in the target
  system. With this fix we can build older target systems such as SLE or
  openSUSE 11.x base images on openSUSE 12.1 build systems.
- Fix a condition where the unit variable in the XML may be potentially
  undefined and therefore an incorrect size may be returned.
