### PR TITLE
Be more quite durin kiwi rpm build

### DIFF
--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -440,7 +440,7 @@ Authors:
 %endif
 
 %prep
-%setup -n %name -a2 -a3
+%setup -q -n %name -a2 -a3
 
 %build
 # empty because of rpmlint warning rpm-buildroot-usage


### PR DESCRIPTION
During kiwi build don't list files and directories of tarball. This
floods build log pretty much, as we have a lot of files and directories.
