### PR TITLE
A _legacy method bites the dust

### DIFF
--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -7879,45 +7879,6 @@ sub getURLHash_legacy {
 }
 
 #==========================================
-# getUsers_legacy
-#------------------------------------------
-sub getUsers_legacy {
-	# ...
-	# Receive a list of users to be added into the image
-	# the user specification contains an optional password
-	# and group. If the group doesn't exist it will be created
-	# ---
-	my $this   = shift;
-	my %result = ();
-	my @node   = $this->{usrdataNodeList} -> get_nodelist();
-	foreach my $element (@node) {
-		my $group = $element -> getAttribute("group");
-		my $gid   = $element -> getAttribute("id");
-		my @ntag  = $element -> getElementsByTagName ("user");
-		foreach my $element (@ntag) {
-			my $name = $element -> getAttribute ("name");
-			my $uid  = $element -> getAttribute ("id");
-			my $pwd  = $element -> getAttribute ("password");
-			my $pwdformat = $element -> getAttribute ("pwdformat");
-			my $home = $element -> getAttribute ("home");
-			my $realname = $element -> getAttribute ("realname");
-			my $shell = $element -> getAttribute ("shell");
-			if (defined $name) {
-				$result{$name}{group} = $group;
-				$result{$name}{gid}   = $gid;
-				$result{$name}{uid}   = $uid;
-				$result{$name}{home}  = $home;
-				$result{$name}{pwd}   = $pwd;
-				$result{$name}{pwdformat}= $pwdformat;
-				$result{$name}{realname} = $realname;
-				$result{$name}{shell} = $shell;
-			}
-		}
-	}
-	return %result;
-}
-
-#==========================================
 # getVMwareConfig_legacy
 #------------------------------------------
 sub getVMwareConfig_legacy {

--- a/modules/KIWIXMLValidator.pm
+++ b/modules/KIWIXMLValidator.pm
@@ -345,7 +345,7 @@ sub __checkEC2IsFsysType {
 	my $this = shift;
 	# TODO:
 	# Excluding btrfs and xfs, needs testing first. There are potentisl issues
-	# with both file systems as they require a boot partiotion and our current
+	# with both file systems as they require a boot partition and our current
 	# setup for EC2 is to not have a boot partition.
 	# Excluding clicfs and squashfs, they appear to be impractical for EC2,
 	# can be enabled if someone complains

--- a/tests/unit/lib/Test/kiwiXML.pm
+++ b/tests/unit/lib/Test/kiwiXML.pm
@@ -8727,48 +8727,6 @@ sub test_getUsers {
 }
 
 #==========================================
-# test_getUsers_legacy
-#------------------------------------------
-sub test_getUsers_legacy {
-	# ...
-	# Verify proper return of user information
-	# ---
-	my $this = shift;
-	my $kiwi = $this -> {kiwi};
-	my $confDir = $this->{dataDir} . 'userConfig';
-	my $xml = KIWIXML -> new(
-		$confDir, undef, undef,$this->{cmdL}
-	);
-	my %usrData = $xml -> getUsers_legacy();
-	my $msg = $kiwi -> getMessage();
-	$this -> assert_str_equals('No messages set', $msg);
-	my $msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('none', $msgT);
-	my $state = $kiwi -> getState();
-	$this -> assert_str_equals('No state set', $state);
-	# Test these conditions last to get potential error messages
-	my @expectedUsers = qw /root auser buser/;
-	my @users = keys %usrData;
-	$this -> assert_array_equal(\@expectedUsers, \@users);
-	# Do not check any values for the auser. There is a bug in the legacy
-	# code that will overwrite existing user data if a user that is defined
-	# in 2 groups. Fixed in the new code, will not fix the legacy
-	# implementation
-	#$this -> assert_str_equals('2000', $usrData{auser}{gid});
-	$this -> assert_str_equals('2000', $usrData{buser}{gid});
-	#$this -> assert_str_equals('mygrp', $usrData{auser}{group});
-	$this -> assert_str_equals('mygrp', $usrData{buser}{group});
-	$this -> assert_str_equals('root', $usrData{root}{group});
-	#$this -> assert_str_equals('2001', $usrData{auser}{uid});
-	$this -> assert_str_equals('/root', $usrData{root}{home});
-	$this -> assert_str_equals('linux', $usrData{buser}{pwd});
-	$this -> assert_str_equals('plain', $usrData{buser}{pwdformat});
-	$this -> assert_str_equals('Bert', $usrData{buser}{realname});
-	#$this -> assert_str_equals('/bin/ksh', $usrData{auser}{shell});
-	return;
-}
-
-#==========================================
 # test_getVMachineConfigOVF
 #------------------------------------------
 sub test_getVMachineConfigOVF {


### PR DESCRIPTION
This was as easy as I had hoped. I think I will try to follow this approach, i.e. pick one _legacy method to eliminate and chase it throughout the code. This implies that for some methods a lot of files may change. However, as everything is focused on one particular change the patch itself should still be reasonably coherent.
