### PR TITLE
- add consistency check for the <packages type="delete"> case

### DIFF
--- a/tests/unit/data/kiwiXMLValidator/deleteArchive.xml
+++ b/tests/unit/data/kiwiXMLValidator/deleteArchive.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.5" name="suse-11.3-vm-guest">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>Try to delete an archive, should trigger error</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-11.3" format="vmdk">
+			<machine memory="512">
+				<vmdisk controller="ide" id="0"/>
+				<vmnic interface="0" driver="e1000" mode="bridged"/>
+				<vmnic interface="1" driver="e1000" mode="bridged"/>
+			</machine>
+		</type>
+		<version>1.0.0</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="linux" pwdformat="plain" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://11.3/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="kernel-default"/>
+		<package name="ifplugd"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="delete">
+		<archive name="myFiles.tar"/>
+		<package name="libre-office"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/deletePattern.xml
+++ b/tests/unit/data/kiwiXMLValidator/deletePattern.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.5" name="suse-11.3-vm-guest">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>Try to delete a pattern, should trigger error</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-11.3" format="vmdk">
+			<machine memory="512">
+				<vmdisk controller="ide" id="0"/>
+				<vmnic interface="0" driver="e1000" mode="bridged"/>
+				<vmnic interface="1" driver="e1000" mode="bridged"/>
+			</machine>
+		</type>
+		<version>1.0.0</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="linux" pwdformat="plain" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://11.3/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="kernel-default"/>
+		<package name="ifplugd"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="delete">
+		<package name="libre-office"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/deleteProduct.xml
+++ b/tests/unit/data/kiwiXMLValidator/deleteProduct.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="5.5" name="suse-11.3-vm-guest">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>Try to delete a product, should trigger error</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-11.3" format="vmdk">
+			<machine memory="512">
+				<vmdisk controller="ide" id="0"/>
+				<vmnic interface="0" driver="e1000" mode="bridged"/>
+				<vmnic interface="1" driver="e1000" mode="bridged"/>
+			</machine>
+		</type>
+		<version>1.0.0</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user pwd="linux" pwdformat="plain" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://11.3/repo/oss/"/>
+	</repository>
+	<packages type="image">
+		<package name="bootsplash-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="kernel-default"/>
+		<package name="ifplugd"/>
+		<package name="vim"/>
+		<opensusePattern name="base"/>
+	</packages>
+	<packages type="delete">
+		<package name="libre-office"/>
+		<opensuseProduct name="SLE"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/lib/Test/kiwiXMLValidator.pm
+++ b/tests/unit/lib/Test/kiwiXMLValidator.pm
@@ -319,6 +319,84 @@ sub test_defaultTypeSpec {
 }
 
 #==========================================
+# test_deleteArchive
+#------------------------------------------
+sub test_deleteArchive {
+	# ...
+	# Test that an error condition is generated when trying to delete
+	# an archive.
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $configFile = $this -> {dataDir} . '/deleteArchive.xml';
+	my $validator = $this -> __getValidator($configFile);
+	my $res = $validator -> validate();
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'Inconsistent data: specified archive for '
+		. 'deletion. This is not supported.';
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_null($res);
+	return;
+}
+
+#==========================================
+# test_deletePattern
+#------------------------------------------
+sub test_deletePattern {
+	# ...
+	# Test that an error condition is generated when trying to delete
+	# patterns.
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $configFile = $this -> {dataDir} . '/deletePattern.xml';
+	my $validator = $this -> __getValidator($configFile);
+	my $res = $validator -> validate();
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'Inconsistent data: specified pattern for '
+		. 'deletion. This is not supported.';
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_null($res);
+	return;
+}
+
+#==========================================
+# test_deleteProduct
+#------------------------------------------
+sub test_deleteProduct {
+	# ...
+	# Test that an error condition is generated when trying to delete
+	# a product.
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $configFile = $this -> {dataDir} . '/deleteProduct.xml';
+	my $validator = $this -> __getValidator($configFile);
+	my $res = $validator -> validate();
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'Inconsistent data: specified product for '
+		. 'deletion. This is not supported.';
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_null($res);
+	return;
+}
+
+#==========================================
 # test_displayName
 #------------------------------------------
 sub test_displayName {


### PR DESCRIPTION
~ can only delete packages, thus specifying archives, patterns, or a
    product is not valid
