### PR TITLE
kiwi.pl: fixed and simpler date(1) use

### DIFF
--- a/kiwi.pl
+++ b/kiwi.pl
@@ -1322,7 +1322,7 @@ sub usage {
 	# image creation system
 	# ---
 	my $exit = shift;
-	my $date = qx (/bash -c 'LANG=POSIX date -I'/); chomp $date;
+	my $date = qx ( date -I ); chomp $date;
 	print "Linux KIWI setup  (image builder) ($date)\n";
 	print "Copyright (c) 2007 - SUSE LINUX Products GmbH\n";
 	print "\n";


### PR DESCRIPTION
- qx (/bash -c .../) produced this on stderr:
  
  sh: /bash: No such file or directory
- date -I is insensitive to locale, which means:
  - LANG=POSIX is not needed, thus
  - explicit bash invocation is not needed (it was there
    because the syntax for setting env. vars varies among
    shells
