### PR TITLE
Fix the handling of the --mbrid command line switch

### DIFF
--- a/kiwi.pl
+++ b/kiwi.pl
@@ -880,7 +880,13 @@ sub init {
 	# check if MBRID is specified
 	#----------------------------------------
 	if (defined $MBRID) {
-		$cmdL -> setMBRID ($MBRID);
+		if ($MBRID < 0 || $MBRID > 0xffffffff) {
+			$kiwi -> error ("Invalid mbrid");
+			$kiwi -> failed ();
+			kiwiExit (1);
+		}
+
+		$cmdL -> setMBRID (sprintf ("0x%08x", $MBRID));
 	}
 	#========================================
 	# check if default answer is specified
@@ -1300,14 +1306,6 @@ sub init {
 	}
 	if (defined $SetImageType) {
 		$cmdL -> setBuildType($SetImageType);
-	}
-	if (defined $MBRID) {
-		if ($MBRID < 0 || $MBRID > 0xffffffff) {
-			$kiwi -> error ("Invalid mbrid");
-			$kiwi -> failed ();
-			kiwiExit (1);
-		}
-		$MBRID = sprintf ("0x%08x", $MBRID);
 	}
 }
 


### PR DESCRIPTION
The value passed to the --mbrid flag is parsed to an integer by
GetOptions (format is 'o' = extended integer). There is code checking
whether this integer is within the expected range and formats it as
hexadecimal value.

But a5c7ab512dfb02dd99044c1db1cbc46ab05bf221 introduced a regression
in the way the value of the --mbrid flag was handled because the value
is set using $cmdL -> setMBRID before the range checking and conversion.

Signed-off-by: Justus Winter winter@pre-sense.de
