### PR TITLE
- add unit tests for the getOEM* methods

### DIFF
--- a/tests/unit/data/kiwiXML/oemSettings/config.xml
+++ b/tests/unit/data/kiwiXML/oemSettings/config.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.3" name="testCase-OEM-settings">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>Test configuration to verify OEM setting are stored and returned properly in the XML object</specification>
+	</description>
+	<preferences>
+		<type image="oem" filesystem="ext4" boot="oemboot/suse-12.1" installiso="true">
+			<oemconfig>
+				<oem-align-partition>true</oem-align-partition>
+				<oem-boot-title>Unit Test</oem-boot-title>
+				<oem-bootwait>false</oem-bootwait>
+				<oem-inplace-recovery>true</oem-inplace-recovery>
+				<oem-kiwi-initrd>true</oem-kiwi-initrd>
+				<oem-partition-install>false</oem-partition-install>
+				<oem-reboot>false</oem-reboot>
+				<oem-reboot-interactive>false</oem-reboot-interactive>
+				<oem-recovery>true</oem-recovery>
+				<oem-recoveryID>20</oem-recoveryID>
+				<oem-silent-boot>true</oem-silent-boot>
+				<oem-shutdown>false</oem-shutdown>
+				<oem-shutdown-interactive>true</oem-shutdown-interactive>
+				<oem-swap>true</oem-swap>
+				<oem-swapsize>2048</oem-swapsize>
+				<oem-systemsize>20G</oem-systemsize>
+				<oem-unattended>true</oem-unattended>
+				<oem-unattended-id>scsi-SATA_ST9500420AS_5VJ5JL6T-part1</oem-unattended-id>
+			</oemconfig>
+		</type>
+		<version>0.0.1</version>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+	<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="kernel-default"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/lib/Test/kiwiXML.pm
+++ b/tests/unit/lib/Test/kiwiXML.pm
@@ -4,7 +4,7 @@
 # PROJECT       : OpenSUSE Build-Service
 # COPYRIGHT     : (c) 2011 Novell Inc.
 #               :
-# AUTHOR        : Robert Schweikert <rschweikert@novell.com>
+# AUTHOR        : Robert Schweikert <rschweikert@suse.com>
 #               :
 # BELONGS TO    : Operating System images
 #               :
@@ -45,6 +45,440 @@ sub new {
 
 	return $this;
 }
+
+#==========================================
+# test_getOEMAlignPartition
+#------------------------------------------
+sub test_getOEMAlignPartition {
+	# ...
+	# Verify proper return of getOEMAlignPartition method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMAlignPartition();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMBootTitle
+#------------------------------------------
+sub test_getOEMBootTitle {
+	# ...
+	# Verify proper return of getOEMBootTitle method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMBootTitle();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('Unit Test', $value);
+}
+
+#==========================================
+# test_getOEMBootWait
+#------------------------------------------
+sub test_getOEMBootWait {
+	# ...
+	# Verify proper return of getOEMBootWait method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMBootWait();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('false', $value);
+}
+
+#==========================================
+# test_getOEMKiwiInitrd
+#------------------------------------------
+sub test_getOEMKiwiInitrd {
+	# ...
+	# Verify proper return of getOEMKiwiInitrd method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMKiwiInitrd();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMPartitionInstall
+#------------------------------------------
+sub test_getOEMPartitionInstall {
+	# ...
+	# Verify proper return of getOEMPartitionInstall method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMPartitionInstall();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('false', $value);
+}
+
+#==========================================
+# test_getOEMReboot
+#------------------------------------------
+sub test_getOEMReboot {
+	# ...
+	# Verify proper return of getOEMReboot method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMReboot();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('false', $value);
+}
+
+#==========================================
+# test_getOEMRebootInter
+#------------------------------------------
+sub test_getOEMRebootInter {
+	# ...
+	# Verify proper return of getOEMRebootInter method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMRebootInter();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('false', $value);
+}
+
+#==========================================
+# test_getOEMRecovery
+#------------------------------------------
+sub test_getOEMRecovery {
+	# ...
+	# Verify proper return of getOEMRecovery method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMRecovery();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMRecoveryID
+#------------------------------------------
+sub test_getOEMRecoveryID {
+	# ...
+	# Verify proper return of getOEMRecoveryID method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMRecoveryID();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('20', $value);
+}
+
+#==========================================
+# test_getOEMRecoveryInPlace
+#------------------------------------------
+sub test_getOEMRecoveryInPlace {
+	# ...
+	# Verify proper return of getOEMRecoveryInPlace method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMRecoveryInPlace();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMShutdown
+#------------------------------------------
+sub test_getOEMShutdown {
+	# ...
+	# Verify proper return of getOEMShutdown method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMShutdown();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('false', $value);
+}
+
+#==========================================
+# test_getOEMShutdownInter
+#------------------------------------------
+sub test_getOEMShutdownInter {
+	# ...
+	# Verify proper return of getOEMShutdownInter method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMShutdownInter();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMSilentBoot
+#------------------------------------------
+sub test_getOEMSilentBoot {
+	# ...
+	# Verify proper return of getOEMSilentBoot method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMSilentBoot();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMSwap
+#------------------------------------------
+sub test_getOEMSwap {
+	# ...
+	# Verify proper return of getOEMSwap method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMSwap();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMSwapSize
+#------------------------------------------
+sub test_getOEMSwapSize {
+	# ...
+	# Verify proper return of getOEMSwapSize method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMSwapSize();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('2048', $value);
+}
+
+#==========================================
+# test_getOEMSystemSize
+#------------------------------------------
+sub test_getOEMSystemSize {
+	# ...
+	# Verify proper return of getOEMSystemSize method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMSystemSize();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('20G', $value);
+}
+
+#==========================================
+# test_getOEMUnattended
+#------------------------------------------
+sub test_getOEMUnattended {
+	# ...
+	# Verify proper return of getOEMUnattended method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMUnattended();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('true', $value);
+}
+
+#==========================================
+# test_getOEMUnattendedID
+#------------------------------------------
+sub test_getOEMUnattendedID {
+	# ...
+	# Verify proper return of getOEMUnattendedID method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'oemSettings';
+	my $xml = new KIWIXML(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $value = $xml -> getOEMUnattendedID();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_str_equals('scsi-SATA_ST9500420AS_5VJ5JL6T-part1', $value);
+}
+
+
 
 #==========================================
 # test_packageManagerInfoHasConfigValue


### PR DESCRIPTION
Prior to undertacing the restructuring of the XML object we need to get
  unit tests in place
