### PR TITLE
- fix the message for KW argument hash presence

### DIFF
--- a/modules/KIWIXMLDataBase.pm
+++ b/modules/KIWIXMLDataBase.pm
@@ -243,7 +243,7 @@ sub __isInitHashRef {
 	my $init = shift;
 	if ($init && ref($init) ne 'HASH') {
 		my $kiwi = $this->{kiwi};
-		my $msg = 'Expecting a hash ref as second argument if provided';
+		my $msg = 'Expecting a hash ref as first argument if provided';
 		$kiwi -> error($msg);
 		$kiwi -> failed();
 		return;

--- a/tests/unit/lib/Test/kiwiXMLEC2ConfigData.pm
+++ b/tests/unit/lib/Test/kiwiXMLEC2ConfigData.pm
@@ -68,7 +68,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $confDataObj = KIWIXMLEC2ConfigData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLFileData.pm
+++ b/tests/unit/lib/Test/kiwiXMLFileData.pm
@@ -46,7 +46,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $fileDataObj = KIWIXMLFileData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLInstRepositoryData.pm
+++ b/tests/unit/lib/Test/kiwiXMLInstRepositoryData.pm
@@ -212,7 +212,7 @@ sub test_ctor_invalidArg {
 	my $kiwi = $this -> {kiwi};
 	my $repoDataObj = KIWIXMLInstRepositoryData -> new('opensuse');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLOEMConfigData.pm
+++ b/tests/unit/lib/Test/kiwiXMLOEMConfigData.pm
@@ -68,7 +68,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $confDataObj = KIWIXMLOEMConfigData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLPXEDeployConfigData.pm
+++ b/tests/unit/lib/Test/kiwiXMLPXEDeployConfigData.pm
@@ -47,7 +47,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $confDataObj = KIWIXMLPXEDeployConfigData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLPXEDeployData.pm
+++ b/tests/unit/lib/Test/kiwiXMLPXEDeployData.pm
@@ -773,7 +773,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $pxeDataObj = KIWIXMLPXEDeployData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLPreferenceData.pm
+++ b/tests/unit/lib/Test/kiwiXMLPreferenceData.pm
@@ -130,7 +130,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $prefDataObj = KIWIXMLPreferenceData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLProductArchitectureData.pm
+++ b/tests/unit/lib/Test/kiwiXMLProductArchitectureData.pm
@@ -48,7 +48,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $prodArchObj = KIWIXMLProductArchitectureData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLProductMetaChrootData.pm
+++ b/tests/unit/lib/Test/kiwiXMLProductMetaChrootData.pm
@@ -47,7 +47,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $fileDataObj = KIWIXMLProductMetaChrootData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLProductMetaFileData.pm
+++ b/tests/unit/lib/Test/kiwiXMLProductMetaFileData.pm
@@ -47,7 +47,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $fileDataObj = KIWIXMLProductMetaFileData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLProductOptionsData.pm
+++ b/tests/unit/lib/Test/kiwiXMLProductOptionsData.pm
@@ -68,7 +68,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $prodOptObj = KIWIXMLProductOptionsData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLProfileData.pm
+++ b/tests/unit/lib/Test/kiwiXMLProfileData.pm
@@ -47,7 +47,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $prefDataObj = KIWIXMLProfileData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLRepositoryData.pm
+++ b/tests/unit/lib/Test/kiwiXMLRepositoryData.pm
@@ -263,7 +263,7 @@ sub test_ctor_invalidArg {
 	my $kiwi = $this -> {kiwi};
 	my $repoDataObj = KIWIXMLRepositoryData -> new('opensuse');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLSplitData.pm
+++ b/tests/unit/lib/Test/kiwiXMLSplitData.pm
@@ -69,7 +69,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $splitDataObj = KIWIXMLSplitData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLSystemdiskData.pm
+++ b/tests/unit/lib/Test/kiwiXMLSystemdiskData.pm
@@ -466,7 +466,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $sysdDataObj = KIWIXMLSystemdiskData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLTypeData.pm
+++ b/tests/unit/lib/Test/kiwiXMLTypeData.pm
@@ -56,7 +56,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $typeDataObj = KIWIXMLTypeData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLUserData.pm
+++ b/tests/unit/lib/Test/kiwiXMLUserData.pm
@@ -47,7 +47,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $userDataObj = KIWIXMLUserData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);

--- a/tests/unit/lib/Test/kiwiXMLVMachineData.pm
+++ b/tests/unit/lib/Test/kiwiXMLVMachineData.pm
@@ -280,7 +280,7 @@ sub test_ctor_improperArg {
 	my $kiwi = $this -> {kiwi};
 	my $machDataObj = KIWIXMLVMachineData -> new('foo');
 	my $msg = $kiwi -> getMessage();
-	my $expected = 'Expecting a hash ref as second argument if provided';
+	my $expected = 'Expecting a hash ref as first argument if provided';
 	$this -> assert_str_equals($expected, $msg);
 	my $msgT = $kiwi -> getMessageType();
 	$this -> assert_str_equals('error', $msgT);


### PR DESCRIPTION
- the log facility is a singleton and is no longer passed as argument,
  thus the initialization KW hash argument is always expected as the first
  argument.
