### PR TITLE
- indicate check failure through return value (undef)

### DIFF
--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -523,6 +523,7 @@ sub __checkVMscsiCapable {
 		. "\nto a newer version of qemu-img or change the controller to ide";
 		$this -> {kiwi} -> error ($msg);
 		$this -> {kiwi} -> failed ();
+        return;
 	}
 	return 1;
 }


### PR DESCRIPTION
- we should have it correct now. Previously a 1 was returned, indicating
  success. This change returns no value on failure to indicate the
  failed state of the check.
