### PR TITLE
add ability to specify package version with instsource repopackages

### DIFF
--- a/modules/KIWICollect.pm
+++ b/modules/KIWICollect.pm
@@ -916,6 +916,9 @@ sub setupPackageFiles
 		my $nofallback = 0;
 		my @archs;
 		$count_packs++;
+		if(defined($packOptions->{'version'})) {
+			$packOptions->{'requireVersion'}->{ $packOptions->{'version'} } = 1;
+		}
 		if ( $mode == 2 ) {
 			# use src or nosrc only for this package
 			push @archs, $packOptions->{'arch'};
@@ -1003,7 +1006,9 @@ sub setupPackageFiles
 					     && ! defined( $packOptions->{requireVersion}->
 							   {$packPointer->{version}
 							    . "-"
-								. $packPointer->{release}} ) )
+								. $packPointer->{release}} )
+					     && ! defined( $packOptions->{requireVersion}->
+							   {$packPointer->{version}} ) )
 					{
 						if ($this->{m_debug} >= 4) {
 							my $msg = "	    => package "
@@ -1731,19 +1736,7 @@ sub lookUpAllPackages
 					# needs to be a string or sort breaks later
 					$package->{'priority'} = "$this->{m_repos}->{$r}->{priority}";
 
-					# We can have a package only once per architecture and in
-					# one repo
-					my $repokey = $r."@".$arch;
-					# BUT src, nosrc and debug packages need to be available
-					# in all versions.
-					if ( !$flags{'SOURCERPM'} || $name =~ /-debugsource$/
-					     || $name =~ /-debuginfo$/ )
-					{
-						$repokey .= "@"
-						    . $package->{'version'}
-						. "@"
-						    . $package->{'release'};
-					}
+					my $repokey = $r."@".$arch."@".$package->{'version'}."@".$package->{'release'};
 					if ( $packPool->{$name}->{$repokey} ) {
 						# we have it already from a more important repo.
 						next;

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -600,6 +600,10 @@ div {
 		## Specifies that the package with
 		## the given arch should be used in any case
 		attribute onlyarch { text }
+	k.repopackage.version.attribute =
+		## Specifies that the package with
+		## the given version[-release] should be used
+		attribute version { text }
 	k.repopackage.medium.attribute =
 		## Specifies that the package will be put
 		## to the specific medium number (CD1, DVD7, ...)
@@ -613,6 +617,7 @@ div {
 		k.repopackage.addarch.attribute? &
 		k.repopackage.removearch.attribute? &
 		k.repopackage.onlyarch.attribute? &
+		k.repopackage.version.attribute? &
 		k.repopackage.source.attribute? &
 		k.repopackage.script.attribute? &
 		k.repopackage.medium.attribute?

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -3175,7 +3175,7 @@ sub getInstSourcePackageAttributes {
 	my %result;
 	my @attrib = (
 		"forcerepo" ,"addarch", "removearch", "arch",
-		"onlyarch", "source", "script", "medium"
+		"onlyarch", "version", "source", "script", "medium"
 	);
 	if(not defined($this->{m_rpacks})) {
 		my @nodes = ();


### PR DESCRIPTION
I am working on several projects where a given instrepo contains multiple versions of the same package and I need kiwi to pick a specific version of the package. This patch leverages existing code that finds specific versions of src and debuginfo packages. By adding an optional "version" attribute to the repopackage element the user can specify the package version (with or without release) and kiwi will use the first match of a package with that version. If the -release suffix is left off the version spec, then kiwi will pick the first package that matches the version while ignoring the release. When no version attribute is used, kiwi works like in the past and grabs the first package it finds regardless of version.

I have been using this patch successfully for several months across several versions of kiwi.
