### PR TITLE
Emacs mode fix

### DIFF
--- a/editing/suse-start-kiwi-mode.el
+++ b/editing/suse-start-kiwi-mode.el
@@ -1,6 +1,7 @@
-(setq auto-mode-alist
-(cons '("\\.\\(xml\\|kiwi\\|xsl\\|rng\\|xhtml\\)\\'" . nxml-mode)
-auto-mode-alist))
+;; For file names ending with kiwi use the nxml-mode
+;; and locate the schemas in kiwi editing directory
 
-(eval-after-load 'rng-loc
-'(add-to-list 'rnc-schema-locating-files "/usr/share/kiwi/editing/suse-start-kiwi-xmllocator.xml"))
+(progn
+  (add-to-list 'auto-mode-alist '("\\.kiwi" . nxml-mode))
+  (eval-after-load 'rng-loc
+    '(add-to-list 'rng-schema-locating-files "/usr/share/kiwi/editing/suse-start-kiwi-xmllocator.xml")))

--- a/editing/suse-start-kiwi-xmllocator.xml
+++ b/editing/suse-start-kiwi-xmllocator.xml
@@ -1,6 +1,6 @@
 <locatingRules xmlns="http://thaiopensource.com/ns/locating-rules/1.0">
-<transformURI fromPattern="*.xml" toPattern="*.rnc"/>
+  <transformURI fromPattern="*.xml" toPattern="*.rnc"/>
 
-<uri pattern=”*.kiwi” typeId=”KIWI”/>
-<typeId id=”KIWI” uri=”/usr/share/kiwi/modules/KIWISchema.rnc”/>
+  <uri pattern="*.kiwi" typeId="KIWI"/>
+  <typeId id="KIWI" uri="/usr/share/kiwi/modules/KIWISchema.rnc"/>
 </locatingRules>


### PR DESCRIPTION
Fix typos in the suse-start-kiwi-xmllocator
Rather than blindly adding suffixes to nxml-mode just add kiwi suffix
to include to the auto-mode-list
