### PR TITLE
doc generation

### DIFF
--- a/doc/genDevDoc
+++ b/doc/genDevDoc
@@ -1,0 +1,627 @@
+#!/usr/bin/perl
+#================
+# FILE          : devAPIdocGen.pl
+#----------------
+# PROJECT       : openSUSE Build-Service
+# COPYRIGHT     : (c) 20013 SUSE LLC
+#               :
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : This code generates a set of web pages that document the
+#               : modules used in kiwi. Each method is extracted from the
+#               : source code and the comment marked by
+#               : # ... and # --- is used as the documentation for the method.
+#               :
+#               : The code cross links the pages and tracks where methods
+#               : are called.
+#               :
+# STATUS        : Development
+#----------------
+
+#==========================================
+# Modules
+#------------------------------------------
+use strict;
+use warnings;
+
+use Data::Dumper;
+use FileHandle;
+use File::Slurp;
+use File::Spec;
+use List::Util qw /first/;
+use PPI;
+
+my @allModules = glob '../modules/*.pm';
+
+my %dependencyMap;
+my %duplicteName;
+my %infoTree;
+my %kiwiMethodNames;
+my %unresolvable;
+
+#==========================================
+# addMethodInfo
+#------------------------------------------
+sub addMethodInfo {
+	# ...
+	# Extract the method name and it's documentation delineated by
+	# # ... and # ---.
+	# ---
+	my $modName = shift;
+	my $content = shift;
+	my $lineNo = 0;
+	my $collectDoc;
+	my $defOnLine;
+	my $docEnd;
+	my $inMethodContext;
+	my $methodDoc = q{};
+	my $methName;
+	my $nothingCollected;
+	my %classInfo;
+#    print "DBG: working for: $modName\n";
+	for my $ln (@{$content}) {
+		$lineNo += 1;
+		if ($ln =~ /^sub\s/) {
+			my ($keyword, $name, $curly) = split / /, $ln;
+#            print "\tDBG found sub: $name\n";
+			if (! $curly) {
+				chomp $name;
+			}
+			$methName = $name;
+			if (! ($methName =~ /^new$|^instance$/)) {
+#                print "\t\tDBG: not new or instance\n";
+				if ($kiwiMethodNames{$methName}) {
+					$duplicteName{$methName} = 1;
+					$kiwiMethodNames{$methName} = 1;
+				} else {
+#                    print "\t\tDBG: add to method hash '$methName'\n";
+					$kiwiMethodNames{$methName} = $modName;
+				}
+			}
+			# Potential 1 line method
+			if ($ln =~ /}/msx) {
+#                print "\t\tDBG potential one liner\n";
+				$ln =~ s/\s//g;
+				my $curlyCnt = 0;
+				my $tok = PPI::Tokenizer->new(\$ln);
+				while ( my $t = $tok->get_token() ) {
+					if ($t eq '{') {
+						$curlyCnt += 1;
+					}
+					if ($t eq '}') {
+						$curlyCnt -= 1;
+					}
+				}
+				if ($curlyCnt == 0) {
+					my $access;
+					if ($methName =~ /^_|^__/) {
+						$access = 'private';
+					} else {
+						$access = 'public';
+					}
+					$classInfo{$access}{$methName}{description} = 'Missing';
+					$classInfo{$access}{$methName}{definedOn} = $lineNo;
+					next;
+				}
+			}
+			$inMethodContext = 1;
+			$nothingCollected = 1;
+			$defOnLine = $lineNo;
+			$docEnd = 0;
+			next;
+		}
+		my $access;
+		if ($methName && $methName =~ /^_|^__/) {
+			$access = 'private';
+		} else {
+			$access = 'public';
+		}
+		if ($inMethodContext && !$docEnd && $ln =~ /# \.\.\./) {
+#            print "\t\tDBG: collect begin; skip line\n";
+			$collectDoc = 1;
+			next;
+		}
+		if ($collectDoc && $ln =~ /# ---/) {
+#            print "\t\tDBG: collect end\n";
+			$classInfo{$access}{$methName}{description} = $methodDoc;
+			$classInfo{$access}{$methName}{definedOn} = $defOnLine;
+			$collectDoc = 0;
+			$docEnd = 1;
+			$methodDoc = q{};
+			$methName = q{};
+		}
+		if ($collectDoc) {
+#            print "\t\tDBG: collect: $ln\n";
+			$nothingCollected = 0;
+			$ln =~ s/#//;
+			$ln =~ s/\t//;
+			$methodDoc .= $ln;
+		}
+		if ($inMethodContext && $nothingCollected && $ln =~ /^}/) {
+#            print "\t\tDBG: method end no doc: $methName\n";
+			$classInfo{$access}{$methName}{description} = 'Missing';
+			$classInfo{$access}{$methName}{definedOn} = $defOnLine;
+			$nothingCollected = 1;
+			$inMethodContext = 0;
+		}
+	}
+	$infoTree{$modName} = \%classInfo;
+	return;
+}
+
+#==========================================
+# addCtorCrossReferences
+#------------------------------------------
+sub addCtorCrossReferences {
+	# ...
+	# Add cross refernces to call origins for new() and instance() calls
+	# ---
+	my $modName = shift;
+	my $content = shift;
+	my $lineNo = 0;
+	my $methName;
+LINE:
+	for my $ln (@{$content}) {
+		$lineNo += 1;
+		if ($ln =~ /^sub\s/) {
+			my ($keyword, $name, $curly) = split /\s/, $ln;
+			$methName = $name;
+			next LINE;
+		}
+		if ($ln =~ /\snew\s|>new|\snew|instance/ && $ln =~ /KIWI/) {
+			$ln =~ s/\s//g;
+			my $tok = PPI::Tokenizer->new(\$ln);
+			my $kObj;
+			while ( my $t = $tok->get_token() ) {
+				if ($t =~ /^\#/msx) {
+					next LINE;
+				}
+				if ($t =~ /^KIWI/) {
+					$kObj = $t;
+				}
+			}
+			if (! $kObj) {
+				next LINE;
+			}
+			my $origin = $modName . ':' . $methName . ':' . $lineNo;
+			if ($ln =~ /new/) {
+				if ($infoTree{$kObj}{public}{new}{called}) {
+					push @{$infoTree{$kObj}
+								->{public}
+								->{new}
+								->{called}}, $origin;
+				} else {
+					my @orig = ($origin);
+					$infoTree{$kObj}{public}{new}{called} = \@orig;
+				}
+			} else {
+				if ($infoTree{$kObj}{public}{instance}) {
+					if ($infoTree{$kObj}{public}{instance}{called}) {
+						push @{$infoTree{$kObj}
+									->{public}
+									->{instance}
+									->{called}}, , $origin;
+					} else {
+						my @orig = ($origin);
+						$infoTree{$kObj}
+							->{public}
+							->{instance}
+							->{called} = \@orig;
+					}
+				} else {
+					my @orig = ($origin);
+					my %callRef = ( called => \@orig);
+					$infoTree{$kObj}{public}{instance} = \%callRef;
+				}
+			}
+		}
+	}
+	return;
+}
+
+#==========================================
+# addMethodCallCrossReferences
+#------------------------------------------
+sub addMethodCallCrossReferences {
+	# ...
+	# Generate cross references for all kiwi methods
+	# ---
+	my $modName = shift;
+	my $content = shift;
+	my $lineNo = 0;
+	my $methName;
+	my $nextMethName;
+LINE:
+	for my $ln (@{$content}) {
+		$lineNo += 1;
+		my $cln = $ln;
+		$cln =~ s/\s//g;
+		my $tok = PPI::Tokenizer->new(\$cln);
+		while ( my $t = $tok->get_token() ) {
+			if ($t =~ /^\#/) {
+				next LINE;
+			}
+			if ($t =~ /^sub$/) {
+				$nextMethName = 1;
+			}
+			if ($nextMethName) {
+				$methName = $t;
+				$nextMethName = 0;
+				next LINE;
+			}
+			if ($kiwiMethodNames{$t}) {
+				if ($duplicteName{$t}) {
+					__disambiguateCall($content, $t, $modName, $lineNo);
+				} else {
+					__addLineCrossRef($t, $modName, $lineNo);
+				}
+			}
+		}
+	}
+	return;
+}
+
+#==========================================
+# generateDependencyData
+#------------------------------------------
+sub generateDependencyData {
+	# ...
+	# Create dependency entries for each module.
+	# ---
+	my $modName = shift;
+	my $content = shift;
+	my @dependencies;
+	for my $ln (@{$content}) {
+		$ln =~ s/\s//g;
+		my $tok = PPI::Tokenizer->new(\$ln);
+		my @tokens = @{$tok->all_tokens()};
+		if ($tokens[0] && $tokens[0] =~ /^use|^require/) {
+			for my $token (@tokens) {
+				if ($token =~ /.*(KIWI\w+).*/) {
+					push @dependencies, $1;
+				}
+			}
+		}
+	}
+	$dependencyMap{$modName} = \@dependencies;
+	return;
+}
+
+#==========================================
+# generateIndexPage
+#------------------------------------------
+sub generateIndexPage {
+	# ...
+	# Generate HTML pages for the information in the tree.
+	# ---
+	if (! -d 'devDocs') {
+		mkdir 'devDocs';
+	}
+	my $index = '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">' . "\n"
+		. '<html>' . "\n"
+		. '<head>' . "\n"
+		. '<title>KIWI Module Index</title>' . "\n"
+		. '</head>' . "\n"
+		. '<body text="#000000" bgcolor="#E8E8FF" link="#3333FF" '
+		. 'vlink="#663366" alink="#FF0000">' . "\n"
+		. '<center><h1>KIWI Module Index</h1></center>' . "\n"
+		. '<p>' . "\n"
+		. '<ul>' . "\n";
+	my @modules = keys %infoTree;
+	@modules = sort @modules;
+	for my $mod (@modules) {
+		$index .= '<li><a href="' . $mod . '.html">' . $mod . '</a></li>';
+		$index .= "\n";
+	}
+	$index .= '</ul>' . "\n"
+		. '<hr>' . "\n"
+		. '<h2>Unresolvable call information</h2>' . "\n"
+		. '<p>' . "\n"
+		. '<ul>' . "\n";
+	my @methods = keys %unresolvable;
+	@methods = sort @methods;
+	for my $meth (@methods) {
+		$index .= '<li>' . $meth . '</li>' . "\n"
+			. '<ul>' . "\n";
+		for my $msg (@{$unresolvable{$meth}}) {
+			$index .= '<li>' . $msg . '</li>' . "\n";
+		}
+		$index .= '</ul>' . "\n";
+	}
+	$index .= '</ul>' . "\n";
+
+	open( my $INDEX, '>', 'devDocs/index.html');
+	print $INDEX $index;
+	close $INDEX;
+	return;
+}
+
+sub generateModulePages {
+	# ...
+	# Generate a page for each module
+	# ---
+	for my $mod (keys %infoTree) {
+		my $page = '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">' . "\n"
+			. '<html>' . "\n"
+			. '<head>' . "\n"
+			. '<title>' . $mod . ' Info</title>' . "\n"
+			. '</head>' . "\n"
+			. '<body text="#000000" bgcolor="#E8E8FF" link="#3333FF" '
+			. 'vlink="#663366" alink="#FF0000">' . "\n"
+			. '<center><h1>' . $mod . ' Info</h1></center>' . "\n"
+			. '<p>' . "\n"
+			. '<hr>' . "\n"
+			. '<a name="TOP"></a>' . "\n"
+			. '<h2>Public methods</h2>' . "\n"
+			. '<p>' . "\n"
+			. '<ul>' . "\n";
+		my @methodsPub = keys %{$infoTree{$mod}{public}};
+		@methodsPub = sort @methodsPub;
+		for my $meth (@methodsPub) {
+			$page .= '<li><a href="#' . $meth . '">' . $meth . '</a></li>'
+				. "\n";
+		}
+		$page .= '</ul>' . "\n";
+		my @methodsPriv;
+		if ($infoTree{$mod}{private}) {
+			@methodsPriv = keys %{$infoTree{$mod}{private}};
+			@methodsPriv = sort @methodsPriv;
+			$page .= '<h2>Private methods</h2>' . "\n"
+				. '<p>' . "\n"
+				. '<ul>' . "\n";
+			for my $meth (@methodsPriv) {
+				$page .= '<li><a href="#' . $meth . '">' . $meth . '</a></li>'
+					. "\n";
+			}
+			$page .= '</ul>' . "\n";
+		}
+		$page .= '<hr>' . "\n";
+		my %accessData = (
+			public => \@methodsPub,
+			private => \@methodsPriv
+		);
+		for my $access (keys %accessData) {
+			for my $meth (@{$accessData{$access}}) {
+				$page .= '<a name="' . $meth . '"><h2>' . $meth . '</h2></a>'
+					. "\n"
+					. '<p>' . "\n";
+				my $doc = $infoTree{$mod}{$access}{$meth}{description};
+				if (! $doc) {
+					$doc = 'Missing documentation';
+				}
+				$page .= $doc
+					. '<p>' . "\n"
+					. 'Defined on line: ';
+				my $lineNo = $infoTree{$mod}{$access}{$meth}{definedOn};
+				if (! $lineNo) {
+					$lineNo = 'Unknown';
+				}
+				$page .= $lineNo . "\n";
+				if ($infoTree{$mod}{$access}{$meth}{called}) {
+					my @calls = @{$infoTree{$mod}{$access}{$meth}{called}};
+					$page .= '<p>' . "\n"
+						. 'Called in' . "\n"
+						. '<ul>' . "\n";
+					for my $call (@calls) {
+						my ($name, $methName, $lineNo) = split /:/msx, $call;
+						$page .= '<li><a href="' . $name . '.html">' . $name
+							. '</a> : ' . $lineNo . '</li>';
+					}
+					$page .= '</ul>' . "\n";
+				}
+			}
+		}
+		open( my $PAGE, '>', "devDocs/$mod.html");
+		print $PAGE $page;
+		close $PAGE;
+	}
+	return;
+}
+
+#==========================================
+# __addLineCrossRef
+#------------------------------------------
+sub __addLineCrossRef {
+	# ...
+	# Add a cross reference to given line number for the given called
+	# kiwi method.
+	# ---
+	my $kiwiMethodName = shift;
+	my $moduleName     = shift;
+	my $lineNo         = shift;
+	my $useObj         = shift;
+	if ($duplicteName{$kiwiMethodName} && ! $useObj) {
+		print "Cannot disambiguate '$kiwiMethodName', use __disambiguateCall "
+			. "method to add cross ref for this method.\n";
+		return;
+	}
+	my $kObj;
+	if ($useObj) {
+		$kObj = $useObj;
+	} else {
+		$kObj = $kiwiMethodNames{$kiwiMethodName};
+	}
+	if (! $kObj) {
+		print "No entry for kiwi method $kiwiMethodName\n";
+		return;
+	}
+	my $origin = $moduleName . ':' . $kiwiMethodName . ':' . $lineNo;
+	if (! $infoTree{$kObj}) {
+		print "Could not add cross reference for '$kObj', called from "
+			. "$origin; no entry.\n";
+		return;
+	}
+	my $access;
+	if ($kiwiMethodName =~ /^_|^__/) {
+		$access = 'private';
+	} else {
+		$access = 'public';
+	}
+	if (! $infoTree{$kObj}{$access}{$kiwiMethodName}) {
+		my $msg = "Could not add cross reference for '$kiwiMethodName' on "
+			. "'$kObj', called from $origin; no entry.\n";
+		if ($unresolvable{$kiwiMethodName}) {
+			push @{$unresolvable{$kiwiMethodName}}, $msg;
+		} else {
+			my @msgs = ($msg);
+			$unresolvable{$kiwiMethodName} = \@msgs
+		}
+		return;
+	}
+	if ($infoTree{$kObj}{$access}{$kiwiMethodName}{called}) {
+		push @{$infoTree{$kObj}{$access}{$kiwiMethodName}{called}}, $origin;
+	} else {
+		my @orig = ($origin);
+		$infoTree{$kObj}{$access}{$kiwiMethodName}{called} = \@orig;
+	}
+	return;
+}
+
+#==========================================
+# __disambiguateCall
+#------------------------------------------
+sub __disambiguateCall {
+	# ...
+	# Figure out on which object the method was called.
+	# ---
+	my $content        = shift;
+	my $kiwiMethodName = shift;
+	my $modName        = shift;
+	my $lineNo         = shift;
+	my %perlSpecial = (
+		BEGIN   => 1,
+		DESTROY => 1
+	);
+	if ($perlSpecial{$kiwiMethodName}) {
+		return;
+	}
+#    print "DBG: Need to disambiguate $kiwiMethodName : in: $modName\n";
+	my @source = @{$content};
+	my $ambigCallLn = $source[$lineNo-1];
+	$ambigCallLn =~ s/\s//g;
+	my $tok = PPI::Tokenizer->new(\$ambigCallLn);
+	my @tokens = @{$tok->all_tokens()};
+	my $methIdx = first { $tokens[$_] eq $kiwiMethodName } 0..$#tokens;
+	my $callerVar = $tokens[$methIdx-2];
+	my $tgtObj;
+	if ($callerVar =~ /^\$/) {
+		if ($callerVar eq '$this') {
+#            print "\t\tDBG: trivial case for: $kiwiMethodName\n";
+			$tgtObj = $modName;
+		} else {
+			$tgtObj = __getKClassName($content, $callerVar, $lineNo);
+			if (! $tgtObj || $tgtObj eq '0') {
+				my $msg = "Cannot disambiguate call to: $kiwiMethodName in "
+					. "$modName at $lineNo\n";
+				if ($unresolvable{$kiwiMethodName}) {
+					push @{$unresolvable{$kiwiMethodName}}, $msg;
+				} else {
+					my @msgs = ($msg);
+					$unresolvable{$kiwiMethodName} = \@msgs
+				}
+				return;
+			}
+		}
+		__addLineCrossRef($kiwiMethodName, $modName, $lineNo, $tgtObj);
+		return;
+	}
+	return;
+}
+
+#==========================================
+# __getKClassName
+#------------------------------------------
+sub __getKClassName {
+	# ...
+	# Find a KIWI class name that maps to the given variable used to a
+	# method.
+	# ---
+	my $content = shift;
+	my $objRef  = shift;
+	my $lineNo  = shift;
+	my @source = @{$content};
+	my $search = quotemeta $objRef;
+#    print "\t\t\tDBG: work backwards from: $lineNo: looking for: '$objRef'\n";
+	while ($lineNo > 0) {
+		$lineNo -= 1;
+		my $ln = $source[$lineNo];
+#        print "\t\t\tDBG: working for: $ln\n";
+		if ($ln =~ /$search\s*=/) {
+#            print "\t\t\tDBG: found assignment\n";
+			my $useNextAsRval;
+			my $rval;
+			$ln =~ s/\s//g;
+			my $tok = PPI::Tokenizer->new(\$ln);
+			while ( my $t = $tok->get_token() ) {
+				if ($useNextAsRval) {
+					$rval = $t;
+#                    print "\t\t\tDBG: found rval: $rval :  objRef: $objRef\n";
+					$useNextAsRval = 0;
+				}
+				if ($t eq '=') {
+					$useNextAsRval = 1;
+				}
+			}
+			if ($rval =~ /KIWI/) {
+				return $rval;
+			} elsif ($rval eq 'shift') {
+				return '0';
+			} else {
+				return __getKClassName($content, $rval, $lineNo);
+			}
+		}
+	}
+	return;
+}
+
+#==========================================
+# processFiles
+#------------------------------------------
+sub processFiles {
+	# ...
+	# Process all the modules
+	# ---
+	for my $flpath (@allModules) {
+		my ($vol, $dir, $fname) =  File::Spec->splitpath( $flpath );
+		my ($name, $ext) = split /\./msx, $fname;
+		my @lines = read_file($flpath);
+		addMethodInfo($name, \@lines);
+	}
+	for my $flpath (@allModules) {
+		my ($vol, $dir, $fname) =  File::Spec->splitpath( $flpath );
+		my ($name, $ext) = split /\./msx, $fname;
+		my @lines = read_file($flpath);
+		addCtorCrossReferences($name, \@lines);
+	}
+	for my $flpath (@allModules) {
+		my ($vol, $dir, $fname) =  File::Spec->splitpath( $flpath );
+		my ($name, $ext) = split /\./msx, $fname;
+		my @lines = read_file($flpath);
+		addMethodCallCrossReferences($name, \@lines);
+	}
+	for my $flpath (@allModules) {
+		my ($vol, $dir, $fname) =  File::Spec->splitpath( $flpath );
+		my ($name, $ext) = split /\./msx, $fname;
+		my @lines = read_file($flpath);
+		generateDependencyData($name, \@lines);
+	}
+	return;
+}
+
+processFiles();
+generateIndexPage();
+generateModulePages();
+
+#$Data::Dumper::Terse  = 1;
+#$Data::Dumper::Indent = 1;
+#$Data::Dumper::Useqq  = 1;
+#my $dd = Data::Dumper->new([ %infoTree ]);
+#my $cd = $dd->Dump();
+#print "DBG catalog:\n";
+#print STDOUT $cd;
+#print "DBG dependencies:\n";
+#$dd = Data::Dumper->new([ %dependencyMap ]);
+#$cd = $dd->Dump();
+#print STDOUT $cd;

--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -3705,7 +3705,6 @@ sub setupBootLoaderStages {
 	#==========================================
 	# more boot managers to come...
 	#------------------------------------------
-	# ...
 	return $this;
 }
 
@@ -4806,7 +4805,6 @@ sub setupBootLoaderConfiguration {
 	#==========================================
 	# more boot managers to come...
 	#------------------------------------------
-	# ...
 	#==========================================
 	# Check for edit boot config
 	#------------------------------------------
@@ -5383,7 +5381,6 @@ sub installBootLoader {
 	#==========================================
 	# more boot managers to come...
 	#------------------------------------------
-	# ...
 	#==========================================
 	# Check for edit boot install
 	#------------------------------------------
@@ -6008,7 +6005,7 @@ sub setMD {
 #------------------------------------------
 sub setVolumeGroup {
 	# ...
-	# create volume group and required logical 
+	# create volume group and required logical
 	# volumes. The function returns a new device map
 	# including the volume device names
 	# ---
@@ -6211,7 +6208,7 @@ sub luksClose {
 sub umountDevice {
 	# ...
 	# umount all mounted filesystems from the given
-	# storage device. The functions searches the 
+	# storage device. The functions searches the
 	# /proc/mounts table and umounts all corresponding
 	# mount entries
 	# ----

--- a/modules/KIWICollect.pm
+++ b/modules/KIWICollect.pm
@@ -1347,7 +1347,6 @@ sub unpackMetapackages
 
 		# regular handling: unpack, put everything from CD1..CD<n> to
 		# cdroot {m_basedir}
-		# ...
 		my $tmp = "$this->{m_basesubdir}->{$medium}/temp";
 		if(-d $tmp) {
 			qx(rm -rf $tmp);

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -2082,7 +2082,7 @@ sub __convertSizeStrToMBVal {
 	# ...
 	# Convert a given size string that contains M or G into a value
 	# that is a representation in MB.
-	#
+	# ---
 	my $this    = shift;
 	my $sizeStr = shift;
 	if (! $sizeStr ) {

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -1976,7 +1976,7 @@ sub __isValidSizeUnit {
 	# ...
 	# Verify that the given unit of measure for the size is a
 	# recognized value
-	#---
+	# ---
 	my $this   = shift;
 	my $unit   = shift;
 	my $caller = shift;


### PR DESCRIPTION
Well, your visualization comment the other day got me rolling on this little side project (visualization is missing of course, but maybe you want to tackle that ;) ).

This scrip generates html pages for each module listing all the method names and the documentation for each method as delimited by # ... and # ---.

The script also generates call information and a list of things it cannot resolve, after all only Perl can parse perl and this is only a static tool.

There is also a dependency map generated, however I am not yet doing anything with that data. I'd love to see a DAG for our dependencies, but I could not find good info on how to generate one. I'll keep looking.

Leaves the question of integration:
Should we pre-generate the doc html files and then track them in git or should we let OBS create a kiwi-devel-doc package and generate the docs in OBS only?

If we pre-generate and track the files in git I'd still like to create a kiwi-devel-doc package.

Also we have to come to terms with integration of the script into the Makefile and/or pre-commit hook. If we pre-generate I think we should make certain the doc generator runs every time any of the modules is changed to make certain the doc is up to date.

It's a start.

Thoughts/Comments
Robert
