### PR TITLE
Fix deleting of /usr/lib/gconv content in baseStripLocales

### DIFF
--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -435,8 +435,7 @@ function baseStripLocales {
 	"
 	find $directories -mindepth 1 -maxdepth 1 -type d 2>/dev/null |\
 		baseStripAndKeep ${keepLocales}
-	directories="/usr/lib/gconv"
-	find $directories 2>/dev/null | xargs rm -f
+	rm -f /usr/lib/gconv/*
 }
 
 #======================================


### PR DESCRIPTION
When running `baseStripLocales` in SUSE Studio build script for 12.2
appliances, the following error is triggered:

```
rm: cannot remove '/usr/lib/gconv': Is a directory
```

This is becasue the `find` command in baseStripLocales finds not only
files in `/usr/lib/gconv`, but also the directory itself.

This commit fixes the problem by just deleting files directly under
`/usr/lib/gconv`.
