### PR TITLE
Finish <size> handling in imageConfig

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -374,11 +374,11 @@ sub new {
 		#==========================================
 		# Store optional size setup from XML
 		#------------------------------------------
-		my $sizeXMLAddBytes = $xml -> getImageSizeAdditiveBytes();
+		my $sizeXMLAddBytes = $xml -> getImageSizeAdditiveBytes_legacy();
 		if ($sizeXMLAddBytes) {
 			$sizeXMLBytes = $sizeBytes + $sizeXMLAddBytes;
 		} else {
-			$sizeXMLBytes = $xml -> getImageSizeBytes();
+			$sizeXMLBytes = $xml -> getImageSizeBytes_legacy();
 		}
 		#==========================================
 		# Store initial disk size

--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -4468,13 +4468,13 @@ sub getSize {
 	#==========================================
 	# XML size calculated in Byte
 	#------------------------------------------
-	my $additive = $xml -> getImageSizeAdditiveBytes();
+	my $additive = $xml -> getImageSizeAdditiveBytes_legacy();
 	if ($additive) {
 		# relative size value specified...
 		$xmlsize = $minsize + $additive;
 	} else {
 		# absolute size value specified...
-		$xmlsize = $xml -> getImageSize();
+		$xmlsize = $xml -> getImageSize_legacy();
 		if ($xmlsize eq "auto") {
 			$xmlsize = $minsize;
 		} elsif ($xmlsize =~ /^(\d+)([MG])$/i) {

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -2351,9 +2351,15 @@ sub __genTypeHash {
 		#------------------------------------------
 		$typeData{oemconfig} = $this -> __genOEMConfigHash($type);
 		#==========================================
-		# store <size>...</size> text
+		# store <size>...</size> text and attributes
 		#------------------------------------------
 		$typeData{size} = $this -> __getChildNodeTextValue($type, 'size');
+		my @sizeNodes = $type -> getChildrenByTagName('size');
+		if (@sizeNodes) {
+			my $sizeNd = $sizeNodes[0];
+			$typeData{sizeadd} = $sizeNd -> getAttribute('additive');
+			$typeData{sizeunit} = $sizeNd -> getAttribute('unit');
+		}
 		#==========================================
 		# store <pxeconfig> child
 		#------------------------------------------
@@ -3755,119 +3761,6 @@ sub getImageID {
 	return 0;
 }
 
-#==========================================
-# getImageSize
-#------------------------------------------
-sub getImageSize {
-	# ...
-	# Get the predefined size of the logical extend
-	# ---
-	my $this = shift;
-	my $node = $this->{typeNode};
-	my $size = $node -> getElementsByTagName ("size");
-	if ($size) {
-		my $plus = $node -> getElementsByTagName ("size")
-			-> get_node(1) -> getAttribute("additive");
-		if ((! defined $plus) || ($plus eq "false")) {
-			my $unit = $node -> getElementsByTagName ("size")
-				-> get_node(1) -> getAttribute("unit");
-			if (! $unit) {
-				# no unit specified assume MB...
-				$unit = "M";
-			}
-			# /.../
-			# the fixed size value was set, we will use this value
-			# connected with the unit string
-			# ----
-			return $size.$unit;
-		} else {
-			# /.../
-			# the size is setup as additive value to the required
-			# size. The real size is calculated later and the additive
-			# value is added at that point
-			# ---
-			return "auto";
-		}
-	} else {
-		return "auto";
-	}
-}
-
-#==========================================
-# getImageSizeAdditiveBytes
-#------------------------------------------
-sub getImageSizeAdditiveBytes {
-	# ...
-	# Get the predefined size if the attribute additive
-	# was set to true
-	# ---
-	my $this = shift;
-	my $node = $this->{typeNode};
-	my $size = $node -> getElementsByTagName ("size");
-	if ($size) {
-		my $plus = $node -> getElementsByTagName ("size")
-			-> get_node(1) -> getAttribute("additive");
-		if ((! defined $plus) || ($plus eq "false")) {
-			return 0;
-		}
-	}
-	if ($size) {
-		my $byte = int $size;
-		my $unit = $node -> getElementsByTagName ("size")
-			-> get_node(1) -> getAttribute("unit");
-		if ((! $unit) || ($unit eq "M")) {
-			# no unit or M specified, turn into Bytes...
-			return $byte * 1024 * 1024;
-		} elsif ($unit eq "G") {
-			# unit G specified, turn into Bytes...
-			return $byte * 1024 * 1024 * 1024;
-		}
-	} else {
-		return 0;
-	}
-}
-
-#==========================================
-# getImageSizeBytes
-#------------------------------------------
-sub getImageSizeBytes {
-	# ...
-	# Get the predefined size of the logical extend
-	# as byte value
-	# ---
-	my $this = shift;
-	my $node = $this->{typeNode};
-	my $size = $node -> getElementsByTagName ("size");
-	if ($size) {
-		my $byte = int $size;
-		my $plus = $node -> getElementsByTagName ("size")
-			-> get_node(1) -> getAttribute("additive");
-		if ((! defined $plus) || ($plus eq "false") || ($plus eq "0")) {
-			# /.../
-			# the fixed size value was set, we will use this value
-			# and return a byte number
-			# ----
-			my $unit = $node -> getElementsByTagName ("size")
-				-> get_node(1) -> getAttribute("unit");
-			if ((! $unit) || ($unit eq "M")) {
-				# no unit or M specified, turn into Bytes...
-				return $byte * 1024 * 1024;
-			} elsif ($unit eq "G") {
-				# unit G specified, turn into Bytes...
-				return $byte * 1024 * 1024 * 1024;
-			}
-		} else {
-			# /.../
-			# the size is setup as additive value to the required
-			# size. The real size is calculated later and the additive
-			# value is added at that point
-			# ---
-			return "auto";
-		}
-	} else {
-		return "auto";
-	}
-}
 
 #==========================================
 # getImageVersion
@@ -5532,7 +5425,7 @@ sub getImageConfig_legacy {
 	my %type  = %{$this->getImageTypeAndAttributes_legacy()};
 	my @delp  = $this -> getDeleteList_legacy();
 	my $iver  = $this -> getImageVersion();
-	my $size  = $this -> getImageSize();
+	my $size  = $this -> getImageSize_legacy();
 	my $name  = $this -> getImageName();
 	my $dname = $this -> getImageDisplayName ($this);
 	my $lics  = $this -> getLicenseNames_legacy();
@@ -5861,6 +5754,119 @@ sub getImageDefaultRoot_legacy {
 		return;
 	}
 	return "$root";
+}
+#==========================================
+# getImageSize_legacy
+#------------------------------------------
+sub getImageSize_legacy {
+	# ...
+	# Get the predefined size of the logical extend
+	# ---
+	my $this = shift;
+	my $node = $this->{typeNode};
+	my $size = $node -> getElementsByTagName ("size");
+	if ($size) {
+		my $plus = $node -> getElementsByTagName ("size")
+			-> get_node(1) -> getAttribute("additive");
+		if ((! defined $plus) || ($plus eq "false")) {
+			my $unit = $node -> getElementsByTagName ("size")
+				-> get_node(1) -> getAttribute("unit");
+			if (! $unit) {
+				# no unit specified assume MB...
+				$unit = "M";
+			}
+			# /.../
+			# the fixed size value was set, we will use this value
+			# connected with the unit string
+			# ----
+			return $size.$unit;
+		} else {
+			# /.../
+			# the size is setup as additive value to the required
+			# size. The real size is calculated later and the additive
+			# value is added at that point
+			# ---
+			return "auto";
+		}
+	} else {
+		return "auto";
+	}
+}
+
+#==========================================
+# getImageSizeAdditiveBytes_legacy
+#------------------------------------------
+sub getImageSizeAdditiveBytes_legacy {
+	# ...
+	# Get the predefined size if the attribute additive
+	# was set to true
+	# ---
+	my $this = shift;
+	my $node = $this->{typeNode};
+	my $size = $node -> getElementsByTagName ("size");
+	if ($size) {
+		my $plus = $node -> getElementsByTagName ("size")
+			-> get_node(1) -> getAttribute("additive");
+		if ((! defined $plus) || ($plus eq "false")) {
+			return 0;
+		}
+	}
+	if ($size) {
+		my $byte = int $size;
+		my $unit = $node -> getElementsByTagName ("size")
+			-> get_node(1) -> getAttribute("unit");
+		if ((! $unit) || ($unit eq "M")) {
+			# no unit or M specified, turn into Bytes...
+			return $byte * 1024 * 1024;
+		} elsif ($unit eq "G") {
+			# unit G specified, turn into Bytes...
+			return $byte * 1024 * 1024 * 1024;
+		}
+	} else {
+		return 0;
+	}
+}
+
+#==========================================
+# getImageSizeBytes_legacy
+#------------------------------------------
+sub getImageSizeBytes_legacy {
+	# ...
+	# Get the predefined size of the logical extend
+	# as byte value
+	# ---
+	my $this = shift;
+	my $node = $this->{typeNode};
+	my $size = $node -> getElementsByTagName ("size");
+	if ($size) {
+		my $byte = int $size;
+		my $plus = $node -> getElementsByTagName ("size")
+			-> get_node(1) -> getAttribute("additive");
+		if ((! defined $plus) || ($plus eq "false") || ($plus eq "0")) {
+			# /.../
+			# the fixed size value was set, we will use this value
+			# and return a byte number
+			# ----
+			my $unit = $node -> getElementsByTagName ("size")
+				-> get_node(1) -> getAttribute("unit");
+			if ((! $unit) || ($unit eq "M")) {
+				# no unit or M specified, turn into Bytes...
+				return $byte * 1024 * 1024;
+			} elsif ($unit eq "G") {
+				# unit G specified, turn into Bytes...
+				return $byte * 1024 * 1024 * 1024;
+			}
+		} else {
+			# /.../
+			# the size is setup as additive value to the required
+			# size. The real size is calculated later and the additive
+			# value is added at that point
+			# ---
+			return "auto";
+		}
+	} else {
+		return "auto";
+	}
 }
 
 #==========================================

--- a/tests/unit/lib/Test/kiwiXML.pm
+++ b/tests/unit/lib/Test/kiwiXML.pm
@@ -19,6 +19,7 @@ use warnings;
 
 use Common::ktLog;
 use Common::ktTestCase;
+use Readonly;
 use base qw /Common::ktTestCase/;
 
 use KIWICommandLine;
@@ -42,6 +43,11 @@ use KIWIXMLSystemdiskData;
 use KIWIXMLTypeData;
 use KIWIXMLUserData;
 use KIWIXMLVMachineData;
+
+#==========================================
+# constants
+#------------------------------------------
+Readonly my $PREFSET_IMAGE_SIZE => 20;
 
 # All tests will need to be adjusted once KIWXML turns into a stateless
 # container and the ctor receives the config.xml file name as an argument.
@@ -5273,9 +5279,9 @@ sub test_getImageName {
 }
 
 #==========================================
-# test_getImageSize
+# test_getImageSizeNotAdditive_legacy
 #------------------------------------------
-sub test_getImageSizeNotAdditive {
+sub test_getImageSizeNotAdditive_legacy {
 	# ...
 	# Verify proper return of getImageSize method
 	# ---
@@ -5285,7 +5291,7 @@ sub test_getImageSizeNotAdditive {
 	my $xml = KIWIXML -> new(
 		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
 	);
-	my $value = $xml -> getImageSize();
+	my $value = $xml -> getImageSize_legacy();
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
@@ -5298,9 +5304,9 @@ sub test_getImageSizeNotAdditive {
 }
 
 #==========================================
-# test_getImageSizeAdditiveBytes
+# test_getImageSizeAdditiveBytesNotAdditive_legacy
 #------------------------------------------
-sub test_getImageSizeAdditiveBytesNotAdditive {
+sub test_getImageSizeAdditiveBytesNotAdditive_legacy {
 	# ...
 	# Verify proper return of getImageSizeAdditiveBytes method
 	# ---
@@ -5310,7 +5316,7 @@ sub test_getImageSizeAdditiveBytesNotAdditive {
 	my $xml = KIWIXML -> new(
 		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
 	);
-	my $value = $xml -> getImageSizeAdditiveBytes();
+	my $value = $xml -> getImageSizeAdditiveBytes_legacy();
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
@@ -5323,9 +5329,9 @@ sub test_getImageSizeAdditiveBytesNotAdditive {
 }
 
 #==========================================
-# test_getImageSizeBytes
+# test_getImageSizeBytesNotAdditive_legacy
 #------------------------------------------
-sub test_getImageSizeBytesNotAdditive {
+sub test_getImageSizeBytesNotAdditive_legacy {
 	# ...
 	# Verify proper return of getImageSizeBytes method
 	# ---
@@ -5335,7 +5341,7 @@ sub test_getImageSizeBytesNotAdditive {
 	my $xml = KIWIXML -> new(
 		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
 	);
-	my $value = $xml -> getImageSizeBytes();
+	my $value = $xml -> getImageSizeBytes_legacy();
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
@@ -9637,6 +9643,35 @@ sub test_setSelectionProfileNamesNoArg {
 	# Test this condition last to get potential error messages
 	my @expectedProf = ('profB');
 	$this -> assert_array_equal(\@expectedProf, $profNames);
+	return;
+}
+
+#==========================================
+# test_sizeHandling
+#------------------------------------------
+sub test_sizeHandling {
+	# ...
+	# Verify that size is properly handled
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDir = $this->{dataDir} . 'preferenceSettings';
+	my $xml = KIWIXML -> new(
+		$this -> {kiwi}, $confDir, undef, undef,$this->{cmdL}
+	);
+	my $typeObj = $xml -> getImageType();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	my $size = $typeObj -> getSize();
+	$this -> assert_equals($PREFSET_IMAGE_SIZE, $size);
+	my $unit = $typeObj -> getSizeUnit();
+	$this -> assert_str_equals('G', $unit);
+	my $add = $typeObj -> isSizeAdditive();
+	$this -> assert_str_equals('false', $add);
 	return;
 }
 


### PR DESCRIPTION
- implement handling of additive and unit attributes of the <size>
  element in the imageConfig data structure and the XMLTypeData class
  - rename the following methods of the XML class
    - getImageSize               => getImageSize_legacy
    - getImageSizeAdditiveBytes  => getImageSizeAdditiveBytes_legacy
    - getImageSizeBytes          => getImageSizeBytes_legacy
