### PR TITLE
fix the suse-live-usbstick config according to the version

### DIFF
--- a/doc/examples/suse-11.4/suse-live-usbstick/config.xml
+++ b/doc/examples/suse-11.4/suse-live-usbstick/config.xml
@@ -7,7 +7,7 @@
 		<specification>openSUSE 11.4 Live system for CD/DVD and USB Stick</specification>
 	</description>
 	<preferences>
-		<type image="oem" boot="oemboot/suse-11.3" filesystem="clicfs" bootloader="syslinux" ramonly="true">
+		<type image="oem" boot="oemboot/suse-11.4" filesystem="clicfs" bootloader="syslinux" ramonly="true">
 			<oemconfig>
 				<oem-swap>false</oem-swap>
 				<oem-systemsize>2048</oem-systemsize>

--- a/doc/examples/suse-12.1/suse-live-usbstick/config.xml
+++ b/doc/examples/suse-12.1/suse-live-usbstick/config.xml
@@ -7,7 +7,7 @@
 		<specification>openSUSE 12.1 Live system for CD/DVD and USB Stick</specification>
 	</description>
 	<preferences>
-		<type image="oem" boot="oemboot/suse-11.3" filesystem="clicfs" bootloader="syslinux" ramonly="true">
+		<type image="oem" boot="oemboot/suse-12.1" filesystem="clicfs" bootloader="syslinux" ramonly="true">
 			<oemconfig>
 				<oem-swap>false</oem-swap>
 				<oem-systemsize>2048</oem-systemsize>

--- a/doc/examples/suse-12.2/suse-live-usbstick/config.xml
+++ b/doc/examples/suse-12.2/suse-live-usbstick/config.xml
@@ -7,7 +7,7 @@
 		<specification>openSUSE 12.2 Live system for CD/DVD and USB Stick</specification>
 	</description>
 	<preferences>
-		<type image="oem" boot="oemboot/suse-11.3" filesystem="clicfs" bootloader="syslinux" ramonly="true">
+		<type image="oem" boot="oemboot/suse-12.2" filesystem="clicfs" bootloader="syslinux" ramonly="true">
 			<oemconfig>
 				<oem-swap>false</oem-swap>
 				<oem-systemsize>2048</oem-systemsize>


### PR DESCRIPTION
Examples of suse-live-usbstick was referring to 11.3 in all cases, where as they should refer to their specific suse release. This commit fixes these
