### PR TITLE
Sle prop fs support 11 1

### DIFF
--- a/system/boot/ix86/netboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/netboot/suse-SLES11/config.xml
@@ -39,8 +39,9 @@
 		<file name="drivers/block/loop.ko"/>
 		<file name="drivers/block/brd.ko"/>
 		<file name="net/packet/*"/>
-		<file name="fs/ext3/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext4/*"/>
 		<file name="fs/binfmt_aout.ko"/>
 		<file name="fs/binfmt_misc.ko"/>
 		<file name="fs/mbcache.ko"/>
@@ -58,6 +59,7 @@
 		<file name="net/sunrpc/*"/>
 		<file name="fs/lockd/*"/>
 		<file name="fs/nfs_common/*"/>
+		<file name="fs/xfs/*"/>
 		<file name="net/ipv6/*"/>
 		<file name="drivers/ata/*"/>
 		<file name="drivers/scsi/*"/>
@@ -160,6 +162,7 @@
 		<package name="cryptsetup"/>
 		<package name="bc"/>
 		<package name="adaptec-firmware"/>
+		<package name="btrfsprogs"/>
 		<package name="curl"/>
 		<package name="psmisc"/>
 		<package name="iputils"/>
@@ -188,6 +191,8 @@
 		<package name="kiwi-tools"/>
 		<package name="cyrus-sasl"/>
 		<package name="mdadm"/>
+		<package name="dmraid"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="image" profiles="diskless">
 		<package name="bc"/>

--- a/system/boot/ix86/oemboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLES11/config.xml
@@ -39,10 +39,13 @@
 		<file name="drivers/block/loop.ko"/>
 		<file name="drivers/hid/*"/>
 		<file name="drivers/ide/*"/>
-		<file name="fs/ext3/*"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext4/*"/>
 		<file name="fs/fat/*"/>
 		<file name="fs/vfat/*"/>
+		<file name="fs/xfs/*"/>
 		<file name="fs/binfmt_aout.ko"/>
 		<file name="fs/binfmt_misc.ko"/>
 		<file name="fs/mbcache.ko"/>
@@ -105,6 +108,7 @@
 		<package name="busybox"/>
 		<package name="parted"/>
 		<package name="adaptec-firmware"/>
+		<package name="btrfsprogs"/>
 		<package name="dialog"/>
 		<package name="psmisc"/>
 		<package name="bind-libs"/>
@@ -129,6 +133,7 @@
 		<package name="lvm2"/>
 		<package name="bzip2"/>
 		<package name="kiwi-tools"/>
+		<package name="dmraid"/>
 		<package name="cryptsetup"/>
 		<package name="fbiterm"/>
 		<package name="bc"/>
@@ -138,6 +143,7 @@
 		<package name="syslinux"/>
 		<package name="dosfstools"/>
 		<package name="iputils"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>

--- a/system/boot/ix86/vmxboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/vmxboot/suse-SLES11/config.xml
@@ -32,8 +32,10 @@
 		<file name="drivers/md/*"/>
 		<file name="drivers/block/loop.ko"/>
 		<file name="drivers/ide/*"/>
-		<file name="fs/ext3/*"/>
+		<file name="fs/btrfs/*"/>
 		<file name="fs/ext2/*"/>
+		<file name="fs/ext3/*"/>
+		<file name="fs/ext3/*"/>
 		<file name="fs/fat/*"/>
 		<file name="fs/vfat/*"/>
 		<file name="fs/binfmt_aout.ko"/>
@@ -49,6 +51,7 @@
 		<file name="fs/nls/nls_cp437.ko"/>
 		<file name="fs/nls/nls_iso8859-1.ko"/>
 		<file name="fs/fuse/*"/>
+		<file name="fs/xfs/*"/>
 		<file name="drivers/ata/*"/>
 		<file name="drivers/scsi/*"/>
 		<file name="drivers/message/fusion/*"/>
@@ -89,6 +92,7 @@
 	</packages>
 	<packages type="image">
 		<package name="psmisc"/>
+		<package name="btrfsprogs"/>
 		<package name="bind-libs"/>
 		<package name="bind-utils"/>
 		<package name="dhcpcd"/>
@@ -116,6 +120,7 @@
 		<package name="parted"/>
 		<package name="syslinux"/>
 		<package name="fbiterm"/>
+		<package name="xfsprogs"/>
 	</packages>
 	<packages type="bootstrap">
 		<package name="filesystem"/>


### PR DESCRIPTION
At present drivers and tools are missing from the initrd, this will cause
  failures when the image is getting booted. This support is only
  for x86 & x86-64.
