### PR TITLE
fix ppc installation cd

### DIFF
--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -700,7 +700,7 @@ sub createISO {
 	my $prog = $this -> {tool};
 	my $cmdL = $this -> {cmdL};
 	my $xml  = $this -> {xml};
-	my $cmdln= "$prog $para -o $dest $ldir $src 2>&1";
+	my $cmdln= "$prog $para -o $dest $src $ldir 2>&1";
 	if ($cmdL) {
 		my $editBoot = $cmdL -> getEditBootConfig();
 		if ((! $editBoot) && ($xml)) {


### PR DESCRIPTION
Those commits mostly targeting to fix ppc install cd. 
The directory not blessed correctly: -hfs-bless failed

There are two other minor things.
1) show cmdL of createISO during product build on OBS
2) fix hardcoded -hfs-volid
