### PR TITLE
- clean up to perl critic level 4

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -76,14 +76,12 @@ my @notClean3 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm KIWICache.pm
 # List of modules not clean to level 4 (stern) of perlcritic
 my @notClean4 = qw (KIWIArchList.pm KIWIArch.pm KIWIBoot.pm
 					KIWICollect.pm KIWIConfigure.pm
-					KIWIImageFormat.pm
-					KIWIImage.pm KIWIIsoLinux.pm
-					KIWILog.pm KIWIManager.pm KIWIMigrate.pm KIWIOverlay.pm
+					KIWIImageFormat.pm KIWIImage.pm
+					KIWILog.pm KIWIManager.pm KIWIMigrate.pm
 					KIWIProductData.pm KIWIRepoMetaHandler.pm
-					KIWIRoot.pm
-					KIWISatSolver.pm KIWISharedMem.pm KIWISocket.pm
+					KIWIRoot.pm KIWISatSolver.pm KIWISharedMem.pm
 					KIWIXML.pm
-					KIWIXMLValidator.pm KIWICommandLine.t KIWIImageCreator.t
+					KIWICommandLine.t KIWIImageCreator.t
 					KIWILocator.t KIWIRuntimeChecker.t KIWIXML.t KIWIXMLInfo.t
 					collector.pl);
 

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,5 +1,4 @@
 [-Miscellanea::RequireRcsKeywords]
 [-Modules::RequireVersionVar]
 [-NamingConventions::Capitalization]
-[InputOutput::RequireBriefOpen]
-lines = 15
+[-InputOutput::RequireBriefOpen]

--- a/modules/KIWILog.pm
+++ b/modules/KIWILog.pm
@@ -927,18 +927,18 @@ sub setLogServer {
 				# Handle log requests...
 				#------------------------------------------
 				$SIG{PIPE} = sub {
-					$logServer -> write ( $this -> getLogServerMessage() );
+					$logServer -> writeTo ( $this -> getLogServerMessage() );
 					$logServer -> closeConnection();
 					$sharedMem -> closeSegment();
 					undef $this-> {smem};
 					exit 1;
 				};
-				while (my $command = $logServer -> read()) {
+				while (my $command = $logServer -> readFrom()) {
 					#==========================================
 					# Handle command: status
 					#------------------------------------------
 					if ($command eq "status") {
-						$logServer -> write (
+						$logServer -> writeTo (
 							$this -> getLogServerMessage()
 						);
 						next;
@@ -956,7 +956,7 @@ sub setLogServer {
 					#==========================================
 					# Invalid command...
 					#------------------------------------------
-					$logServer -> write (
+					$logServer -> writeTo (
 						$this -> getLogServerDefaultErrorMessage()
 					);
 				}

--- a/modules/KIWIOverlay.pm
+++ b/modules/KIWIOverlay.pm
@@ -9,7 +9,7 @@
 # BELONGS TO    : Operating System images
 #               :
 # DESCRIPTION   : This module is used for directory overlay techniques
-#               : 
+#               :
 #               :
 # STATUS        : Development
 #----------------
@@ -18,6 +18,7 @@ package KIWIOverlay;
 # Modules
 #------------------------------------------
 use strict;
+use warnings;
 use Carp qw (cluck);
 use File::Spec;
 use KIWILog;

--- a/modules/KIWISocket.pm
+++ b/modules/KIWISocket.pm
@@ -20,10 +20,14 @@ package KIWISocket;
 # Modules
 #------------------------------------------
 use strict;
+use warnings;
+use base qw (Exporter);
 use Carp qw (cluck);
 use FileHandle;
 use Socket;
 use KIWIQX qw (qxx);
+
+my @EXPORT_OK = qw ();
 
 #==========================================
 # Constructor
@@ -107,12 +111,13 @@ sub closeConnection {
 	if (defined $client) {
 		close $client;
 	}
+	return;
 }
 
 #==========================================
 # write
 #------------------------------------------
-sub write {
+sub writeTo {
 	my $this    = shift;
 	my $message = shift;
 	my $client  = $this->{client};
@@ -124,7 +129,7 @@ sub write {
 #==========================================
 # read
 #------------------------------------------
-sub read {
+sub readFrom {
 	my $this    = shift;
 	my $client  = $this->{client};
 	if (! defined $client) {


### PR DESCRIPTION
- disable the brief file open/close check
  - this check is unreliable when using multiple open/close constructs in one
    routine.
