### PR TITLE
- prep the code for the move of the udev tools to the usr tree

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -526,9 +526,12 @@ function errorLogStart {
 #--------------------------------------
 function udevPending {
 	local timeout=30
-	if [ -x /sbin/udevadm ];then
-		/sbin/udevadm settle --timeout=$timeout
+	local udevadmExec=$(which udevadm 2>/dev/null)
+	if [ -x $udevadmExec ];then
+		$udevadmExec settle --timeout=$timeout
 	else
+		# udevsettle exists on old distros and is not effected by usr move
+		# SLE 10
 		/sbin/udevsettle --timeout=$timeout
 	fi
 }


### PR DESCRIPTION
At present the location of udevadmin is hardcoded to /sbin, once the
  tools move into the /usr tree and a link exists the -x test will fail. This
  would result in broken images.
