### PR TITLE
- properly pick up splash image for pre-built initrd

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -439,8 +439,8 @@ sub checkAndSetupPrebuiltBootImage {
 	}
 	my $pinitrd = $lookup.$bootImageName.".gz";
 	my $psplash;
-	if (-f $lookup.$bootImageName.".splash.gz") {
-		$psplash = $lookup.$bootImageName.".splash.gz";
+	if (-f $lookup.$bootImageName.'.spl') {
+		$psplash = $lookup.$bootImageName.'.spl';
 	}
 	my $plinux  = $lookup.$bootImageName.".kernel";
 	if (! -f $pinitrd) {


### PR DESCRIPTION
At present it is not possible to use a splash screen with a prebuilt initrd.
  For a pre-built initrd the splash file is named with extension '.spl', but
  we are loking for the extension '.splash.gz', thus the file is not found.
  With this change we look for the filw with the appropriate extension.
