### PR TITLE
- set the db45-utils package as recommend for openSUSE 12.1 and later

### DIFF
--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -84,6 +84,9 @@ Recommends:     perl-satsolver >= 0.42
 Recommends:     jing
 Recommends:     zypper
 %endif
+%if %{suse_version} > 1140
+Recommends:     db45-utils
+%endif
 # obsoletes
 Obsoletes:      kiwi-desc-usbboot <= 4.81
 # sources


### PR DESCRIPTION
- at present a user running into a rpm db incompatibility issue may get
  an error message that the db45_load tool is not available. This leaves
  the user with no idea where the tool may be found. Unfortunately the
  command-not-found utility does not turn up the command either. Setting
  the package as recommends increases the chance that it will be installed
  when KIWI packages get installed.
