### PR TITLE
- implement the getDescriptionInfo method in the XML object

### DIFF
--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -29,6 +29,7 @@ use KIWILocator;
 use KIWILog;
 use KIWIQX qw (qxx);
 use KIWIURL;
+use KIWIXMLDescriptionData;
 use KIWIXMLValidator;
 use KIWISatSolver;
 
@@ -387,6 +388,20 @@ sub getDefaultPrebuiltDir {
 	my $node = $this -> __getPreferencesNodeByTagName ('defaultprebuilt');
 	my $imgDir = $node -> getElementsByTagName ('defaultprebuilt');
 	return $imgDir;
+}
+
+#==========================================
+# getDescriptionInfo
+#------------------------------------------
+sub getDescriptionInfo {
+	# ...
+	# Return an object that encapsulates the description information
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $descriptObj = KIWIXMLDescriptionData -> new($kiwi,
+										$this->{imageConfig}->{description});
+	return $descriptObj;
 }
 
 #==========================================

--- a/tests/unit/data/kiwiXML/descriptData/config.xml
+++ b/tests/unit/data/kiwiXML/descriptData/config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.4" name="testCase-package-settings">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>Verify proper handling of description in XML obj</specification>
+	</description>
+	<preferences>
+		<type image="oem" filesystem="ext4" boot="oemboot/suse-12.1" installiso="true"/>
+		<version>0.0.1</version>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>false</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+	<user pwd="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<archive name="myInitStuff.tar" bootinclude="true"/>
+		<archive name="myImageStuff.tgz"/>
+		<opensusePattern name="base"/>
+		<opensusePattern name="xfce"/>
+		<package name="ed"/>
+		<package name="kernel-default"/>
+		<package name="python" bootinclude="true"/>
+		<package name="vim" bootinclude="true"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/lib/Test/kiwiXML.pm
+++ b/tests/unit/lib/Test/kiwiXML.pm
@@ -21,8 +21,9 @@ use Common::ktLog;
 use Common::ktTestCase;
 use base qw /Common::ktTestCase/;
 
-use KIWIXML;
 use KIWICommandLine;
+use KIWIXML;
+use KIWIXMLDescriptionData;
 
 # All tests will need to be adjusted once KIWXML turns into a stateless
 # container and the ctor receives the config.xml file name as an argument.
@@ -1293,6 +1294,39 @@ sub test_getDeleteListInstallDelete {
 	$this -> assert_str_equals('No state set', $state);
 	# Test this condition last to get potential error messages
 	$this -> assert_null(@delPcks);
+	return;
+}
+
+#==========================================
+# test_getDescriptionInfo
+#------------------------------------------
+sub test_getDescriptionInfo {
+	# ...
+	# Verify the proper return of getDescriptionInfo methof
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'descriptData';
+	my $xml = KIWIXML -> new(
+		$this -> {kiwi}, $confDir, undef, undef, $this->{cmdL}
+	);
+	my $descrpObj = $xml -> getDescriptionInfo();
+	$this -> assert_not_null($descrpObj);
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	my $author = $descrpObj -> getAuthor();
+	$this -> assert_str_equals('Robert Schweikert', $author);
+	my $contact = $descrpObj -> getContactInfo();
+	$this -> assert_str_equals('rjschwei@suse.com', $contact);
+	my $spec = $descrpObj -> getSpecificationDescript();
+	my $expected = 'Verify proper handling of description in XML obj';
+	$this -> assert_str_equals($expected, $spec);
+	my $type = $descrpObj -> getType();
+	$this -> assert_str_equals('system', $type);
 	return;
 }
 


### PR DESCRIPTION
~ the method uses the new KIWIXMLDescriptionData object, which gets
    created based on the data in the imageConfig datastructure and
- implement unit test for the getDescriptionInfo method
