### PR TITLE
Consistency cleanup

### DIFF
--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -26,7 +26,7 @@ db:info [
 	db:releaseinfo [
 		"$Id: kiwi.rnc 2957 2008-01-11 12:53:39Z thomas-schraitle $"
 	]
-	db:releaseinfo [ "RNC Schema Version 5.5" ]
+	db:releaseinfo [ "RNC Schema Version 5.6" ]
 	db:pubdate [ "START" ]
 	db:pubdate [ "2008-01-08" ]
 ]
@@ -60,7 +60,7 @@ div {
 		attribute xsi:schemaLocation { xsd:anyURI }
 	k.image.schemaversion.attribute =
 		## The allowed Schema version (fixed value)
-		attribute schemaversion { "5.5" }
+		attribute schemaversion { "5.6" }
 	k.image.kiwirevision.attribute =
 		## A kiwi git revision number which is known to build
 		## a working image from this description. If the kiwi git
@@ -142,7 +142,7 @@ k.path.attribute        =
 k.profiles.attribute    =
 	## A profile name which binds the section to this name
 	attribute profiles { text }
-k.pwd.attribute         =
+k.password.attribute    =
 	## The password
 	attribute pwd { text }
 k.script.attribute      =
@@ -386,22 +386,21 @@ div {
 # common element <instrepo>
 #
 div {
-	#k.instrepo.name.attribute = k.id.attribute
+	k.instrepo.local.attribute =
+		attribute local { xsd:boolean }
 	k.instrepo.name.attribute = 
 		attribute name { xsd:ID }
+	k.instrepo.password.attribute = k.password.attribute
 	k.instrepo.priority.attribute =
 		## Search priority for packages in this repo
 		attribute priority { text }
 	k.instrepo.username.attribute = k.username.attribute
-	k.instrepo.pwd.attribute = k.pwd.attribute
-	k.instrepo.local.attribute =
-		attribute local { xsd:boolean }
 	k.instrepo.attlist =
+		k.instrepo.local.attribute? &
 		k.instrepo.name.attribute &
+		k.instrepo.password.attribute? &
 		k.instrepo.priority.attribute &
-		k.instrepo.username.attribute? &
-		k.instrepo.pwd.attribute? &
-		k.instrepo.local.attribute?
+		k.instrepo.username.attribute?
 	k.instrepo =
 		## Name of a Installation Repository
 		[
@@ -858,11 +857,11 @@ div {
 	k.repository.password.attribute =
 		## Channel password if required. It depends on the url type
 		## whether and how this information is passed
-		attribute password { text }
+		k.password.attribute
 	k.repository.username.attribute =
 		## Channel username if required. It depends on the url type
 		## whether and how this information is passed
-		attribute username { text }
+		k.username.attribute
 	k.repository.attlist =
 		k.repository.type.attribute &
 		k.repository.profiles.attribute? &
@@ -1823,7 +1822,7 @@ div {
 	k.user.realname.attribute =
 		## The name of an user
 		attribute realname { text }
-	k.user.pwd.attribute = k.pwd.attribute
+	k.user.pwd.attribute = k.password.attribute
 	k.user.pwdformat =
 		## Format of the given password, encrypted is the default
 		attribute pwdformat { "encrypted" | "plain" }

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -23,7 +23,7 @@
 <grammar xmlns:db="http://docbook.org/ns/docbook" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <db:info>
     <db:releaseinfo>$Id: kiwi.rnc 2957 2008-01-11 12:53:39Z thomas-schraitle $</db:releaseinfo>
-    <db:releaseinfo>RNC Schema Version 5.5</db:releaseinfo>
+    <db:releaseinfo>RNC Schema Version 5.6</db:releaseinfo>
     <db:pubdate>START</db:pubdate>
     <db:pubdate>2008-01-08</db:pubdate>
   </db:info>
@@ -91,7 +91,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>5.5</value>
+        <value>5.6</value>
       </attribute>
     </define>
     <define name="k.image.kiwirevision.attribute">
@@ -238,7 +238,7 @@ for isolinux and grub</a:documentation>
       <a:documentation>A profile name which binds the section to this name</a:documentation>
     </attribute>
   </define>
-  <define name="k.pwd.attribute">
+  <define name="k.password.attribute">
     <attribute name="pwd">
       <a:documentation>The password</a:documentation>
     </attribute>
@@ -564,11 +564,18 @@ specifies where the boot image (initrd) can be found.</db:para>
     
   -->
   <div>
-    <!-- k.instrepo.name.attribute = k.id.attribute -->
+    <define name="k.instrepo.local.attribute">
+      <attribute name="local">
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.instrepo.name.attribute">
       <attribute name="name">
         <data type="ID"/>
       </attribute>
+    </define>
+    <define name="k.instrepo.password.attribute">
+      <ref name="k.password.attribute"/>
     </define>
     <define name="k.instrepo.priority.attribute">
       <attribute name="priority">
@@ -578,26 +585,18 @@ specifies where the boot image (initrd) can be found.</db:para>
     <define name="k.instrepo.username.attribute">
       <ref name="k.username.attribute"/>
     </define>
-    <define name="k.instrepo.pwd.attribute">
-      <ref name="k.pwd.attribute"/>
-    </define>
-    <define name="k.instrepo.local.attribute">
-      <attribute name="local">
-        <data type="boolean"/>
-      </attribute>
-    </define>
     <define name="k.instrepo.attlist">
       <interleave>
+        <optional>
+          <ref name="k.instrepo.local.attribute"/>
+        </optional>
         <ref name="k.instrepo.name.attribute"/>
+        <optional>
+          <ref name="k.instrepo.password.attribute"/>
+        </optional>
         <ref name="k.instrepo.priority.attribute"/>
         <optional>
           <ref name="k.instrepo.username.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.instrepo.pwd.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.instrepo.local.attribute"/>
         </optional>
       </interleave>
     </define>
@@ -1266,16 +1265,16 @@ priority is used</a:documentation>
       </attribute>
     </define>
     <define name="k.repository.password.attribute">
-      <attribute name="password">
+      <ref name="k.password.attribute">
         <a:documentation>Channel password if required. It depends on the url type
 whether and how this information is passed</a:documentation>
-      </attribute>
+      </ref>
     </define>
     <define name="k.repository.username.attribute">
-      <attribute name="username">
+      <ref name="k.username.attribute">
         <a:documentation>Channel username if required. It depends on the url type
 whether and how this information is passed</a:documentation>
-      </attribute>
+      </ref>
     </define>
     <define name="k.repository.attlist">
       <interleave>
@@ -2573,7 +2572,7 @@ compressed filesystem.</db:para>
       </attribute>
     </define>
     <define name="k.user.pwd.attribute">
-      <ref name="k.pwd.attribute"/>
+      <ref name="k.password.attribute"/>
     </define>
     <define name="k.user.pwdformat">
       <attribute name="pwdformat">

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -3817,7 +3817,7 @@ sub getInstSourceRepository {
 		my $prio = $element -> getAttribute("priority");
 		my $name = $element -> getAttribute("name");
 		my $user = $element -> getAttribute("username");
-		my $pwd  = $element -> getAttribute("pwd");
+		my $pwd  = $element -> getAttribute("password");
 		my $islocal  = $element -> getAttribute("local");
 		my $stag = $element -> getElementsByTagName ("source") -> get_node(1);
 		my $source = $this -> __resolveLink ( $stag -> getAttribute ("path") );

--- a/tests/unit/data/kiwiImageCreator/prepareNoRoot/config.xml
+++ b/tests/unit/data/kiwiImageCreator/prepareNoRoot/config.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="5.2" name="test-imagecreate-prepare">
+<image schemaversion="5.6" name="test-imagecreate-prepare">
 	<description type="system">
 		<author>Robert Schweikert</author>
-		<contact>rschweikert@novell.com</contact>
+		<contact>rjschwei@suse.com</contact>
 		<specification>test case for the ImageCreator prepare</specification>
 	</description>
 	<preferences>
-		<type image="iso" boot="isoboot/suse-11.4"/>
+		<type image="iso" boot="isoboot/suse-12.2"/>
 		<packagemanager>zypper</packagemanager>
 		<rpm-check-signatures>false</rpm-check-signatures>
 		<rpm-force>true</rpm-force>

--- a/xsl/convert55to56.xsl
+++ b/xsl/convert55to56.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+	indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*|processing-instruction()|comment()" mode="conv55to56">
+	<xsl:copy>
+		<xsl:copy-of select="@*"/>
+		<xsl:apply-templates mode="conv55to56"/>
+	</xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+	Changed attribute <tag class="attribute">schemaversion</tag>
+	to <tag class="attribute">schemaversion</tag> from
+	<literal>5.5</literal> to <literal>5.6</literal>.
+</para>
+<xsl:template match="image" mode="conv55to56">
+	<xsl:choose>
+		<!-- nothing to do if already at 5.6 -->
+		<xsl:when test="@schemaversion > 5.5">
+			<xsl:copy-of select="/"/>
+		</xsl:when>
+		<!-- otherwise apply templates -->
+		<xsl:otherwise>
+			<image schemaversion="5.6">
+				<xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+				<xsl:apply-templates  mode="conv55to56"/>
+			</image>
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<!-- transform the pwd attribute of the instrepo element to password -->
+<xsl:template match="instsource/instrepo" mode="conv55to56">
+	<instrepo>
+		<xsl:choose>
+			<xsl:when test="@pwd">
+				<xsl:attribute name="password">
+					<xsl:value-of select="@pwd"/>
+				</xsl:attribute>
+			</xsl:when>
+		</xsl:choose>
+		<xsl:copy-of select="@*[not(local-name(.) = 'pwd')]"/>
+		  <xsl:apply-templates mode="conv55to56"/>
+	</instrepo>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/master.xsl
+++ b/xsl/master.xsl
@@ -26,6 +26,7 @@
 <xsl:import href="convert52to53.xsl"/>
 <xsl:import href="convert53to54.xsl"/>
 <xsl:import href="convert54to55.xsl"/>
+<xsl:import href="convert55to56.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -116,8 +117,12 @@
 		<xsl:apply-templates select="exslt:node-set($v54)" mode="conv54to55"/>
 	</xsl:variable>
 
+	<xsl:variable name="v56">
+		<xsl:apply-templates select="exslt:node-set($v55)" mode="conv55to56"/>
+	</xsl:variable>
+
 	<xsl:apply-templates
-		select="exslt:node-set($v55)" mode="pretty"
+		select="exslt:node-set($v56)" mode="pretty"
 	/>
 </xsl:template>
 


### PR DESCRIPTION
As I started looking at the <instsource> implementation for the new data structure I noticed the inconsistency of the name of the attribute to provide a password, between the <instrepo> and <repository> elements. This addresses this inconsistency by renaming the attribute of the <instrepo> element to password.
