### PR TITLE
mktemp(1) templates do not hardcode /tmp

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -194,14 +194,14 @@ sub new {
 	#==========================================
 	# create tmp dir for operations
 	#------------------------------------------
-	$tmpdir = qxx ("mktemp -q -d /tmp/kiwiboot.XXXXXX"); chomp $tmpdir;
+	$tmpdir = qxx ("mktemp -qdt kiwiboot.XXXXXX"); chomp $tmpdir;
 	$result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> error  ("Couldn't create tmp dir: $tmpdir: $!");
 		$kiwi -> failed ();
 		return;
 	}
-	$loopdir = qxx ("mktemp -q -d /tmp/kiwiloop.XXXXXX"); chomp $loopdir;
+	$loopdir = qxx ("mktemp -qdt kiwiloop.XXXXXX"); chomp $loopdir;
 	$result  = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> error  ("Couldn't create tmp dir: $loopdir: $!");
@@ -1115,7 +1115,7 @@ sub setupInstallStick {
 	#==========================================
 	# create tmp directory
 	#------------------------------------------
-	$tmpdir = qxx ( "mktemp -q -d /tmp/kiwistickinst.XXXXXX" ); chomp $tmpdir;
+	$tmpdir = qxx ( "mktemp -qdt kiwistickinst.XXXXXX" ); chomp $tmpdir;
 	$result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> error  ("Couldn't create tmp dir: $tmpdir: $!");
@@ -2746,7 +2746,7 @@ sub setupInstallFlags {
 	my $xml    = $this->{xml};
 	my $zipper = $this->{gdata}->{Gzip};
 	my $newird;
-	my $irddir = qxx ("mktemp -q -d /tmp/kiwiird.XXXXXX"); chomp $irddir;
+	my $irddir = qxx ("mktemp -qdt kiwiird.XXXXXX"); chomp $irddir;
 	my $result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> failed ();
@@ -2876,7 +2876,7 @@ sub setupBootFlags {
 	my $initrd = $this->{initrd};
 	my $zipper = $this->{gdata}->{Gzip};
 	my $newird;
-	my $irddir = qxx ("mktemp -q -d /tmp/kiwiird.XXXXXX"); chomp $irddir;
+	my $irddir = qxx ("mktemp -qdt kiwiird.XXXXXX"); chomp $irddir;
 	my $result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> error  ("Couldn't create tmp dir: $irddir: $!");

--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -4618,7 +4618,7 @@ sub checkKernel {
 	# fix kernel inconsistency:
 	#------------------------------------------
 	$kiwi -> info ("Fixing kernel inconsistency...");
-	$tmpdir = qxx ("mktemp -q -d /tmp/kiwi-fixboot.XXXXXX"); chomp $tmpdir;
+	$tmpdir = qxx ("mktemp -qdt kiwi-fixboot.XXXXXX"); chomp $tmpdir;
 	$result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> failed ();

--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -176,7 +176,7 @@ sub new {
 	#==========================================
 	# create tmp files/directories 
 	#------------------------------------------
-	$sort = qxx ("mktemp /tmp/kiso-sort-XXXXXX 2>&1"); chomp $sort;
+	$sort = qxx ("mktemp -t kiso-sort-XXXXXX 2>&1"); chomp $sort;
 	$code = $? >> 8;
 	if ($code != 0) {
 		$kiwi -> error  ("Couldn't create sort file: $sort: $!");
@@ -184,7 +184,7 @@ sub new {
 		$this -> cleanISO();
 		return;
 	}
-	$ldir = qxx ("mktemp -q -d /tmp/kiso-loader-XXXXXX 2>&1"); chomp $ldir;
+	$ldir = qxx ("mktemp -qdt kiso-loader-XXXXXX 2>&1"); chomp $ldir;
 	$code = $? >> 8;
 	if ($code != 0) {
 		$kiwi -> error  ("Couldn't create tmp directory: $ldir: $!");

--- a/modules/KIWILocator.pm
+++ b/modules/KIWILocator.pm
@@ -71,7 +71,7 @@ sub createTmpDirectory {
 	my $forceRoot = $cmdL -> getForceNewRoot();
 	if (! defined $useRoot) {
 		if (! defined $selfRoot) {
-			$root = qxx (" mktemp -q -d /tmp/kiwi.XXXXXX ");
+			$root = qxx ("mktemp -qdt kiwi.XXXXXX");
 			$code = $? >> 8;
 			if ($code == 0) {
 				$rootError = 0;

--- a/modules/KIWILog.pm
+++ b/modules/KIWILog.pm
@@ -1047,13 +1047,13 @@ sub writeXMLDiff {
 		return;
 	}
 	qxxLogOff();
-	my $used = qxx ("mktemp -q /tmp/kiwi-xmlused.XXXXXX"); chomp $used;
+	my $used = qxx ("mktemp -qt kiwi-xmlused.XXXXXX"); chomp $used;
 	my $code = $? >> 8;
 	if ($code != 0) {
 		qxxLogOn();
 		return;
 	}
-	my $orig = qxx ("mktemp -q /tmp/kiwi-xmlorig.XXXXXX"); chomp $orig;
+	my $orig = qxx ("mktemp -qt kiwi-xmlorig.XXXXXX"); chomp $orig;
 	if ($code != 0) {
 		qxxLogOn();
 		return;

--- a/modules/KIWIMigrate.pm
+++ b/modules/KIWIMigrate.pm
@@ -96,7 +96,7 @@ sub new {
 		qxx ("rm -rf $dest");
 	}
 	if (! defined $dest) {
-		$dest = qxx (" mktemp -q -d /tmp/kiwi-migrate.XXXXXX ");
+		$dest = qxx ("mktemp -qdt kiwi-migrate.XXXXXX");
 		$code = $? >> 8;
 		if ($code != 0) {
 			$kiwi -> failed ();
@@ -691,7 +691,7 @@ sub getRepos {
 						$kiwi -> skipped ();
 						next;
 					}
-					my $mpoint = qxx ("mktemp -q -d /tmp/kiwimpoint.XXXXXX");
+					my $mpoint = qxx ("mktemp -qdt kiwimpoint.XXXXXX");
 					my $result = $? >> 8;
 					if ($result != 0) {
 						$kiwi -> warning ("DVD tmpdir failed: $mpoint: $!");
@@ -720,7 +720,7 @@ sub getRepos {
 						$kiwi -> skipped ();
 						next;
 					}
-					my $mpoint = qxx ("mktemp -q -d /tmp/kiwimpoint.XXXXXX");
+					my $mpoint = qxx ("mktemp -qdt kiwimpoint.XXXXXX");
 					my $result = $? >> 8;
 					if ($result != 0) {
 						$kiwi -> warning ("ISO tmpdir failed: $mpoint: $!");

--- a/modules/KIWIOverlay.pm
+++ b/modules/KIWIOverlay.pm
@@ -144,7 +144,7 @@ sub unionOverlay {
 	#==========================================
 	# Create tmpdir for mount point
 	#------------------------------------------
-	$tmpdir = qxx ("mktemp -q -d /tmp/kiwiRootOverlay.XXXXXX"); chomp $tmpdir;
+	$tmpdir = qxx ("mktemp -qdt kiwiRootOverlay.XXXXXX"); chomp $tmpdir;
 	$result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> failed ();

--- a/modules/KIWIURL.pm
+++ b/modules/KIWIURL.pm
@@ -390,7 +390,7 @@ sub smbPath {
 	if (! defined $root) {
 		return $tmpdir;
 	}
-	$tmpdir = qxx ("mktemp -q -d /tmp/kiwimount.XXXXXX"); chomp $tmpdir;
+	$tmpdir = qxx ("mktemp -qdt kiwimount.XXXXXX"); chomp $tmpdir;
 	$result = $? >> 8;
 	if ($result != 0) {
 		$kiwi -> warning ("Couldn't create tmp dir for smb mount: $tmpdir: $!");

--- a/modules/KIWIXMLInfo.pm
+++ b/modules/KIWIXMLInfo.pm
@@ -135,7 +135,7 @@ sub printXMLInfo {
 	if (! $infoRequests) {
 		return;
 	}
-	my $outfile = qxx ("mktemp -q /tmp/kiwi-xmlinfo-XXXXXX 2>&1");
+	my $outfile = qxx ("mktemp -qt kiwi-xmlinfo-XXXXXX 2>&1");
 	my $code = $? >> 8; chomp $outfile;
 	if ($code != 0) {
 		$kiwi -> error  ("Couldn't create tmp file: $outfile: $!");


### PR DESCRIPTION
mktemp -t uses $TMPDIR, falls back to /tmp.

buyer beware: i have tested mktemp(1) behavior in isolation; i have _not_ run kiwi with this change.
