### PR TITLE
I always fall into this trap, grmbl....

### DIFF
--- a/modules/KIWIXMLVMachineData.pm
+++ b/modules/KIWIXMLVMachineData.pm
@@ -650,7 +650,7 @@ sub setDVDID {
 	# ---
 	my $this = shift;
 	my $id   = shift;
-	if (! $id ) {
+	if (! defined $id ) {
 		my $kiwi = $this->{kiwi};
 		my $msg = 'setDVDID: no ID data provided, retaining current data.';
 		$kiwi -> error($msg);
@@ -1148,7 +1148,7 @@ sub setSystemDiskID {
 	# ---
 	my $this   = shift;
 	my $id = shift;
-	if (! $id ) {
+	if (! defined $id ) {
 		my $kiwi = $this->{kiwi};
 		my $msg = 'setSystemDiskID: no value provided, retaining '
 			. 'current data.';
@@ -1420,7 +1420,7 @@ sub __isDVDInitValid {
 		$kiwi -> failed();
 		return;
 	}
-	if (! $dvd->{id} ) {
+	if (! defined $dvd->{id} ) {
 		my $msg = 'Initialization data for vmdvd incomplete, must '
 			. 'provide "id" key-value pair.';
 		$kiwi -> error($msg);

--- a/tests/unit/lib/Test/kiwiXMLVMachineData.pm
+++ b/tests/unit/lib/Test/kiwiXMLVMachineData.pm
@@ -981,7 +981,7 @@ sub test_getDVDID {
 	$this -> assert_str_equals('none', $msgT);
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
-	$this -> assert_str_equals('2', $id);
+	$this -> assert_str_equals('0', $id);
 	return;
 }
 
@@ -1656,7 +1656,7 @@ sub test_getXMLElement{
 		. '<vmconfig-entry>foo=bar</vmconfig-entry>'
 		. '<vmconfig-entry>cd=none</vmconfig-entry>'
 		. '<vmdisk controller="scsi" device="sda" disktype="hdd" id="1"/>'
-		. '<vmdvd controller="ide" id="2"/>'
+		. '<vmdvd controller="ide" id="0"/>'
 		. '<vmnic interface="eth0" driver="e1000" mac="FE:C0:B1:96:64:AC"/>'
 		. '<vmnic interface="eth1" driver="r8169" mac="FE:C0:B1:96:64:AD" '
 		. 'mode="bridge"/>'
@@ -1960,7 +1960,7 @@ sub test_setDVDIDNoArg {
 	$this -> assert_str_equals('none', $msgT);
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
-	$this -> assert_str_equals('2', $id);
+	$this -> assert_str_equals('0', $id);
 	return;
 }
 
@@ -3373,7 +3373,7 @@ sub __getVMachineObj {
 	my %disks = ( system => \%diskData );
 	my %dvd = (
 		controller => 'ide',
-		id         => '2'
+		id         => '0'
 	);
 	my %nicData1 = (
 		driver    => 'e1000',


### PR DESCRIPTION
- allow the id for a vmdisk and vmdvd to be 0
  - trapped again by Perl's a string with zero ("0") is false
