### PR TITLE
6b637e8c9 for 5.03

### DIFF
--- a/modules/KIWIRoot.pm
+++ b/modules/KIWIRoot.pm
@@ -138,6 +138,7 @@ sub new {
 		if (! $channel) {
 			$channel = $publics_url;
 			$channel =~ s/\//_/g;
+			$channel =~ s/_\$//g;
 			$channel =~ s/^_//;
 			$channel =~ s/_$//;
 		}


### PR DESCRIPTION
- fix the automatic alias generation to remove '$' from the
  name, this allows users to use SMT repos without having to
  specify an alias in the config.xml file
  (cherry picked from commit 6b637e8c9fc3b95a36ae3fe8d9787286cf123bad)
