### PR TITLE
- Properly support image builds for SLE with xfs and btrfs filesystem

### DIFF
--- a/system/boot/ix86/netboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/netboot/suse-SLES11/config.xml
@@ -39,8 +39,9 @@
 		<file name="drivers/block/loop.ko"/>
 		<file name="drivers/block/brd.ko"/>
 		<file name="net/packet/*"/>
-		<file name="fs/ext3/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext4/*"/>
 		<file name="fs/binfmt_aout.ko"/>
 		<file name="fs/binfmt_misc.ko"/>
 		<file name="fs/mbcache.ko"/>
@@ -58,6 +59,7 @@
 		<file name="net/sunrpc/*"/>
 		<file name="fs/lockd/*"/>
 		<file name="fs/nfs_common/*"/>
+		<file name="fs/xfs/*"/>
 		<file name="net/ipv6/*"/>
 		<file name="drivers/ata/*"/>
 		<file name="drivers/scsi/*"/>
@@ -160,6 +162,7 @@
 		<package name="cryptsetup"/>
 		<package name="bc"/>
 		<package name="adaptec-firmware"/>
+		<package name="btrfsprogs"/>
 		<package name="curl"/>
 		<package name="psmisc"/>
 		<package name="iputils"/>
@@ -189,6 +192,7 @@
 		<package name="cyrus-sasl"/>
 		<package name="mdadm"/>
 		<package name="dmraid"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="image" profiles="diskless">
 		<package name="bc"/>

--- a/system/boot/ix86/oemboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLES11/config.xml
@@ -40,10 +40,13 @@
 		<file name="drivers/block/loop.ko"/>
 		<file name="drivers/hid/*"/>
 		<file name="drivers/ide/*"/>
-		<file name="fs/ext3/*"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext4/*"/>
 		<file name="fs/fat/*"/>
 		<file name="fs/vfat/*"/>
+		<file name="fs/xfs/*"/>
 		<file name="fs/binfmt_aout.ko"/>
 		<file name="fs/binfmt_misc.ko"/>
 		<file name="fs/mbcache.ko"/>
@@ -106,6 +109,7 @@
 		<package name="busybox"/>
 		<package name="parted"/>
 		<package name="adaptec-firmware"/>
+		<package name="btrfsprogs"/>
 		<package name="dialog"/>
 		<package name="psmisc"/>
 		<package name="bind-libs"/>
@@ -140,6 +144,7 @@
 		<package name="syslinux"/>
 		<package name="dosfstools"/>
 		<package name="iputils"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>

--- a/system/boot/ix86/vmxboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/vmxboot/suse-SLES11/config.xml
@@ -32,8 +32,10 @@
 		<file name="drivers/md/*"/>
 		<file name="drivers/block/loop.ko"/>
 		<file name="drivers/ide/*"/>
-		<file name="fs/ext3/*"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext3/*"/>
 		<file name="fs/fat/*"/>
 		<file name="fs/vfat/*"/>
 		<file name="fs/binfmt_aout.ko"/>
@@ -49,6 +51,7 @@
 		<file name="fs/nls/nls_cp437.ko"/>
 		<file name="fs/nls/nls_iso8859-1.ko"/>
 		<file name="fs/fuse/*"/>
+		<file name="fs/xfs/*"/>
 		<file name="drivers/ata/*"/>
 		<file name="drivers/scsi/*"/>
 		<file name="drivers/message/fusion/*"/>
@@ -89,6 +92,7 @@
 	</packages>
 	<packages type="image">
 		<package name="psmisc"/>
+		<package name="btrfsprogs"/>
 		<package name="bind-libs"/>
 		<package name="bind-utils"/>
 		<package name="dhcpcd"/>
@@ -116,6 +120,7 @@
 		<package name="parted"/>
 		<package name="syslinux"/>
 		<package name="fbiterm"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>

--- a/system/boot/ppc/netboot/suse-SLES11/config.xml
+++ b/system/boot/ppc/netboot/suse-SLES11/config.xml
@@ -37,6 +37,7 @@
 		<file name="net/packet/*"/>
 		<file name="lib/zlib_deflate/zlib_deflate.ko"/>
 		<file name="lib/libcrc32c.ko"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext3/*"/>
 		<file name="fs/ext4/*"/>
 		<file name="fs/ext2/*"/>
@@ -166,6 +167,7 @@
 		<package name="busybox"/>
 		<package name="bind-libs"/>
 		<package name="bind-utils"/>
+		<package name="btrfsprogs"/>
 		<package name="dhcpcd"/>
 		<package name="e2fsprogs"/>
 		<package name="file"/>
@@ -187,6 +189,7 @@
 		<package name="kiwi-tools"/>
 		<package name="cyrus-sasl"/>
 		<package name="mdadm"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="image" profiles="diskless">
 		<package name="bc"/>

--- a/system/boot/ppc/oemboot/suse-SLES11/config.xml
+++ b/system/boot/ppc/oemboot/suse-SLES11/config.xml
@@ -30,6 +30,7 @@
 		<file name="net/packet/*"/>
 		<file name="lib/zlib_deflate/zlib_deflate.ko"/>
 		<file name="lib/libcrc32c.ko"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext3/*"/>
 		<file name="fs/ext4/*"/>
 		<file name="fs/ext2/*"/>
@@ -100,6 +101,7 @@
 		<package name="busybox"/>
 		<package name="parted"/>
 		<package name="adaptec-firmware"/>
+		<package name="btrfsprogs"/>
 		<package name="dialog"/>
 		<package name="psmisc"/>
 		<package name="bind-libs"/>
@@ -132,6 +134,7 @@
 		<package name="kpartx"/>
 		<package name="iputils"/>
 		<package name="dosfstools"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>

--- a/system/boot/ppc/vmxboot/suse-SLES11/config.xml
+++ b/system/boot/ppc/vmxboot/suse-SLES11/config.xml
@@ -23,6 +23,7 @@
 		<file name="net/packet/*"/>
 		<file name="lib/zlib_deflate/zlib_deflate.ko"/>
 		<file name="lib/libcrc32c.ko"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext3/*"/>
 		<file name="fs/ext4/*"/>
 		<file name="fs/ext2/*"/>
@@ -70,6 +71,7 @@
 		<package name="psmisc"/>
 		<package name="bind-libs"/>
 		<package name="bind-utils"/>
+		<package name="btrfsprogs"/>
 		<package name="dhcpcd"/>
 		<package name="e2fsprogs"/>
 		<package name="file"/>
@@ -92,6 +94,7 @@
 		<package name="gettext-runtime"/>
 		<package name="parted"/>
 		<package name="fbiterm"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>

--- a/system/boot/s390/netboot/suse-SLES11/config.xml
+++ b/system/boot/s390/netboot/suse-SLES11/config.xml
@@ -27,8 +27,10 @@
 		<file name="drivers/block/loop.ko"/>
 		<file name="drivers/block/brd.ko"/>
 		<file name="net/packet/*"/>
-		<file name="fs/ext3/*"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext4/*"/>
 		<file name="fs/binfmt_aout.ko"/>
 		<file name="fs/binfmt_misc.ko"/>
 		<file name="fs/mbcache.ko"/>
@@ -46,6 +48,7 @@
 		<file name="net/sunrpc/*"/>
 		<file name="fs/lockd/*"/>
 		<file name="fs/nfs_common/*"/>
+		<file name="fs/xfs/*"/>
 		<file name="net/ipv6/*"/>
 		<file name="drivers/ata/*"/>
 		<file name="drivers/scsi/*"/>
@@ -70,6 +73,7 @@
 	<packages type="image">
 		<package name="cryptsetup"/>
 		<package name="bc"/>
+		<package name="btrfsprogs"/>
 		<package name="curl"/>
 		<package name="psmisc"/>
 		<package name="iputils"/>
@@ -98,6 +102,7 @@
 		<package name="cyrus-sasl"/>
 		<package name="mdadm"/>
 		<package name="dmraid"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>

--- a/system/boot/s390/oemboot/suse-SLES11/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES11/config.xml
@@ -28,8 +28,9 @@
 		<file name="drivers/scsi/*"/>
 		<file name="drivers/cdrom/*"/>
 		<file name="drivers/char/*"/>
-		<file name="fs/ext3/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext4/*"/>
 		<file name="fs/fat/*"/>
 		<file name="fs/vfat/*"/>
 		<file name="fs/binfmt_aout.ko"/>
@@ -46,6 +47,7 @@
 		<file name="fs/nls/nls_iso8859-1.ko"/>
 		<file name="fs/fuse/*"/>
 		<file name="fs/udf/*"/>
+		<file name="fs/xfs/*"/>
 	</drivers>
 	<repository type="yast2" status="replaceable">
 		<source path="http://download.suse.de/install/SLP/SLES-11-SP1-GM/%arch/DVD1/"/>
@@ -66,6 +68,7 @@
 		<package name="psmisc"/>
 		<package name="bind-libs"/>
 		<package name="bind-utils"/>
+		<package name="btrfsprogs"/>
 		<package name="dhcpcd"/>
 		<package name="e2fsprogs"/>
 		<package name="file"/>
@@ -92,6 +95,7 @@
 		<package name="kexec-tools"/>
 		<package name="kpartx"/>
 		<package name="iputils"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>

--- a/system/boot/s390/vmxboot/suse-SLES11/config.xml
+++ b/system/boot/s390/vmxboot/suse-SLES11/config.xml
@@ -25,8 +25,10 @@
 		<file name="drivers/md/*"/>
 		<file name="drivers/block/*"/>
 		<file name="drivers/scsi/*"/>
-		<file name="fs/ext3/*"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext4/*"/>
 		<file name="fs/fat/*"/>
 		<file name="fs/vfat/*"/>
 		<file name="fs/binfmt_aout.ko"/>
@@ -42,6 +44,7 @@
 		<file name="fs/nls/nls_cp437.ko"/>
 		<file name="fs/nls/nls_iso8859-1.ko"/>
 		<file name="fs/fuse/*"/>
+		<file name="fs/xfs/*"/>
 	</drivers>
 	<repository type="yast2" status="replaceable">
 		<source path="http://download.suse.de/install/SLP/SLES-11-SP1-GM/%arch/DVD1/"/>
@@ -57,6 +60,7 @@
 		<package name="psmisc"/>
 		<package name="bind-libs"/>
 		<package name="bind-utils"/>
+		<package name="btrfsprogs"/>
 		<package name="dhcpcd"/>
 		<package name="e2fsprogs"/>
 		<package name="file"/>
@@ -80,6 +84,7 @@
 		<package name="gettext-runtime"/>
 		<package name="parted"/>
 		<package name="fbiterm"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>


### PR DESCRIPTION
The initrd image descriptions previously did not include necessary
  drivers and packages.
