### PR TITLE
- eliminate getXenDomain method from XML

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -236,7 +236,14 @@ sub updateDescription {
 	#------------------------------------------
 	$changeset{"packagemanager"} = $src_xml->getPackageManager();
 	$changeset{"showlicense"}    = $src_xml->getLicenseNames();
-	$changeset{"domain"}         = $src_xml->getXenDomain();
+	my $domain;
+	my %xenc = $src_xml -> getXenConfig();
+	if (%xenc) {
+		if (defined $xenc{xen_domain} && $xenc{xen_domain} ne '') {
+			$domain = $xenc{xen_domain};
+		}
+	}
+	$changeset{"domain"}         = $domain;
 	$changeset{"displayname"}    = $src_xml->getImageDisplayName();
 	$changeset{"locale"}         = $src_xml->getLocale();
 	$changeset{"boot-theme"}     = $src_xml->getBootTheme();
@@ -2511,7 +2518,7 @@ sub createImageSplit {
 	$sizeBytes+= $minInodes * $inodesize;
 	$sizeBytes = sprintf ("%.0f", $sizeBytes);
 	$minInodes*= 2;
-	if (open (my $FD,">$imageTree/rootfs.meta")) {
+	if (open (my $FD, '>', "$imageTree/rootfs.meta")) {
 		print $FD "inode_nr=$minInodes\n";
 		print $FD "min_size=$sizeBytes\n";
 		close $FD;

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -1041,26 +1041,6 @@ sub getLicenseNames {
 }
 
 #==========================================
-# getXenDomain
-#------------------------------------------
-sub getXenDomain {
-	# ...
-	# Obtain the Xen domain information if set
-	# ---
-	my $this = shift;
-	my $tnode= $this->{typeNode};
-	my $node = $tnode -> getElementsByTagName ("machine") -> get_node(1);
-	if (! defined $node) {
-		return;
-	}
-	my $domain = $node -> getAttribute ("domain");
-	if ((! defined $domain) || ("$domain" eq "")) {
-		return;
-	}
-	return $domain;
-}
-
-#==========================================
 # getOEMSwapSize
 #------------------------------------------
 sub getOEMSwapSize {
@@ -2557,9 +2537,14 @@ sub getImageConfig {
 	#==========================================
 	# machine
 	#------------------------------------------
-	my $xendomain = $this -> getXenDomain();
-	if (defined $xendomain) {
-		$result{kiwi_xendomain} = $xendomain;
+	my $xendomain;
+	my $tnode= $this->{typeNode};
+	my $xenNode = $tnode -> getElementsByTagName ("machine") -> get_node(1);
+	if ($xenNode) {
+		$xendomain = $xenNode -> getAttribute ("domain");
+		if (defined $xendomain) {
+			$result{kiwi_xendomain} = $xendomain;
+		}
 	}
 	#==========================================
 	# systemdisk
@@ -2589,7 +2574,6 @@ sub getImageConfig {
 	#==========================================
 	# oemconfig
 	#------------------------------------------
-	my $tnode= $this->{typeNode};
 	my $node = $tnode -> getElementsByTagName ("oemconfig") -> get_node(1);
 	if (defined $node) {
 		my $oemswapMB= $node


### PR DESCRIPTION
- the domain is part of the Xen config and can be accessed
  via getXenConfig we should not have multiple methods to
  get the same data
