### PR TITLE
Fixes regular expression for replacing HWCLOCK in clock config file

### DIFF
--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -344,7 +344,7 @@ function suseConfig {
 	#--------------------------------------
 	if [ ! -z "$kiwi_hwclock" ];then
 		cat /etc/sysconfig/clock |\
-			sed -e s"@HWCLOCK=\".*\"@HWCLOCK=\"--$kiwi_hwclock\"@" \
+			sed -e s"@^HWCLOCK=\".*\"@HWCLOCK=\"--$kiwi_hwclock\"@" \
 		> etc/sysconfig/clock.new
 		mv etc/sysconfig/clock.new etc/sysconfig/clock
 	fi


### PR DESCRIPTION
This fixes a bug that causes a wrong '--localtime' / '--utc' entry in
USE_HWCLOCK setting. This setting got introduced with 12.2.
