### PR TITLE
- add a reference to the online and local schema documentation

### DIFF
--- a/doc/docbook/kiwi-doc-introduction.xml
+++ b/doc/docbook/kiwi-doc-introduction.xml
@@ -34,6 +34,14 @@
     image format of the image produced by KIWI is defined within a
     configuration file named <filename>config.xml</filename> as described in
     <xref linkend="chap.description"/>.</para>
+      <para>Note that not all elements and attributes that may be used in
+    the KIWI <filename>config.xml</filename> configuration file are listed
+    or described in this document. The complete schema documentation
+    can be accessed on the web at
+    <ulink url="http://doc.opensuse.org/projects/kiwi/schema-doc/"/>, latest
+    version, or on you local system using the <filename>
+    file:///usr/share/doc/packages/kiwi/schema/kiwi.html</filename> path
+    as the URL in the browser.</para>
   </sect1>
   <sect1 id="sec.introduction.howtousekiwi">
     <title>How do I use KIWI?</title>


### PR DESCRIPTION
~ a recent discussion on the mailing list revealed that there is
    no reference to the complete schema documentation in the docbook
    doc and not all available elements are listed in the docbooc
    documentation
