### PR TITLE
- Do not allow whitespce in the value of the name attribute for the

### DIFF
--- a/modules/KIWIXMLValidator.pm
+++ b/modules/KIWIXMLValidator.pm
@@ -745,6 +745,36 @@ sub __checkRevision {
 }
 
 #==========================================
+# __checkSysdiskNameNoWhitespace
+#------------------------------------------
+sub __checkSysdiskNameNoWhitespace {
+	# ...
+	# Check that the name attribute of the <systemdisk> element does not
+	# contain white space
+	# ---
+	my $this        = shift;
+	my $systemTree  = $this -> {systemTree};
+	my @sysdiskNodes = $systemTree -> getElementsByTagName('systemdisk');
+	if (! @sysdiskNodes ) {
+		return 1;
+	}
+	for my $sysdiskNode (@sysdiskNodes) {
+		my $name = $sysdiskNode -> getAttribute('name');
+		if ($name) {
+			if ($name =~ /\s/x) {
+				my $kiwi = $this -> {kiwi};
+				my $msg = 'Found whitespace in name given for systemdisk. '
+					. 'Provided name may not contain whitespace.';
+				$kiwi -> error($msg);
+				$kiwi -> failed();
+				return;
+			}
+		}
+	}
+	return 1;
+}
+
+#==========================================
 # __checkTypeConfigConsist
 #------------------------------------------
 sub __checkTypeConfigConsist {
@@ -877,6 +907,34 @@ sub __checkVersionDefinition {
 }
 
 #==========================================
+# __checkVolNameNoWhitespace
+#------------------------------------------
+sub __checkVolNameNoWhitespace {
+	# ...
+	# Check that the name attribute of the <volume> element does not
+	# contain white space
+	# ---
+	my $this        = shift;
+	my $systemTree  = $this -> {systemTree};
+	my @volumeNodes = $systemTree -> getElementsByTagName('volume');
+	if (! @volumeNodes ) {
+		return 1;
+	}
+	for my $volNode (@volumeNodes) {
+		my $name = $volNode -> getAttribute('name');
+		if ($name =~ /\s/x) {
+			my $kiwi = $this -> {kiwi};
+			my $msg = 'Found whitespace in given volume name. '
+				. 'Provided name may not contain whitespace.';
+			$kiwi -> error($msg);
+			$kiwi -> failed();
+			return;
+		}
+	}
+	return 1;
+}
+
+#==========================================
 # __getXMLDocTree
 #------------------------------------------
 sub __getXMLDocTree {
@@ -989,13 +1047,19 @@ sub __validateConsistency {
 	if (! $this -> __checkRevision()) {
 		return;
 	}
-		if (! $this -> __checkTypeConfigConsist()) {
+	if (! $this -> __checkSysdiskNameNoWhitespace()) {
+		return;
+	}
+	if (! $this -> __checkTypeConfigConsist()) {
 		return;
 	}
 	if (! $this -> __checkTypeUnique()) {
 		return;
 	}
 	if (! $this -> __checkVersionDefinition()) {
+		return;
+	}
+	if (! $this -> __checkVolNameNoWhitespace()) {
 		return;
 	}
 	return 1;

--- a/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceInvalid_1.xml
+++ b/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceInvalid_1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in system disk name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+			<systemdisk name="my vol">
+				<volume name="tmp"/>
+			</systemdisk>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceInvalid_2.xml
+++ b/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceInvalid_2.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in system disk name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+			<systemdisk name="nameW	tab">
+		    <volume name="tmp"/>
+			</systemdisk>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceValid_1.xml
+++ b/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceValid_1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in system disk name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+			<systemdisk name="myLVMname">
+				<volume name="tmp"/>
+			</systemdisk>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceValid_2.xml
+++ b/tests/unit/data/kiwiXMLValidator/sysdiskWhitespaceValid_2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in system disk name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/volumeWhitespaceInvalid_1.xml
+++ b/tests/unit/data/kiwiXMLValidator/volumeWhitespaceInvalid_1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in volume name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+			<systemdisk name="myVolume">
+				<volume name="tmp onTmp"/>
+			</systemdisk>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/volumeWhitespaceInvalid_2.xml
+++ b/tests/unit/data/kiwiXMLValidator/volumeWhitespaceInvalid_2.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in volume name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+			<systemdisk name="myVolume">
+				<volume name="nameW	tab"/>
+			</systemdisk>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/volumeWhitespaceValid_1.xml
+++ b/tests/unit/data/kiwiXMLValidator/volumeWhitespaceValid_1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in volume name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+			<systemdisk name="myLVMname">
+				<volume name="tmp"/>
+			</systemdisk>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/volumeWhitespaceValid_2.xml
+++ b/tests/unit/data/kiwiXMLValidator/volumeWhitespaceValid_2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="suse-12.1-test-image">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test whitespace in volume name attribute value</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext3" boot="vmxboot/suse-12.1">
+			<machine memory="512">
+				<vmdisk controller="scsi" id="0"/>
+			</machine>
+		</type>
+		<version>0.0.1</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="ifplugd"/>
+		<package name="kernel-default"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/lib/Test/kiwiXMLValidator.pm
+++ b/tests/unit/lib/Test/kiwiXMLValidator.pm
@@ -677,6 +677,35 @@ sub test_revisionMismatch {
 }
 
 #==========================================
+# test_sysdiskNameAttrNoWhiteSpace
+#------------------------------------------
+sub test_sysdiskNameAttrNoWhiteSpace {
+	# ...
+	# Test that the value of the name attribute of the <systemdisk>
+	# element does not contain whitespace.
+	# ---
+	my $this = shift;
+	my @invalidConfigs = $this -> __getInvalidFiles('sysdiskWhitespace');
+	my $expectedMsg = 'Found whitespace in name given for systemdisk. '
+		. 'Provided name may not contain whitespace.';
+	for my $iConfFile (@invalidConfigs) {
+		my $validator = $this -> __getValidator($iConfFile);
+		$validator -> validate();
+		my $kiwi = $this -> {kiwi};
+		my $msg = $kiwi -> getMessage();
+			$this -> assert_str_equals($expectedMsg, $msg);
+		my $msgT = $kiwi -> getMessageType();
+		$this -> assert_str_equals('error', $msgT);
+		my $state = $kiwi -> getState();
+		$this -> assert_str_equals('failed', $state);
+		# Test this condition last to get potential error messages
+		$this -> assert_not_null($validator);
+	}
+	my @validConfigs = $this -> __getValidFiles('sysdiskWhitespace');
+	$this -> __verifyValid(@validConfigs);
+}
+
+#==========================================
 # test_typeConfigConsist
 #------------------------------------------
 sub test_typeConfigConsist {
@@ -774,6 +803,35 @@ sub test_versionFormat {
 		$this -> assert_not_null($validator);
 	}
 	my @validConfigs = $this -> __getValidFiles('versionFormat');
+	$this -> __verifyValid(@validConfigs);
+}
+
+#==========================================
+# test_volumeNameAttrNoWhiteSpace
+#------------------------------------------
+sub test_volumeNameAttrNoWhiteSpace {
+	# ...
+	# Test that the value of the name attribute of the <volume>
+	# element does not contain whitespace.
+	# ---
+	my $this = shift;
+	my @invalidConfigs = $this -> __getInvalidFiles('volumeWhitespace');
+	my $expectedMsg = 'Found whitespace in given volume name. '
+		. 'Provided name may not contain whitespace.';
+	for my $iConfFile (@invalidConfigs) {
+		my $validator = $this -> __getValidator($iConfFile);
+		$validator -> validate();
+		my $kiwi = $this -> {kiwi};
+		my $msg = $kiwi -> getMessage();
+			$this -> assert_str_equals($expectedMsg, $msg);
+		my $msgT = $kiwi -> getMessageType();
+		$this -> assert_str_equals('error', $msgT);
+		my $state = $kiwi -> getState();
+		$this -> assert_str_equals('failed', $state);
+		# Test this condition last to get potential error messages
+		$this -> assert_not_null($validator);
+	}
+	my @validConfigs = $this -> __getValidFiles('volumeWhitespace');
 	$this -> __verifyValid(@validConfigs);
 }
 


### PR DESCRIPTION
<systemdisk> and <volume> elements.
  ~ At present the user can specify a name containing whitespace. This leads
    to problems that are difficult to diagnose in when the user tries to run
    the resulting image, as the image will not properly operate.

Also could have implemented in the Schema definition, but I decided to add it to the validator as we can provide a better/nicer error message.
