### PR TITLE
XML writing

### DIFF
--- a/modules/KIWILocator.pm
+++ b/modules/KIWILocator.pm
@@ -286,6 +286,4 @@ sub getExecPath {
 	return $execPath;
 }
 
-
-
 1;

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -167,6 +167,23 @@ k.imagename.attribute   =
 	attribute name { image-name }
 
 #==========================================
+# common element <archive>
+#
+div {
+	k.archive.name.attribute = k.name.attribute
+	k.archive.bootinclude.attribute = k.bootinclude.attribute
+	k.archive.attlist =
+		k.archive.name.attribute &
+		k.archive.bootinclude.attribute?
+	k.archive =
+		## Name of an image archive file (tarball)
+		element archive {
+			k.archive.attlist,
+			empty
+		}
+}
+
+#==========================================
 # common element <author>
 #
 div {
@@ -174,6 +191,42 @@ div {
 	k.author =
 		## Author of the image
 		element author { k.author.attlist, text }
+}
+
+#==========================================
+# common element <bootloader-theme>
+#
+div {
+	k.bootloader-theme.attlist = empty
+	k.bootloader-theme =
+		## Image bootloader theme setup.
+		[
+		db:para [
+			"The value will be used in KIWIConfig.sh::suseGFXBoot"
+		]
+		]
+		element bootloader-theme {
+			k.bootloader-theme.attlist,
+			text
+		}
+}
+
+#==========================================
+# common element <bootsplash-theme>
+#
+div {
+	k.bootsplash-theme.attlist = empty
+	k.bootsplash-theme =
+		## Image bootsplash theme setup.
+		[
+		db:para [
+			"The value will be used in KIWIConfig.sh::suseGFXBoot"
+		]
+		]
+		element bootsplash-theme {
+			k.bootsplash-theme.attlist,
+			text
+		}
 }
 
 #==========================================
@@ -307,13 +360,28 @@ div {
 		db:para [
 			"Specify the region/availability zone in EC2 for this image.\x{a}"~
 			"Values are limited to the EC2 recognized zones:\x{a}"~
-			"AP-Northeast, AP-Southeast, EU-West, SA-East, US-East, \x{a}"~
+			"AP-Northeast, AP-Southeast, EU-West, SA-East, US-East,\x{a}"~
 			"US-West, and US-West2"
 		]
 		]
 		element ec2region {
 			k.ec2region.attlist,
 			text
+		}
+}
+
+#==========================================
+# common element <except>
+#
+div {
+	k.except.name.attribute = k.name.attribute
+	k.except.attlist =
+		k.except.name.attribute
+	k.except =
+		## A Pointer to a File which should be excluded
+		element except {
+			k.except.attlist,
+			empty
 		}
 }
 
@@ -335,17 +403,22 @@ div {
 }
 
 #==========================================
-# common element <except>
+# common element <hwclock>
 #
 div {
-	k.except.name.attribute = k.name.attribute
-	k.except.attlist =
-		k.except.name.attribute
-	k.except =
-		## A Pointer to a File which should be excluded
-		element except {
-			k.except.attlist,
-			empty
+	k.hwclock.content = "utc" | "localtime"
+	k.hwclock.attlist = empty
+	k.hwclock =
+		## Setup Image harware clock setup, either utc or localtime
+		[
+		db:para [
+			"Image hardware clock setup. The value can be either\x{a}"~
+			"set to utc or localtime."
+		]
+		]
+		element hwclock {
+			k.hwclock.attlist,
+			k.hwclock.content
 		}
 }
 
@@ -477,42 +550,6 @@ div { # locale
 }
 
 #==========================================
-# common element <bootloader-theme>
-#
-div {
-	k.bootloader-theme.attlist = empty
-	k.bootloader-theme =
-		## Image bootloader theme setup.
-		[
-		db:para [
-			"The value will be used in KIWIConfig.sh::suseGFXBoot"
-		]
-		]
-		element bootloader-theme {
-			k.bootloader-theme.attlist,
-			text
-		}
-}
-
-#==========================================
-# common element <bootsplash-theme>
-#
-div {
-	k.bootsplash-theme.attlist = empty
-	k.bootsplash-theme =
-		## Image bootsplash theme setup.
-		[
-		db:para [
-			"The value will be used in KIWIConfig.sh::suseGFXBoot"
-		]
-		]
-		element bootsplash-theme {
-			k.bootsplash-theme.attlist,
-			text
-		}
-}
-
-#==========================================
 # common element <metadata>
 #
 div {
@@ -560,396 +597,19 @@ div {
 }
 
 #==========================================
-# common element <opensusePattern>
+# common element <namedCollection>
 #
 div {
-	k.opensusepattern.name.attribute = k.name.attribute
-	k.opensusepattern.arch.attribute = k.arch.attribute
-	k.opensusepattern.attlist =
-		k.opensusepattern.name.attribute &
-		k.opensusepattern.arch.attribute?
-	k.opensusepattern =
-		## Name of a Pattern From openSUSE
-		element opensusePattern {
-			k.opensusepattern.attlist,
+	k.namedCollection.name.attribute = k.name.attribute
+	k.namedCollection.arch.attribute = k.arch.attribute
+	k.namedCollection.attlist =
+		k.namedCollection.name.attribute &
+		k.namedCollection.arch.attribute?
+	k.namedCollection =
+		## Name of a Pattern for SUSE or a Group for RH
+		element namedCollection {
+			k.namedCollection.attlist,
 			empty
-		}
-}
-
-#==========================================
-# common element <rhelGroup>
-#
-div {
-	k.rhelgroup.name.attribute = k.name.attribute
-	k.rhelgroup.arch.attribute = k.arch.attribute
-	k.rhelgroup.attlist =
-		k.rhelgroup.name.attribute &
-		k.rhelgroup.arch.attribute?
-	k.rhelgroup =
-		## Name of RHEL package group 
-		element rhelGroup {
-			k.rhelgroup.attlist,
-			empty
-		}
-}
-
-#==========================================
-# common element <opensuseProduct>
-#
-div {
-	k.opensuseproduct.name.attribute = k.name.attribute
-	k.opensuseproduct.arch.attribute = k.arch.attribute
-	k.opensuseproduct.attlist =
-		k.opensuseproduct.name.attribute &
-		k.opensuseproduct.arch.attribute?
-	k.opensuseproduct =
-		## Name of a Product From openSUSE
-		element opensuseProduct {
-			k.opensuseproduct.attlist,
-			empty
-		}
-}
-
-#==========================================
-# common element <repopackage>
-#
-div {
-	k.repopackage.name.attribute = k.name.attribute
-	k.repopackage.arch.attribute = k.arch.attribute
-	k.repopackage.forcerepo.attribute =
-		## Specifies the search priority
-		attribute forcerepo { xsd:IDREF }
-	k.repopackage.addarch.attribute =
-		## Specifies that this package should
-		## additionally add the same package from the given arch
-		attribute addarch { text }
-	k.repopackage.removearch.attribute =
-		## Specifies that the package with the
-		## given arch should be removed
-		attribute removearch { text }
-	k.repopackage.onlyarch.attribute =
-		## Specifies that the package with
-		## the given arch should be used in any case
-		attribute onlyarch { text }
-	k.repopackage.medium.attribute =
-		## Specifies that the package will be put
-		## to the specific medium number (CD1, DVD7, ...)
-		attribute medium { xsd:nonNegativeInteger }
-	k.repopackage.source.attribute = k.source.attribute
-	k.repopackage.script.attribute = k.script.attribute
-	k.repopackage.attlist =
-		k.repopackage.name.attribute & 
-		k.repopackage.arch.attribute? &
-		k.repopackage.forcerepo.attribute? &
-		k.repopackage.addarch.attribute? &
-		k.repopackage.removearch.attribute? &
-		k.repopackage.onlyarch.attribute? &
-		k.repopackage.source.attribute? &
-		k.repopackage.script.attribute? &
-		k.repopackage.medium.attribute?
-	k.repopackage =
-		## Name of an instsource Package
-		element repopackage {
-			k.repopackage.attlist,
-			empty
-		}
-}
-
-#==========================================
-# common element <package>
-#
-div {
-	k.package.name.attribute = k.name.attribute
-	k.package.arch.attribute = k.arch.attribute
-	k.package.replaces.attribute = k.replaces.attribute
-	k.package.bootinclude.attribute = k.bootinclude.attribute
-	k.package.bootdelete.attribute = k.bootdelete.attribute
-	k.package.attlist =
-		k.package.name.attribute &
-		k.package.arch.attribute? &
-		k.replaces.attribute? &
-		k.bootdelete.attribute? &
-		k.bootinclude.attribute?
-	k.package =
-		## Name of an image Package
-		element package {
-			k.package.attlist,
-			empty
-		}
-}
-
-#==========================================
-# common element <archive>
-#
-div {
-	k.archive.name.attribute = k.name.attribute
-	k.archive.bootinclude.attribute = k.bootinclude.attribute
-	k.archive.attlist =
-		k.archive.name.attribute &
-		k.archive.bootinclude.attribute?
-	k.archive =
-		## Name of an image archive file (tarball)
-		element archive {
-			k.archive.attlist,
-			empty
-		}
-}
-
-#==========================================
-# common element <packagemanager>
-#
-div {
-	k.packagemanager.content = 
-		"apt-get" | "smart" | "zypper" | "ensconce" | "yum"
-	k.packagemanager.attlist = empty
-	k.packagemanager =
-		## Name of the Package Manager
-		[
-		db:para [
-			"The package manager used for package installation\x{a}"~
-			"could be either zypper or smart"
-		]
-		]
-		element packagemanager {
-			k.packagemanager.attlist,
-			k.packagemanager.content
-		}
-}
-
-#==========================================
-# common element <partitions>
-#
-div {
-	k.partitions.device.attribute =
-		## As part of the network deploy configuration this section
-		## specifies the disk device name
-		attribute device { text }
-	k.partitions.attlist = k.partitions.device.attribute?
-	k.partitions =
-		## A List of Partitions
-		element partitions { 
-			k.partitions.attlist, 
-			k.partition+
-		}
-}
-
-#==========================================
-# common element <partition>
-#
-div {
-	k.partition.type.attribute =
-		## Partition Type identifier, see parted for details
-		attribute type { text }
-	k.partition.number.attribute =
-		## Partition ID
-		attribute number { text }
-	k.partition.size.attribute = k.size.attribute
-	k.partition.mountpoint.attribute = 
-		## Mount path for this partition
-		attribute mountpoint { text }
-	k.partition.target.attribute =
-		## Is a real target or not which means is part of
-		## the /etc/fstab file or not
-		attribute target { xsd:boolean }
-	k.partition.attlist =
-		k.partition.type.attribute &
-		k.partition.number.attribute & 
-		k.partition.size.attribute? &
-		k.partition.mountpoint.attribute? &
-		k.partition.target.attribute?
-	k.partition =
-		## A Partition
-		element partition {
-			k.partition.attlist,
-			empty
-		}
-}
-
-#==========================================
-# common element <persistent>
-#
-div {
-	k.persistent.attlist = empty
-	k.persistent =
-		## Specifies Filenames in the Read-Write Disk Area
-		[
-		db:para [
-			"As part of the split section the persistent element\x{a}"~
-			"specifies filenames which are in the read-write disk area"
-		]
-		]
-		element persistent {
-			k.persistent.attlist &
-			k.except* &
-			k.file+
-		}
-}
-
-#==========================================
-# common element <profile>
-#
-div {
-	k.profile.name.attribute = k.name.attribute
-	k.profile.description.attribute =
-		## Description of how this profiles influences the image
-		attribute description { text }
-	k.profile.import.attribute =
-		## Import profile by default if no profile was set on
-		## the command line
-		attribute import { xsd:boolean }
-	k.profile.attlist =
-		k.profile.name.attribute &
-		k.profile.description.attribute &
-		k.profile.import.attribute?
-	k.profile =
-		## Creates Profiles
-		[
-		db:para [
-			"Profiles creates a namespace on an image description and\x{a}"~
-			"thus can be used to have one description with different\x{a}"~
-			"profiles for example KDE and GNOME including different\x{a}"~
-			"packages."
-		]
-		]
-		element profile {
-			k.profile.attlist,
-			empty
-		}
-}
-
-#==========================================
-# common element <repository>
-#
-div {
-	k.repository.profiles.attribute = k.profiles.attribute
-	k.repository.type.attribute =
-	  ## Type of repository
-	  attribute type {
-		"apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "red-carpet" |
-		"rpm-dir" | "rpm-md"  | "slack-site" | "up2date-mirrors" | "urpmi" |
-		"yast2"
-	}
-	k.repository.status.attribute =
-		## Specifies the status of the repository. This can be
-		## replacable or if not specified it's a must have repository
-		attribute status {  "fixed" | "replaceable" }
-	k.repository.alias.attribute =
-		## Alias name to be used for this repository. This is an
-		## optional free form text. If not set the source attribute
-		## value is used and builds the alias name by replacing
-		## each '/' with a '_'. An alias name should be set if the
-		## source argument doesn't really explain what this repository
-		## contains
-		attribute alias { text }
-	k.repository.components.attribute =
-		## Distribution components, used for deb repositories. If
-		## not set it defaults to main
-		attribute components { text }
-	k.repository.distribution.attribute =
-		## Distribution name information, used for deb repositories
-		attribute distribution { text }
-	k.repository.imageinclude.attribute =
-		## Specify whether or not this repository should be configured in the
-		## resulting image. Boolean value true or false, the default is false.
-		attribute imageinclude { xsd:boolean }
-	k.repository.prefer-license.attribute =
-		## Use the license found in this repository, if any, as the
-		## license installed in the image
-		attribute prefer-license { xsd:boolean }
-	k.repository.priority.attribute =
-		## Channel priority assigned to all packages available in
-		## this channel (0 if not set). If the exact same package
-		## is available in more than one channel, the highest
-		## priority is used
-		attribute priority { xsd:integer }
-	k.repository.password.attribute =
-		## Channel password if required. It depends on the url type
-		## whether and how this information is passed
-		k.password.attribute
-	k.repository.username.attribute =
-		## Channel username if required. It depends on the url type
-		## whether and how this information is passed
-		k.username.attribute
-	k.repository.attlist =
-		k.repository.type.attribute &
-		k.repository.profiles.attribute? &
-		k.repository.status.attribute? &
-		k.repository.alias.attribute? &
-		k.repository.components.attribute? &
-		k.repository.distribution.attribute? &
-		k.repository.imageinclude.attribute? &
-		k.repository.prefer-license.attribute? &
-		k.repository.priority.attribute? &
-		k.repository.password.attribute? &
-		k.repository.username.attribute?
-	k.repository =
-		## The Name of the Repository
-		element repository {
-			k.repository.attlist,
-			k.source
-		}
-}
-
-#==========================================
-# common element <rpm-check-signatures>
-#
-div {
-	k.rpm-check-signatures.content = xsd:boolean
-	k.rpm-check-signatures.attlist = empty
-	k.rpm-check-signatures =
-		## Setup a Package Signature
-		[
-		db:para [
-			"Setup if the package manager should check the package\x{a}"~
-			"signature or not. This option could be ignored according\x{a}"~
-			"to the used package manager."
-		]
-		]
-		element rpm-check-signatures {
-			k.rpm-check-signatures.attlist,
-			k.rpm-check-signatures.content
-		}
-}
-
-#==========================================
-# common element <rpm-excludedocs>
-#
-div {
-	k.rpm-excludedocs.content = xsd:boolean
-	k.rpm-excludedocs.attlist = empty
-	k.rpm-excludedocs =
-		## Do not install files marked as documentation in the package
-		[
-		db:para [
-			"Setup if the package manager should exclude docs files\x{a}"~
-			"during package installation. This option could be ignored\x{a}"~
-			"according to the used package manager."
-		]
-		]
-		element rpm-excludedocs {
-			k.rpm-excludedocs.attlist,
-			k.rpm-excludedocs.content
-		}
-}
-
-#==========================================
-# common element <rpm-force>
-#
-div {
-	k.rpm-force.content = xsd:boolean
-	k.rpm-force.attlist = empty
-	k.rpm-force =
-		## Force the Installation of a Package
-		[
-		db:para [
-			"Setup if the package manager should force the install of the\x{a}"~
-			"package or not. This option could be ignored according\x{a}"~
-			"to the used package manager."
-		]
-		]
-		element rpm-force {
-			k.rpm-force.attlist,
-			k.rpm-force.content
 		}
 }
 
@@ -1175,27 +835,6 @@ div {
 }
 
 #==========================================
-# common element <oem-silent-boot>
-#
-div {
-	k.oem-silent-boot.content = xsd:boolean
-	k.oem-silent-boot.attlist = empty
-	k.oem-silent-boot =
-		## For oemboot driven images: boot silently during the initial boot
-		## true/false
-		[
-		db:para [
-			"For oemboot driven images: complete the initial boot of the "~
-			"system in silent mode, true/false. "
-		]
-		]
-		element oem-silent-boot {
-			k.oem-silent-boot.attlist,
-			k.oem-silent-boot.content
-		}
-}
-
-#==========================================
 # common element <oem-shutdown>
 #
 div {
@@ -1237,6 +876,27 @@ div {
 		element oem-shutdown-interactive {
 			k.oem-shutdown-interactive.attlist,
 			k.oem-shutdown-interactive.content
+		}
+}
+
+#==========================================
+# common element <oem-silent-boot>
+#
+div {
+	k.oem-silent-boot.content = xsd:boolean
+	k.oem-silent-boot.attlist = empty
+	k.oem-silent-boot =
+		## For oemboot driven images: boot silently during the initial boot
+		## true/false
+		[
+		db:para [
+			"For oemboot driven images: complete the initial boot of the "~
+			"system in silent mode, true/false. "
+		]
+		]
+		element oem-silent-boot {
+			k.oem-silent-boot.attlist,
+			k.oem-silent-boot.content
 		}
 }
 
@@ -1343,6 +1003,402 @@ div {
 }
 
 #==========================================
+# common element <opensusePattern>
+#
+div {
+	k.opensusepattern.name.attribute = k.name.attribute
+	k.opensusepattern.arch.attribute = k.arch.attribute
+	k.opensusepattern.attlist =
+		k.opensusepattern.name.attribute &
+		k.opensusepattern.arch.attribute?
+	k.opensusepattern =
+		## Name of a Pattern From openSUSE
+		element opensusePattern {
+			k.opensusepattern.attlist,
+			empty
+		}
+}
+
+#==========================================
+# common element <opensuseProduct>
+#
+div {
+	k.opensuseproduct.name.attribute = k.name.attribute
+	k.opensuseproduct.arch.attribute = k.arch.attribute
+	k.opensuseproduct.attlist =
+		k.opensuseproduct.name.attribute &
+		k.opensuseproduct.arch.attribute?
+	k.opensuseproduct =
+		## Name of a Product From openSUSE
+		element opensuseProduct {
+			k.opensuseproduct.attlist,
+			empty
+		}
+}
+
+#==========================================
+# common element <package>
+#
+div {
+	k.package.name.attribute = k.name.attribute
+	k.package.arch.attribute = k.arch.attribute
+	k.package.replaces.attribute = k.replaces.attribute
+	k.package.bootinclude.attribute = k.bootinclude.attribute
+	k.package.bootdelete.attribute = k.bootdelete.attribute
+	k.package.attlist =
+		k.package.name.attribute &
+		k.package.arch.attribute? &
+		k.replaces.attribute? &
+		k.bootdelete.attribute? &
+		k.bootinclude.attribute?
+	k.package =
+		## Name of an image Package
+		element package {
+			k.package.attlist,
+			empty
+		}
+}
+
+#==========================================
+# common element <packagemanager>
+#
+div {
+	k.packagemanager.content = 
+		"apt-get" | "smart" | "zypper" | "ensconce" | "yum"
+	k.packagemanager.attlist = empty
+	k.packagemanager =
+		## Name of the Package Manager
+		[
+		db:para [
+			"The package manager used for package installation\x{a}"~
+			"could be either zypper or smart"
+		]
+		]
+		element packagemanager {
+			k.packagemanager.attlist,
+			k.packagemanager.content
+		}
+}
+
+#==========================================
+# common element <partition>
+#
+div {
+	k.partition.type.attribute =
+		## Partition Type identifier, see parted for details
+		attribute type { text }
+	k.partition.number.attribute =
+		## Partition ID
+		attribute number { text }
+	k.partition.size.attribute = k.size.attribute
+	k.partition.mountpoint.attribute = 
+		## Mount path for this partition
+		attribute mountpoint { text }
+	k.partition.target.attribute =
+		## Is a real target or not which means is part of
+		## the /etc/fstab file or not
+		attribute target { xsd:boolean }
+	k.partition.attlist =
+		k.partition.type.attribute &
+		k.partition.number.attribute & 
+		k.partition.size.attribute? &
+		k.partition.mountpoint.attribute? &
+		k.partition.target.attribute?
+	k.partition =
+		## A Partition
+		element partition {
+			k.partition.attlist,
+			empty
+		}
+}
+
+#==========================================
+# common element <partitions>
+#
+div {
+	k.partitions.device.attribute =
+		## As part of the network deploy configuration this section
+		## specifies the disk device name
+		attribute device { text }
+	k.partitions.attlist = k.partitions.device.attribute?
+	k.partitions =
+		## A List of Partitions
+		element partitions { 
+			k.partitions.attlist, 
+			k.partition+
+		}
+}
+
+#==========================================
+# common element <persistent>
+#
+div {
+	k.persistent.attlist = empty
+	k.persistent =
+		## Specifies Filenames in the Read-Write Disk Area
+		[
+		db:para [
+			"As part of the split section the persistent element\x{a}"~
+			"specifies filenames which are in the read-write disk area"
+		]
+		]
+		element persistent {
+			k.persistent.attlist &
+			k.except* &
+			k.file+
+		}
+}
+
+#==========================================
+# common element <profile>
+#
+div {
+	k.profile.name.attribute = k.name.attribute
+	k.profile.description.attribute =
+		## Description of how this profiles influences the image
+		attribute description { text }
+	k.profile.import.attribute =
+		## Import profile by default if no profile was set on
+		## the command line
+		attribute import { xsd:boolean }
+	k.profile.attlist =
+		k.profile.name.attribute &
+		k.profile.description.attribute &
+		k.profile.import.attribute?
+	k.profile =
+		## Creates Profiles
+		[
+		db:para [
+			"Profiles creates a namespace on an image description and\x{a}"~
+			"thus can be used to have one description with different\x{a}"~
+			"profiles for example KDE and GNOME including different\x{a}"~
+			"packages."
+		]
+		]
+		element profile {
+			k.profile.attlist,
+			empty
+		}
+}
+
+#==========================================
+# common element <repopackage>
+#
+div {
+	k.repopackage.name.attribute = k.name.attribute
+	k.repopackage.arch.attribute = k.arch.attribute
+	k.repopackage.forcerepo.attribute =
+		## Specifies the search priority
+		attribute forcerepo { xsd:IDREF }
+	k.repopackage.addarch.attribute =
+		## Specifies that this package should
+		## additionally add the same package from the given arch
+		attribute addarch { text }
+	k.repopackage.removearch.attribute =
+		## Specifies that the package with the
+		## given arch should be removed
+		attribute removearch { text }
+	k.repopackage.onlyarch.attribute =
+		## Specifies that the package with
+		## the given arch should be used in any case
+		attribute onlyarch { text }
+	k.repopackage.medium.attribute =
+		## Specifies that the package will be put
+		## to the specific medium number (CD1, DVD7, ...)
+		attribute medium { xsd:nonNegativeInteger }
+	k.repopackage.source.attribute = k.source.attribute
+	k.repopackage.script.attribute = k.script.attribute
+	k.repopackage.attlist =
+		k.repopackage.name.attribute & 
+		k.repopackage.arch.attribute? &
+		k.repopackage.forcerepo.attribute? &
+		k.repopackage.addarch.attribute? &
+		k.repopackage.removearch.attribute? &
+		k.repopackage.onlyarch.attribute? &
+		k.repopackage.source.attribute? &
+		k.repopackage.script.attribute? &
+		k.repopackage.medium.attribute?
+	k.repopackage =
+		## Name of an instsource Package
+		element repopackage {
+			k.repopackage.attlist,
+			empty
+		}
+}
+
+#==========================================
+# common element <repository>
+#
+div {
+	k.repository.profiles.attribute = k.profiles.attribute
+	k.repository.type.attribute =
+	  ## Type of repository
+	  attribute type {
+		"apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "red-carpet" |
+		"rpm-dir" | "rpm-md"  | "slack-site" | "up2date-mirrors" | "urpmi" |
+		"yast2"
+	}
+	k.repository.status.attribute =
+		## Specifies the status of the repository. This can be
+		## replacable or if not specified it's a must have repository
+		attribute status {  "fixed" | "replaceable" }
+	k.repository.alias.attribute =
+		## Alias name to be used for this repository. This is an
+		## optional free form text. If not set the source attribute
+		## value is used and builds the alias name by replacing
+		## each '/' with a '_'. An alias name should be set if the
+		## source argument doesn't really explain what this repository
+		## contains
+		attribute alias { text }
+	k.repository.components.attribute =
+		## Distribution components, used for deb repositories. If
+		## not set it defaults to main
+		attribute components { text }
+	k.repository.distribution.attribute =
+		## Distribution name information, used for deb repositories
+		attribute distribution { text }
+	k.repository.imageinclude.attribute =
+		## Specify whether or not this repository should be configured in the
+		## resulting image. Boolean value true or false, the default is false.
+		attribute imageinclude { xsd:boolean }
+	k.repository.prefer-license.attribute =
+		## Use the license found in this repository, if any, as the
+		## license installed in the image
+		attribute prefer-license { xsd:boolean }
+	k.repository.priority.attribute =
+		## Channel priority assigned to all packages available in
+		## this channel (0 if not set). If the exact same package
+		## is available in more than one channel, the highest
+		## priority is used
+		attribute priority { xsd:integer }
+	k.repository.password.attribute =
+		## Channel password if required. It depends on the url type
+		## whether and how this information is passed
+		k.password.attribute
+	k.repository.username.attribute =
+		## Channel username if required. It depends on the url type
+		## whether and how this information is passed
+		k.username.attribute
+	k.repository.attlist =
+		k.repository.type.attribute &
+		k.repository.profiles.attribute? &
+		k.repository.status.attribute? &
+		k.repository.alias.attribute? &
+		k.repository.components.attribute? &
+		k.repository.distribution.attribute? &
+		k.repository.imageinclude.attribute? &
+		k.repository.prefer-license.attribute? &
+		k.repository.priority.attribute? &
+		k.repository.password.attribute? &
+		k.repository.username.attribute?
+	k.repository =
+		## The Name of the Repository
+		element repository {
+			k.repository.attlist,
+			k.source
+		}
+}
+
+#==========================================
+# common element <rhelGroup>
+#
+div {
+	k.rhelgroup.name.attribute = k.name.attribute
+	k.rhelgroup.arch.attribute = k.arch.attribute
+	k.rhelgroup.attlist =
+		k.rhelgroup.name.attribute &
+		k.rhelgroup.arch.attribute?
+	k.rhelgroup =
+		## Name of RHEL package group 
+		element rhelGroup {
+			k.rhelgroup.attlist,
+			empty
+		}
+}
+
+#==========================================
+# common element <rpm-check-signatures>
+#
+div {
+	k.rpm-check-signatures.content = xsd:boolean
+	k.rpm-check-signatures.attlist = empty
+	k.rpm-check-signatures =
+		## Setup a Package Signature
+		[
+		db:para [
+			"Setup if the package manager should check the package\x{a}"~
+			"signature or not. This option could be ignored according\x{a}"~
+			"to the used package manager."
+		]
+		]
+		element rpm-check-signatures {
+			k.rpm-check-signatures.attlist,
+			k.rpm-check-signatures.content
+		}
+}
+
+#==========================================
+# common element <rpm-excludedocs>
+#
+div {
+	k.rpm-excludedocs.content = xsd:boolean
+	k.rpm-excludedocs.attlist = empty
+	k.rpm-excludedocs =
+		## Do not install files marked as documentation in the package
+		[
+		db:para [
+			"Setup if the package manager should exclude docs files\x{a}"~
+			"during package installation. This option could be ignored\x{a}"~
+			"according to the used package manager."
+		]
+		]
+		element rpm-excludedocs {
+			k.rpm-excludedocs.attlist,
+			k.rpm-excludedocs.content
+		}
+}
+
+#==========================================
+# common element <rpm-force>
+#
+div {
+	k.rpm-force.content = xsd:boolean
+	k.rpm-force.attlist = empty
+	k.rpm-force =
+		## Force the Installation of a Package
+		[
+		db:para [
+		"Setup if the package manager should force the install\x{a}"~
+		"of the package or not. This option could be ignored\x{a}"~
+		"according to the used package manager."
+		]
+		]
+		element rpm-force {
+			k.rpm-force.attlist,
+			k.rpm-force.content
+		}
+}
+
+#==========================================
+# common element <showlicense>
+#
+div {
+	k.showlicense.attlist = empty
+	k.showlicense =
+		## Setup showlicense
+		[
+		db:para [
+			"Image license setup. The specfied license name\x{a}"~
+			"will be displayed in a dialog window on boot."
+		]
+		]
+		element showlicense {
+			k.showlicense.attlist,
+			text
+		}
+}
+
+#==========================================
 # common element <size>
 #
 div {
@@ -1398,6 +1454,29 @@ div {
 }
 
 #==========================================
+# common element <systemdisk>
+#
+div {
+	k.systemdisk.lvmgroup.attribute =
+		## Specify Volume group name, default is kiwiVG.
+		attribute name { text }
+	k.systemdisk.attlist =
+		k.systemdisk.lvmgroup.attribute?
+
+	k.systemdisk =
+		## Specify LVM volumes other than the root volume
+		[
+		db:para [
+			"Specify LVM volumes other than the root volume."
+		]
+		]
+		element systemdisk {
+			k.systemdisk.attlist &
+			k.volume*
+		}
+}
+
+#==========================================
 # common element <temporary>
 #
 div {
@@ -1426,51 +1505,12 @@ div {
 		## Specifies an ATFTP Download Timeout
 		[
 		db:para [
-			"As part of the network deploy configuration this section \x{a}"~
+			"As part of the network deploy configuration this section\x{a}"~
 			"specifies an ATFTP download timeout"
 		]
 		]
 		element timeout {
 			k.timeout.attlist,
-			text
-		}
-}
-
-#==========================================
-# common element <hwclock>
-#
-div {
-	k.hwclock.content = "utc" | "localtime"
-	k.hwclock.attlist = empty
-	k.hwclock =
-		## Setup Image harware clock setup, either utc or localtime
-		[
-		db:para [
-			"Image hardware clock setup. The value can be either\x{a}"~
-			"set to utc or localtime."
-		]
-		]
-		element hwclock {
-			k.hwclock.attlist,
-			k.hwclock.content
-		}
-}
-
-#==========================================
-# common element <showlicense>
-#
-div {
-	k.showlicense.attlist = empty
-	k.showlicense =
-		## Setup showlicense
-		[
-		db:para [
-			"Image license setup. The specfied license name\x{a}"~
-			"will be displayed in a dialog window on boot."
-		]
-		]
-		element showlicense {
-			k.showlicense.attlist,
 			text
 		}
 }
@@ -1734,68 +1774,6 @@ div {
 }
 
 #==========================================
-# common element <volume>
-#
-div {
-	k.volume.freespace.attribute =
-		## free space to be added to this volume. The value is
-		## used as MB by default but you can add "M" and/or "G" as
-		## postfix
-		attribute freespace { volume-size-type }
-	k.volume.name.attribute =
-		## volume name. The name specifies a path which has to
-		## exist inside the root directory.
-		attribute name { text }
-	k.volume.size.attribute =
-		## absolute size of the volume. If the size value
-		## is too small to store all data it will be ignored.
-		## The value is used as MB by default but you can
-		## add "M" and/or "G" as postfix
-		attribute size { volume-size-type }
-	k.volume.attlist =
-		k.volume.freespace.attribute? &
-		k.volume.name.attribute &
-		k.volume.size.attribute?
-	k.volume =
-		## Specify which parts of the filesystem should be
-		## on an extra volume.
-		[
-		db:para [
-			"Specify which parts of the filesystem should be on\x{a}"
-			"an extra volume."
-		]
-		]
-		element volume {
-			k.volume.attlist,
-			empty
-		}
-}
-
-
-#==========================================
-# common element <systemdisk>
-#
-div {
-	k.systemdisk.lvmgroup.attribute =
-		## Specify Volume group name, default is kiwiVG.
-		attribute name { text }
-	k.systemdisk.attlist =
-		k.systemdisk.lvmgroup.attribute?
-
-	k.systemdisk =
-		## Specify LVM volumes other than the root volume
-		[
-		db:para [
-			"Specify LVM volumes other than the root volume."
-		]
-		]
-		element systemdisk {
-			k.systemdisk.attlist &
-			k.volume*
-		}
-}
-
-#==========================================
 # common element <union>
 #
 div {
@@ -1817,8 +1795,8 @@ div {
 		db:para [
 			"As part of the network deploy configuration this section\x{a}"~
 			"specifies the overlay filesystem setup if required by the\x{a}"~
-			"filesystem type of the system image.An overlay setup is only\x{a}"~
-			"required if the system image uses a squashfs\x{a}"~
+			"filesystem type of the system image.An overlay setup is\x{a}"~
+			"only required if the system image uses a squashfs\x{a}"~
 			"compressed filesystem."
 		]
 		]
@@ -1896,7 +1874,8 @@ div {
 #
 div {
 	k.vmdisk.disktype.attribute =
-		## The type of the disk as it is internally handled by the VM (ovf only)
+		## The type of the disk as it is internally handled
+		## by the VM (ovf only)
 		attribute disktype { text }
 	k.vmdisk.controller.attribute =
 		## The disk controller used for the VM guest (vmdk only)
@@ -1970,6 +1949,45 @@ div {
 			empty
 		}
 }
+
+#==========================================
+# common element <volume>
+#
+div {
+	k.volume.freespace.attribute =
+		## free space to be added to this volume. The value is
+		## used as MB by default but you can add "M" and/or "G" as
+		## postfix
+		attribute freespace { volume-size-type }
+	k.volume.name.attribute =
+		## volume name. The name specifies a path which has to
+		## exist inside the root directory.
+		attribute name { text }
+	k.volume.size.attribute =
+		## absolute size of the volume. If the size value
+		## is too small to store all data it will be ignored.
+		## The value is used as MB by default but you can
+		## add "M" and/or "G" as postfix
+		attribute size { volume-size-type }
+	k.volume.attlist =
+		k.volume.freespace.attribute? &
+		k.volume.name.attribute &
+		k.volume.size.attribute?
+	k.volume =
+		## Specify which parts of the filesystem should be
+		## on an extra volume.
+		[
+		db:para [
+			"Specify which parts of the filesystem should be on\x{a}"
+			"an extra volume."
+		]
+		]
+		element volume {
+			k.volume.attlist,
+			empty
+		}
+}
+
 
 #==========================================
 # main block: <pxedeploy>
@@ -2270,7 +2288,7 @@ div {
 			"The chroot element contains one particular environment\x{a}"~
 			"variable and its value. Shell rules for the names apply.\x{a}"~
 			"The value must not exceed a certain length for sanity.\x{a}"~
-			"reasons Any funny characters like tabs, line break, \x{a}"~
+			"reasons Any funny characters like tabs, line break,\x{a}"~
 			"carriage return or combinations are converted to spaces\x{a}"~
 			"(one each) which may lead to unexpected contents."
 		]
@@ -2555,12 +2573,13 @@ div {
 		]
 		element packages {
 			k.packages.attlist &
+			k.archive* &
+			k.ignore* &
+			k.namedCollection* &
+			k.opensuseproduct* &
 			k.package* &
 			k.opensusepattern* &
-			k.rhelgroup* &
-			k.opensuseproduct* &
-			k.ignore* &
-			k.archive*
+			k.rhelgroup*
 		}
 }
 

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -279,6 +279,34 @@ installation source from</a:documentation>
   </define>
   <!--
     ==========================================
+    common element <archive>
+    
+  -->
+  <div>
+    <define name="k.archive.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.archive.bootinclude.attribute">
+      <ref name="k.bootinclude.attribute"/>
+    </define>
+    <define name="k.archive.attlist">
+      <interleave>
+        <ref name="k.archive.name.attribute"/>
+        <optional>
+          <ref name="k.archive.bootinclude.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.archive">
+      <element name="archive">
+        <a:documentation>Name of an image archive file (tarball)</a:documentation>
+        <ref name="k.archive.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <author>
     
   -->
@@ -290,6 +318,42 @@ installation source from</a:documentation>
       <element name="author">
         <a:documentation>Author of the image</a:documentation>
         <ref name="k.author.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <bootloader-theme>
+    
+  -->
+  <div>
+    <define name="k.bootloader-theme.attlist">
+      <empty/>
+    </define>
+    <define name="k.bootloader-theme">
+      <element name="bootloader-theme">
+        <a:documentation>Image bootloader theme setup.</a:documentation>
+        <db:para>The value will be used in KIWIConfig.sh::suseGFXBoot</db:para>
+        <ref name="k.bootloader-theme.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <bootsplash-theme>
+    
+  -->
+  <div>
+    <define name="k.bootsplash-theme.attlist">
+      <empty/>
+    </define>
+    <define name="k.bootsplash-theme">
+      <element name="bootsplash-theme">
+        <a:documentation>Image bootsplash theme setup.</a:documentation>
+        <db:para>The value will be used in KIWIConfig.sh::suseGFXBoot</db:para>
+        <ref name="k.bootsplash-theme.attlist"/>
         <text/>
       </element>
     </define>
@@ -464,10 +528,30 @@ cert-*.pem</a:documentation>
         <a:documentation>Specify the region/availability zone</a:documentation>
         <db:para>Specify the region/availability zone in EC2 for this image.
 Values are limited to the EC2 recognized zones:
-AP-Northeast, AP-Southeast, EU-West, SA-East, US-East, 
+AP-Northeast, AP-Southeast, EU-West, SA-East, US-East,
 US-West, and US-West2</db:para>
         <ref name="k.ec2region.attlist"/>
         <text/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <except>
+    
+  -->
+  <div>
+    <define name="k.except.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.except.attlist">
+      <ref name="k.except.name.attribute"/>
+    </define>
+    <define name="k.except">
+      <element name="except">
+        <a:documentation>A Pointer to a File which should be excluded</a:documentation>
+        <ref name="k.except.attlist"/>
+        <empty/>
       </element>
     </define>
   </div>
@@ -501,21 +585,26 @@ US-West, and US-West2</db:para>
   </div>
   <!--
     ==========================================
-    common element <except>
+    common element <hwclock>
     
   -->
   <div>
-    <define name="k.except.name.attribute">
-      <ref name="k.name.attribute"/>
+    <define name="k.hwclock.content">
+      <choice>
+        <value>utc</value>
+        <value>localtime</value>
+      </choice>
     </define>
-    <define name="k.except.attlist">
-      <ref name="k.except.name.attribute"/>
+    <define name="k.hwclock.attlist">
+      <empty/>
     </define>
-    <define name="k.except">
-      <element name="except">
-        <a:documentation>A Pointer to a File which should be excluded</a:documentation>
-        <ref name="k.except.attlist"/>
-        <empty/>
+    <define name="k.hwclock">
+      <element name="hwclock">
+        <a:documentation>Setup Image harware clock setup, either utc or localtime</a:documentation>
+        <db:para>Image hardware clock setup. The value can be either
+set to utc or localtime.</db:para>
+        <ref name="k.hwclock.attlist"/>
+        <ref name="k.hwclock.content"/>
       </element>
     </define>
   </div>
@@ -674,42 +763,6 @@ specifies the where to find the boot kernel.</db:para>
   </div>
   <!--
     ==========================================
-    common element <bootloader-theme>
-    
-  -->
-  <div>
-    <define name="k.bootloader-theme.attlist">
-      <empty/>
-    </define>
-    <define name="k.bootloader-theme">
-      <element name="bootloader-theme">
-        <a:documentation>Image bootloader theme setup.</a:documentation>
-        <db:para>The value will be used in KIWIConfig.sh::suseGFXBoot</db:para>
-        <ref name="k.bootloader-theme.attlist"/>
-        <text/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <bootsplash-theme>
-    
-  -->
-  <div>
-    <define name="k.bootsplash-theme.attlist">
-      <empty/>
-    </define>
-    <define name="k.bootsplash-theme">
-      <element name="bootsplash-theme">
-        <a:documentation>Image bootsplash theme setup.</a:documentation>
-        <db:para>The value will be used in KIWIConfig.sh::suseGFXBoot</db:para>
-        <ref name="k.bootsplash-theme.attlist"/>
-        <text/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
     common element <metadata>
     
   -->
@@ -776,627 +829,29 @@ archive is extracted in a specific way.</db:para>
   </div>
   <!--
     ==========================================
-    common element <opensusePattern>
+    common element <namedCollection>
     
   -->
   <div>
-    <define name="k.opensusepattern.name.attribute">
+    <define name="k.namedCollection.name.attribute">
       <ref name="k.name.attribute"/>
     </define>
-    <define name="k.opensusepattern.arch.attribute">
+    <define name="k.namedCollection.arch.attribute">
       <ref name="k.arch.attribute"/>
     </define>
-    <define name="k.opensusepattern.attlist">
+    <define name="k.namedCollection.attlist">
       <interleave>
-        <ref name="k.opensusepattern.name.attribute"/>
+        <ref name="k.namedCollection.name.attribute"/>
         <optional>
-          <ref name="k.opensusepattern.arch.attribute"/>
+          <ref name="k.namedCollection.arch.attribute"/>
         </optional>
       </interleave>
     </define>
-    <define name="k.opensusepattern">
-      <element name="opensusePattern">
-        <a:documentation>Name of a Pattern From openSUSE</a:documentation>
-        <ref name="k.opensusepattern.attlist"/>
+    <define name="k.namedCollection">
+      <element name="namedCollection">
+        <a:documentation>Name of a Pattern for SUSE or a Group for RH</a:documentation>
+        <ref name="k.namedCollection.attlist"/>
         <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <rhelGroup>
-    
-  -->
-  <div>
-    <define name="k.rhelgroup.name.attribute">
-      <ref name="k.name.attribute"/>
-    </define>
-    <define name="k.rhelgroup.arch.attribute">
-      <ref name="k.arch.attribute"/>
-    </define>
-    <define name="k.rhelgroup.attlist">
-      <interleave>
-        <ref name="k.rhelgroup.name.attribute"/>
-        <optional>
-          <ref name="k.rhelgroup.arch.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.rhelgroup">
-      <element name="rhelGroup">
-        <a:documentation>Name of RHEL package group </a:documentation>
-        <ref name="k.rhelgroup.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <opensuseProduct>
-    
-  -->
-  <div>
-    <define name="k.opensuseproduct.name.attribute">
-      <ref name="k.name.attribute"/>
-    </define>
-    <define name="k.opensuseproduct.arch.attribute">
-      <ref name="k.arch.attribute"/>
-    </define>
-    <define name="k.opensuseproduct.attlist">
-      <interleave>
-        <ref name="k.opensuseproduct.name.attribute"/>
-        <optional>
-          <ref name="k.opensuseproduct.arch.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.opensuseproduct">
-      <element name="opensuseProduct">
-        <a:documentation>Name of a Product From openSUSE</a:documentation>
-        <ref name="k.opensuseproduct.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <repopackage>
-    
-  -->
-  <div>
-    <define name="k.repopackage.name.attribute">
-      <ref name="k.name.attribute"/>
-    </define>
-    <define name="k.repopackage.arch.attribute">
-      <ref name="k.arch.attribute"/>
-    </define>
-    <define name="k.repopackage.forcerepo.attribute">
-      <attribute name="forcerepo">
-        <a:documentation>Specifies the search priority</a:documentation>
-        <data type="IDREF"/>
-      </attribute>
-    </define>
-    <define name="k.repopackage.addarch.attribute">
-      <attribute name="addarch">
-        <a:documentation>Specifies that this package should
-additionally add the same package from the given arch</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.repopackage.removearch.attribute">
-      <attribute name="removearch">
-        <a:documentation>Specifies that the package with the
-given arch should be removed</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.repopackage.onlyarch.attribute">
-      <attribute name="onlyarch">
-        <a:documentation>Specifies that the package with
-the given arch should be used in any case</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.repopackage.medium.attribute">
-      <attribute name="medium">
-        <a:documentation>Specifies that the package will be put
-to the specific medium number (CD1, DVD7, ...)</a:documentation>
-        <data type="nonNegativeInteger"/>
-      </attribute>
-    </define>
-    <define name="k.repopackage.source.attribute">
-      <ref name="k.source.attribute"/>
-    </define>
-    <define name="k.repopackage.script.attribute">
-      <ref name="k.script.attribute"/>
-    </define>
-    <define name="k.repopackage.attlist">
-      <interleave>
-        <ref name="k.repopackage.name.attribute"/>
-        <optional>
-          <ref name="k.repopackage.arch.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repopackage.forcerepo.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repopackage.addarch.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repopackage.removearch.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repopackage.onlyarch.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repopackage.source.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repopackage.script.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repopackage.medium.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.repopackage">
-      <element name="repopackage">
-        <a:documentation>Name of an instsource Package</a:documentation>
-        <ref name="k.repopackage.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <package>
-    
-  -->
-  <div>
-    <define name="k.package.name.attribute">
-      <ref name="k.name.attribute"/>
-    </define>
-    <define name="k.package.arch.attribute">
-      <ref name="k.arch.attribute"/>
-    </define>
-    <define name="k.package.replaces.attribute">
-      <ref name="k.replaces.attribute"/>
-    </define>
-    <define name="k.package.bootinclude.attribute">
-      <ref name="k.bootinclude.attribute"/>
-    </define>
-    <define name="k.package.bootdelete.attribute">
-      <ref name="k.bootdelete.attribute"/>
-    </define>
-    <define name="k.package.attlist">
-      <interleave>
-        <ref name="k.package.name.attribute"/>
-        <optional>
-          <ref name="k.package.arch.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.replaces.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.bootdelete.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.bootinclude.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.package">
-      <element name="package">
-        <a:documentation>Name of an image Package</a:documentation>
-        <ref name="k.package.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <archive>
-    
-  -->
-  <div>
-    <define name="k.archive.name.attribute">
-      <ref name="k.name.attribute"/>
-    </define>
-    <define name="k.archive.bootinclude.attribute">
-      <ref name="k.bootinclude.attribute"/>
-    </define>
-    <define name="k.archive.attlist">
-      <interleave>
-        <ref name="k.archive.name.attribute"/>
-        <optional>
-          <ref name="k.archive.bootinclude.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.archive">
-      <element name="archive">
-        <a:documentation>Name of an image archive file (tarball)</a:documentation>
-        <ref name="k.archive.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <packagemanager>
-    
-  -->
-  <div>
-    <define name="k.packagemanager.content">
-      <choice>
-        <value>apt-get</value>
-        <value>smart</value>
-        <value>zypper</value>
-        <value>ensconce</value>
-        <value>yum</value>
-      </choice>
-    </define>
-    <define name="k.packagemanager.attlist">
-      <empty/>
-    </define>
-    <define name="k.packagemanager">
-      <element name="packagemanager">
-        <a:documentation>Name of the Package Manager</a:documentation>
-        <db:para>The package manager used for package installation
-could be either zypper or smart</db:para>
-        <ref name="k.packagemanager.attlist"/>
-        <ref name="k.packagemanager.content"/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <partitions>
-    
-  -->
-  <div>
-    <define name="k.partitions.device.attribute">
-      <attribute name="device">
-        <a:documentation>As part of the network deploy configuration this section
-specifies the disk device name</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.partitions.attlist">
-      <optional>
-        <ref name="k.partitions.device.attribute"/>
-      </optional>
-    </define>
-    <define name="k.partitions">
-      <element name="partitions">
-        <a:documentation>A List of Partitions</a:documentation>
-        <ref name="k.partitions.attlist"/>
-        <oneOrMore>
-          <ref name="k.partition"/>
-        </oneOrMore>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <partition>
-    
-  -->
-  <div>
-    <define name="k.partition.type.attribute">
-      <attribute name="type">
-        <a:documentation>Partition Type identifier, see parted for details</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.partition.number.attribute">
-      <attribute name="number">
-        <a:documentation>Partition ID</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.partition.size.attribute">
-      <ref name="k.size.attribute"/>
-    </define>
-    <define name="k.partition.mountpoint.attribute">
-      <attribute name="mountpoint">
-        <a:documentation>Mount path for this partition</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.partition.target.attribute">
-      <attribute name="target">
-        <a:documentation>Is a real target or not which means is part of
-the /etc/fstab file or not</a:documentation>
-        <data type="boolean"/>
-      </attribute>
-    </define>
-    <define name="k.partition.attlist">
-      <interleave>
-        <ref name="k.partition.type.attribute"/>
-        <ref name="k.partition.number.attribute"/>
-        <optional>
-          <ref name="k.partition.size.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.partition.mountpoint.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.partition.target.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.partition">
-      <element name="partition">
-        <a:documentation>A Partition</a:documentation>
-        <ref name="k.partition.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <persistent>
-    
-  -->
-  <div>
-    <define name="k.persistent.attlist">
-      <empty/>
-    </define>
-    <define name="k.persistent">
-      <element name="persistent">
-        <a:documentation>Specifies Filenames in the Read-Write Disk Area</a:documentation>
-        <db:para>As part of the split section the persistent element
-specifies filenames which are in the read-write disk area</db:para>
-        <interleave>
-          <ref name="k.persistent.attlist"/>
-          <zeroOrMore>
-            <ref name="k.except"/>
-          </zeroOrMore>
-          <oneOrMore>
-            <ref name="k.file"/>
-          </oneOrMore>
-        </interleave>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <profile>
-    
-  -->
-  <div>
-    <define name="k.profile.name.attribute">
-      <ref name="k.name.attribute"/>
-    </define>
-    <define name="k.profile.description.attribute">
-      <attribute name="description">
-        <a:documentation>Description of how this profiles influences the image</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.profile.import.attribute">
-      <attribute name="import">
-        <a:documentation>Import profile by default if no profile was set on
-the command line</a:documentation>
-        <data type="boolean"/>
-      </attribute>
-    </define>
-    <define name="k.profile.attlist">
-      <interleave>
-        <ref name="k.profile.name.attribute"/>
-        <ref name="k.profile.description.attribute"/>
-        <optional>
-          <ref name="k.profile.import.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.profile">
-      <element name="profile">
-        <a:documentation>Creates Profiles</a:documentation>
-        <db:para>Profiles creates a namespace on an image description and
-thus can be used to have one description with different
-profiles for example KDE and GNOME including different
-packages.</db:para>
-        <ref name="k.profile.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <repository>
-    
-  -->
-  <div>
-    <define name="k.repository.profiles.attribute">
-      <ref name="k.profiles.attribute"/>
-    </define>
-    <define name="k.repository.type.attribute">
-      <attribute name="type">
-        <a:documentation>Type of repository</a:documentation>
-        <choice>
-          <value>apt-deb</value>
-          <value>apt-rpm</value>
-          <value>deb-dir</value>
-          <value>mirrors</value>
-          <value>red-carpet</value>
-          <value>rpm-dir</value>
-          <value>rpm-md</value>
-          <value>slack-site</value>
-          <value>up2date-mirrors</value>
-          <value>urpmi</value>
-          <value>yast2</value>
-        </choice>
-      </attribute>
-    </define>
-    <define name="k.repository.status.attribute">
-      <attribute name="status">
-        <a:documentation>Specifies the status of the repository. This can be
-replacable or if not specified it's a must have repository</a:documentation>
-        <choice>
-          <value>fixed</value>
-          <value>replaceable</value>
-        </choice>
-      </attribute>
-    </define>
-    <define name="k.repository.alias.attribute">
-      <attribute name="alias">
-        <a:documentation>Alias name to be used for this repository. This is an
-optional free form text. If not set the source attribute
-value is used and builds the alias name by replacing
-each '/' with a '_'. An alias name should be set if the
-source argument doesn't really explain what this repository
-contains</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.repository.components.attribute">
-      <attribute name="components">
-        <a:documentation>Distribution components, used for deb repositories. If
-not set it defaults to main</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.repository.distribution.attribute">
-      <attribute name="distribution">
-        <a:documentation>Distribution name information, used for deb repositories</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.repository.imageinclude.attribute">
-      <attribute name="imageinclude">
-        <a:documentation>Specify whether or not this repository should be configured in the
-resulting image. Boolean value true or false, the default is false.</a:documentation>
-        <data type="boolean"/>
-      </attribute>
-    </define>
-    <define name="k.repository.prefer-license.attribute">
-      <attribute name="prefer-license">
-        <a:documentation>Use the license found in this repository, if any, as the
-license installed in the image</a:documentation>
-        <data type="boolean"/>
-      </attribute>
-    </define>
-    <define name="k.repository.priority.attribute">
-      <attribute name="priority">
-        <a:documentation>Channel priority assigned to all packages available in
-this channel (0 if not set). If the exact same package
-is available in more than one channel, the highest
-priority is used</a:documentation>
-        <data type="integer"/>
-      </attribute>
-    </define>
-    <define name="k.repository.password.attribute">
-      <ref name="k.password.attribute">
-        <a:documentation>Channel password if required. It depends on the url type
-whether and how this information is passed</a:documentation>
-      </ref>
-    </define>
-    <define name="k.repository.username.attribute">
-      <ref name="k.username.attribute">
-        <a:documentation>Channel username if required. It depends on the url type
-whether and how this information is passed</a:documentation>
-      </ref>
-    </define>
-    <define name="k.repository.attlist">
-      <interleave>
-        <ref name="k.repository.type.attribute"/>
-        <optional>
-          <ref name="k.repository.profiles.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.status.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.alias.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.components.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.distribution.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.imageinclude.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.prefer-license.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.priority.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.password.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.repository.username.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.repository">
-      <element name="repository">
-        <a:documentation>The Name of the Repository</a:documentation>
-        <ref name="k.repository.attlist"/>
-        <ref name="k.source"/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <rpm-check-signatures>
-    
-  -->
-  <div>
-    <define name="k.rpm-check-signatures.content">
-      <data type="boolean"/>
-    </define>
-    <define name="k.rpm-check-signatures.attlist">
-      <empty/>
-    </define>
-    <define name="k.rpm-check-signatures">
-      <element name="rpm-check-signatures">
-        <a:documentation>Setup a Package Signature</a:documentation>
-        <db:para>Setup if the package manager should check the package
-signature or not. This option could be ignored according
-to the used package manager.</db:para>
-        <ref name="k.rpm-check-signatures.attlist"/>
-        <ref name="k.rpm-check-signatures.content"/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <rpm-excludedocs>
-    
-  -->
-  <div>
-    <define name="k.rpm-excludedocs.content">
-      <data type="boolean"/>
-    </define>
-    <define name="k.rpm-excludedocs.attlist">
-      <empty/>
-    </define>
-    <define name="k.rpm-excludedocs">
-      <element name="rpm-excludedocs">
-        <a:documentation>Do not install files marked as documentation in the package</a:documentation>
-        <db:para>Setup if the package manager should exclude docs files
-during package installation. This option could be ignored
-according to the used package manager.</db:para>
-        <ref name="k.rpm-excludedocs.attlist"/>
-        <ref name="k.rpm-excludedocs.content"/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <rpm-force>
-    
-  -->
-  <div>
-    <define name="k.rpm-force.content">
-      <data type="boolean"/>
-    </define>
-    <define name="k.rpm-force.attlist">
-      <empty/>
-    </define>
-    <define name="k.rpm-force">
-      <element name="rpm-force">
-        <a:documentation>Force the Installation of a Package</a:documentation>
-        <db:para>Setup if the package manager should force the install of the
-package or not. This option could be ignored according
-to the used package manager.</db:para>
-        <ref name="k.rpm-force.attlist"/>
-        <ref name="k.rpm-force.content"/>
       </element>
     </define>
   </div>
@@ -1628,28 +1083,6 @@ recovery partition. Default value is 83 (Linux)</db:para>
   </div>
   <!--
     ==========================================
-    common element <oem-silent-boot>
-    
-  -->
-  <div>
-    <define name="k.oem-silent-boot.content">
-      <data type="boolean"/>
-    </define>
-    <define name="k.oem-silent-boot.attlist">
-      <empty/>
-    </define>
-    <define name="k.oem-silent-boot">
-      <element name="oem-silent-boot">
-        <a:documentation>For oemboot driven images: boot silently during the initial boot
-true/false</a:documentation>
-        <db:para>For oemboot driven images: complete the initial boot of the system in silent mode, true/false. </db:para>
-        <ref name="k.oem-silent-boot.attlist"/>
-        <ref name="k.oem-silent-boot.content"/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
     common element <oem-shutdown>
     
   -->
@@ -1689,6 +1122,28 @@ true/false</a:documentation>
         <db:para>For oemboot driven images: shutdown after first deployment true/false. A message to be acknowledged by the user is posted after the image has been dumped (installed) and expanded on the target disk. After user interaction the system is shutdown.</db:para>
         <ref name="k.oem-shutdown-interactive.attlist"/>
         <ref name="k.oem-shutdown-interactive.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <oem-silent-boot>
+    
+  -->
+  <div>
+    <define name="k.oem-silent-boot.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.oem-silent-boot.attlist">
+      <empty/>
+    </define>
+    <define name="k.oem-silent-boot">
+      <element name="oem-silent-boot">
+        <a:documentation>For oemboot driven images: boot silently during the initial boot
+true/false</a:documentation>
+        <db:para>For oemboot driven images: complete the initial boot of the system in silent mode, true/false. </db:para>
+        <ref name="k.oem-silent-boot.attlist"/>
+        <ref name="k.oem-silent-boot.content"/>
       </element>
     </define>
   </div>
@@ -1797,6 +1252,623 @@ or by default with /dev/disk/by-id/...</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <opensusePattern>
+    
+  -->
+  <div>
+    <define name="k.opensusepattern.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.opensusepattern.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
+    <define name="k.opensusepattern.attlist">
+      <interleave>
+        <ref name="k.opensusepattern.name.attribute"/>
+        <optional>
+          <ref name="k.opensusepattern.arch.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.opensusepattern">
+      <element name="opensusePattern">
+        <a:documentation>Name of a Pattern From openSUSE</a:documentation>
+        <ref name="k.opensusepattern.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <opensuseProduct>
+    
+  -->
+  <div>
+    <define name="k.opensuseproduct.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.opensuseproduct.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
+    <define name="k.opensuseproduct.attlist">
+      <interleave>
+        <ref name="k.opensuseproduct.name.attribute"/>
+        <optional>
+          <ref name="k.opensuseproduct.arch.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.opensuseproduct">
+      <element name="opensuseProduct">
+        <a:documentation>Name of a Product From openSUSE</a:documentation>
+        <ref name="k.opensuseproduct.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <package>
+    
+  -->
+  <div>
+    <define name="k.package.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.package.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
+    <define name="k.package.replaces.attribute">
+      <ref name="k.replaces.attribute"/>
+    </define>
+    <define name="k.package.bootinclude.attribute">
+      <ref name="k.bootinclude.attribute"/>
+    </define>
+    <define name="k.package.bootdelete.attribute">
+      <ref name="k.bootdelete.attribute"/>
+    </define>
+    <define name="k.package.attlist">
+      <interleave>
+        <ref name="k.package.name.attribute"/>
+        <optional>
+          <ref name="k.package.arch.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.replaces.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.bootdelete.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.bootinclude.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.package">
+      <element name="package">
+        <a:documentation>Name of an image Package</a:documentation>
+        <ref name="k.package.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <packagemanager>
+    
+  -->
+  <div>
+    <define name="k.packagemanager.content">
+      <choice>
+        <value>apt-get</value>
+        <value>smart</value>
+        <value>zypper</value>
+        <value>ensconce</value>
+        <value>yum</value>
+      </choice>
+    </define>
+    <define name="k.packagemanager.attlist">
+      <empty/>
+    </define>
+    <define name="k.packagemanager">
+      <element name="packagemanager">
+        <a:documentation>Name of the Package Manager</a:documentation>
+        <db:para>The package manager used for package installation
+could be either zypper or smart</db:para>
+        <ref name="k.packagemanager.attlist"/>
+        <ref name="k.packagemanager.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <partition>
+    
+  -->
+  <div>
+    <define name="k.partition.type.attribute">
+      <attribute name="type">
+        <a:documentation>Partition Type identifier, see parted for details</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.partition.number.attribute">
+      <attribute name="number">
+        <a:documentation>Partition ID</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.partition.size.attribute">
+      <ref name="k.size.attribute"/>
+    </define>
+    <define name="k.partition.mountpoint.attribute">
+      <attribute name="mountpoint">
+        <a:documentation>Mount path for this partition</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.partition.target.attribute">
+      <attribute name="target">
+        <a:documentation>Is a real target or not which means is part of
+the /etc/fstab file or not</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
+    <define name="k.partition.attlist">
+      <interleave>
+        <ref name="k.partition.type.attribute"/>
+        <ref name="k.partition.number.attribute"/>
+        <optional>
+          <ref name="k.partition.size.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.partition.mountpoint.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.partition.target.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.partition">
+      <element name="partition">
+        <a:documentation>A Partition</a:documentation>
+        <ref name="k.partition.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <partitions>
+    
+  -->
+  <div>
+    <define name="k.partitions.device.attribute">
+      <attribute name="device">
+        <a:documentation>As part of the network deploy configuration this section
+specifies the disk device name</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.partitions.attlist">
+      <optional>
+        <ref name="k.partitions.device.attribute"/>
+      </optional>
+    </define>
+    <define name="k.partitions">
+      <element name="partitions">
+        <a:documentation>A List of Partitions</a:documentation>
+        <ref name="k.partitions.attlist"/>
+        <oneOrMore>
+          <ref name="k.partition"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <persistent>
+    
+  -->
+  <div>
+    <define name="k.persistent.attlist">
+      <empty/>
+    </define>
+    <define name="k.persistent">
+      <element name="persistent">
+        <a:documentation>Specifies Filenames in the Read-Write Disk Area</a:documentation>
+        <db:para>As part of the split section the persistent element
+specifies filenames which are in the read-write disk area</db:para>
+        <interleave>
+          <ref name="k.persistent.attlist"/>
+          <zeroOrMore>
+            <ref name="k.except"/>
+          </zeroOrMore>
+          <oneOrMore>
+            <ref name="k.file"/>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <profile>
+    
+  -->
+  <div>
+    <define name="k.profile.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.profile.description.attribute">
+      <attribute name="description">
+        <a:documentation>Description of how this profiles influences the image</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.profile.import.attribute">
+      <attribute name="import">
+        <a:documentation>Import profile by default if no profile was set on
+the command line</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
+    <define name="k.profile.attlist">
+      <interleave>
+        <ref name="k.profile.name.attribute"/>
+        <ref name="k.profile.description.attribute"/>
+        <optional>
+          <ref name="k.profile.import.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.profile">
+      <element name="profile">
+        <a:documentation>Creates Profiles</a:documentation>
+        <db:para>Profiles creates a namespace on an image description and
+thus can be used to have one description with different
+profiles for example KDE and GNOME including different
+packages.</db:para>
+        <ref name="k.profile.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <repopackage>
+    
+  -->
+  <div>
+    <define name="k.repopackage.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.repopackage.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
+    <define name="k.repopackage.forcerepo.attribute">
+      <attribute name="forcerepo">
+        <a:documentation>Specifies the search priority</a:documentation>
+        <data type="IDREF"/>
+      </attribute>
+    </define>
+    <define name="k.repopackage.addarch.attribute">
+      <attribute name="addarch">
+        <a:documentation>Specifies that this package should
+additionally add the same package from the given arch</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.repopackage.removearch.attribute">
+      <attribute name="removearch">
+        <a:documentation>Specifies that the package with the
+given arch should be removed</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.repopackage.onlyarch.attribute">
+      <attribute name="onlyarch">
+        <a:documentation>Specifies that the package with
+the given arch should be used in any case</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.repopackage.medium.attribute">
+      <attribute name="medium">
+        <a:documentation>Specifies that the package will be put
+to the specific medium number (CD1, DVD7, ...)</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+    </define>
+    <define name="k.repopackage.source.attribute">
+      <ref name="k.source.attribute"/>
+    </define>
+    <define name="k.repopackage.script.attribute">
+      <ref name="k.script.attribute"/>
+    </define>
+    <define name="k.repopackage.attlist">
+      <interleave>
+        <ref name="k.repopackage.name.attribute"/>
+        <optional>
+          <ref name="k.repopackage.arch.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repopackage.forcerepo.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repopackage.addarch.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repopackage.removearch.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repopackage.onlyarch.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repopackage.source.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repopackage.script.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repopackage.medium.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.repopackage">
+      <element name="repopackage">
+        <a:documentation>Name of an instsource Package</a:documentation>
+        <ref name="k.repopackage.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <repository>
+    
+  -->
+  <div>
+    <define name="k.repository.profiles.attribute">
+      <ref name="k.profiles.attribute"/>
+    </define>
+    <define name="k.repository.type.attribute">
+      <attribute name="type">
+        <a:documentation>Type of repository</a:documentation>
+        <choice>
+          <value>apt-deb</value>
+          <value>apt-rpm</value>
+          <value>deb-dir</value>
+          <value>mirrors</value>
+          <value>red-carpet</value>
+          <value>rpm-dir</value>
+          <value>rpm-md</value>
+          <value>slack-site</value>
+          <value>up2date-mirrors</value>
+          <value>urpmi</value>
+          <value>yast2</value>
+        </choice>
+      </attribute>
+    </define>
+    <define name="k.repository.status.attribute">
+      <attribute name="status">
+        <a:documentation>Specifies the status of the repository. This can be
+replacable or if not specified it's a must have repository</a:documentation>
+        <choice>
+          <value>fixed</value>
+          <value>replaceable</value>
+        </choice>
+      </attribute>
+    </define>
+    <define name="k.repository.alias.attribute">
+      <attribute name="alias">
+        <a:documentation>Alias name to be used for this repository. This is an
+optional free form text. If not set the source attribute
+value is used and builds the alias name by replacing
+each '/' with a '_'. An alias name should be set if the
+source argument doesn't really explain what this repository
+contains</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.repository.components.attribute">
+      <attribute name="components">
+        <a:documentation>Distribution components, used for deb repositories. If
+not set it defaults to main</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.repository.distribution.attribute">
+      <attribute name="distribution">
+        <a:documentation>Distribution name information, used for deb repositories</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.repository.imageinclude.attribute">
+      <attribute name="imageinclude">
+        <a:documentation>Specify whether or not this repository should be configured in the
+resulting image. Boolean value true or false, the default is false.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
+    <define name="k.repository.prefer-license.attribute">
+      <attribute name="prefer-license">
+        <a:documentation>Use the license found in this repository, if any, as the
+license installed in the image</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
+    <define name="k.repository.priority.attribute">
+      <attribute name="priority">
+        <a:documentation>Channel priority assigned to all packages available in
+this channel (0 if not set). If the exact same package
+is available in more than one channel, the highest
+priority is used</a:documentation>
+        <data type="integer"/>
+      </attribute>
+    </define>
+    <define name="k.repository.password.attribute">
+      <ref name="k.password.attribute">
+        <a:documentation>Channel password if required. It depends on the url type
+whether and how this information is passed</a:documentation>
+      </ref>
+    </define>
+    <define name="k.repository.username.attribute">
+      <ref name="k.username.attribute">
+        <a:documentation>Channel username if required. It depends on the url type
+whether and how this information is passed</a:documentation>
+      </ref>
+    </define>
+    <define name="k.repository.attlist">
+      <interleave>
+        <ref name="k.repository.type.attribute"/>
+        <optional>
+          <ref name="k.repository.profiles.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.status.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.alias.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.components.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.distribution.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.imageinclude.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.prefer-license.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.priority.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.password.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.username.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.repository">
+      <element name="repository">
+        <a:documentation>The Name of the Repository</a:documentation>
+        <ref name="k.repository.attlist"/>
+        <ref name="k.source"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <rhelGroup>
+    
+  -->
+  <div>
+    <define name="k.rhelgroup.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.rhelgroup.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
+    <define name="k.rhelgroup.attlist">
+      <interleave>
+        <ref name="k.rhelgroup.name.attribute"/>
+        <optional>
+          <ref name="k.rhelgroup.arch.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.rhelgroup">
+      <element name="rhelGroup">
+        <a:documentation>Name of RHEL package group </a:documentation>
+        <ref name="k.rhelgroup.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <rpm-check-signatures>
+    
+  -->
+  <div>
+    <define name="k.rpm-check-signatures.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.rpm-check-signatures.attlist">
+      <empty/>
+    </define>
+    <define name="k.rpm-check-signatures">
+      <element name="rpm-check-signatures">
+        <a:documentation>Setup a Package Signature</a:documentation>
+        <db:para>Setup if the package manager should check the package
+signature or not. This option could be ignored according
+to the used package manager.</db:para>
+        <ref name="k.rpm-check-signatures.attlist"/>
+        <ref name="k.rpm-check-signatures.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <rpm-excludedocs>
+    
+  -->
+  <div>
+    <define name="k.rpm-excludedocs.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.rpm-excludedocs.attlist">
+      <empty/>
+    </define>
+    <define name="k.rpm-excludedocs">
+      <element name="rpm-excludedocs">
+        <a:documentation>Do not install files marked as documentation in the package</a:documentation>
+        <db:para>Setup if the package manager should exclude docs files
+during package installation. This option could be ignored
+according to the used package manager.</db:para>
+        <ref name="k.rpm-excludedocs.attlist"/>
+        <ref name="k.rpm-excludedocs.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <rpm-force>
+    
+  -->
+  <div>
+    <define name="k.rpm-force.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.rpm-force.attlist">
+      <empty/>
+    </define>
+    <define name="k.rpm-force">
+      <element name="rpm-force">
+        <a:documentation>Force the Installation of a Package</a:documentation>
+        <db:para>Setup if the package manager should force the install
+of the package or not. This option could be ignored
+according to the used package manager.</db:para>
+        <ref name="k.rpm-force.attlist"/>
+        <ref name="k.rpm-force.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <showlicense>
+    
+  -->
+  <div>
+    <define name="k.showlicense.attlist">
+      <empty/>
+    </define>
+    <define name="k.showlicense">
+      <element name="showlicense">
+        <a:documentation>Setup showlicense</a:documentation>
+        <db:para>Image license setup. The specfied license name
+will be displayed in a dialog window on boot.</db:para>
+        <ref name="k.showlicense.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <size>
     
   -->
@@ -1876,6 +1948,35 @@ used for.</db:para>
   </div>
   <!--
     ==========================================
+    common element <systemdisk>
+    
+  -->
+  <div>
+    <define name="k.systemdisk.lvmgroup.attribute">
+      <attribute name="name">
+        <a:documentation>Specify Volume group name, default is kiwiVG.</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.systemdisk.attlist">
+      <optional>
+        <ref name="k.systemdisk.lvmgroup.attribute"/>
+      </optional>
+    </define>
+    <define name="k.systemdisk">
+      <element name="systemdisk">
+        <a:documentation>Specify LVM volumes other than the root volume</a:documentation>
+        <db:para>Specify LVM volumes other than the root volume.</db:para>
+        <interleave>
+          <ref name="k.systemdisk.attlist"/>
+          <zeroOrMore>
+            <ref name="k.volume"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <temporary>
     
   -->
@@ -1912,53 +2013,9 @@ specifies file names which are in the RAM disk area.</db:para>
     <define name="k.timeout">
       <element name="timeout">
         <a:documentation>Specifies an ATFTP Download Timeout</a:documentation>
-        <db:para>As part of the network deploy configuration this section 
+        <db:para>As part of the network deploy configuration this section
 specifies an ATFTP download timeout</db:para>
         <ref name="k.timeout.attlist"/>
-        <text/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <hwclock>
-    
-  -->
-  <div>
-    <define name="k.hwclock.content">
-      <choice>
-        <value>utc</value>
-        <value>localtime</value>
-      </choice>
-    </define>
-    <define name="k.hwclock.attlist">
-      <empty/>
-    </define>
-    <define name="k.hwclock">
-      <element name="hwclock">
-        <a:documentation>Setup Image harware clock setup, either utc or localtime</a:documentation>
-        <db:para>Image hardware clock setup. The value can be either
-set to utc or localtime.</db:para>
-        <ref name="k.hwclock.attlist"/>
-        <ref name="k.hwclock.content"/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <showlicense>
-    
-  -->
-  <div>
-    <define name="k.showlicense.attlist">
-      <empty/>
-    </define>
-    <define name="k.showlicense">
-      <element name="showlicense">
-        <a:documentation>Setup showlicense</a:documentation>
-        <db:para>Image license setup. The specfied license name
-will be displayed in a dialog window on boot.</db:para>
-        <ref name="k.showlicense.attlist"/>
         <text/>
       </element>
     </define>
@@ -2465,86 +2522,6 @@ into the master block. There is space for 32 characters.</a:documentation>
   </div>
   <!--
     ==========================================
-    common element <volume>
-    
-  -->
-  <div>
-    <define name="k.volume.freespace.attribute">
-      <attribute name="freespace">
-        <a:documentation>free space to be added to this volume. The value is
-used as MB by default but you can add "M" and/or "G" as
-postfix</a:documentation>
-        <ref name="volume-size-type"/>
-      </attribute>
-    </define>
-    <define name="k.volume.name.attribute">
-      <attribute name="name">
-        <a:documentation>volume name. The name specifies a path which has to
-exist inside the root directory.</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.volume.size.attribute">
-      <attribute name="size">
-        <a:documentation>absolute size of the volume. If the size value
-is too small to store all data it will be ignored.
-The value is used as MB by default but you can
-add "M" and/or "G" as postfix</a:documentation>
-        <ref name="volume-size-type"/>
-      </attribute>
-    </define>
-    <define name="k.volume.attlist">
-      <interleave>
-        <optional>
-          <ref name="k.volume.freespace.attribute"/>
-        </optional>
-        <ref name="k.volume.name.attribute"/>
-        <optional>
-          <ref name="k.volume.size.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.volume">
-      <element name="volume">
-        <a:documentation>Specify which parts of the filesystem should be
-on an extra volume.</a:documentation>
-        <db:para>Specify which parts of the filesystem should be on
-an extra volume.</db:para>
-        <ref name="k.volume.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <systemdisk>
-    
-  -->
-  <div>
-    <define name="k.systemdisk.lvmgroup.attribute">
-      <attribute name="name">
-        <a:documentation>Specify Volume group name, default is kiwiVG.</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.systemdisk.attlist">
-      <optional>
-        <ref name="k.systemdisk.lvmgroup.attribute"/>
-      </optional>
-    </define>
-    <define name="k.systemdisk">
-      <element name="systemdisk">
-        <a:documentation>Specify LVM volumes other than the root volume</a:documentation>
-        <db:para>Specify LVM volumes other than the root volume.</db:para>
-        <interleave>
-          <ref name="k.systemdisk.attlist"/>
-          <zeroOrMore>
-            <ref name="k.volume"/>
-          </zeroOrMore>
-        </interleave>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
     common element <union>
     
   -->
@@ -2576,8 +2553,8 @@ an extra volume.</db:para>
         <a:documentation>Specifies the Overlay Filesystem</a:documentation>
         <db:para>As part of the network deploy configuration this section
 specifies the overlay filesystem setup if required by the
-filesystem type of the system image.An overlay setup is only
-required if the system image uses a squashfs
+filesystem type of the system image.An overlay setup is
+only required if the system image uses a squashfs
 compressed filesystem.</db:para>
         <ref name="k.union.attlist"/>
         <empty/>
@@ -2703,7 +2680,8 @@ compressed filesystem.</db:para>
   <div>
     <define name="k.vmdisk.disktype.attribute">
       <attribute name="disktype">
-        <a:documentation>The type of the disk as it is internally handled by the VM (ovf only)</a:documentation>
+        <a:documentation>The type of the disk as it is internally handled
+by the VM (ovf only)</a:documentation>
       </attribute>
     </define>
     <define name="k.vmdisk.controller.attribute">
@@ -2838,6 +2816,57 @@ scsi CD or an ide CD drive</a:documentation>
           <ref name="k.vmnic.attlist"/>
           <empty/>
         </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <volume>
+    
+  -->
+  <div>
+    <define name="k.volume.freespace.attribute">
+      <attribute name="freespace">
+        <a:documentation>free space to be added to this volume. The value is
+used as MB by default but you can add "M" and/or "G" as
+postfix</a:documentation>
+        <ref name="volume-size-type"/>
+      </attribute>
+    </define>
+    <define name="k.volume.name.attribute">
+      <attribute name="name">
+        <a:documentation>volume name. The name specifies a path which has to
+exist inside the root directory.</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.volume.size.attribute">
+      <attribute name="size">
+        <a:documentation>absolute size of the volume. If the size value
+is too small to store all data it will be ignored.
+The value is used as MB by default but you can
+add "M" and/or "G" as postfix</a:documentation>
+        <ref name="volume-size-type"/>
+      </attribute>
+    </define>
+    <define name="k.volume.attlist">
+      <interleave>
+        <optional>
+          <ref name="k.volume.freespace.attribute"/>
+        </optional>
+        <ref name="k.volume.name.attribute"/>
+        <optional>
+          <ref name="k.volume.size.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.volume">
+      <element name="volume">
+        <a:documentation>Specify which parts of the filesystem should be
+on an extra volume.</a:documentation>
+        <db:para>Specify which parts of the filesystem should be on
+an extra volume.</db:para>
+        <ref name="k.volume.attlist"/>
+        <empty/>
       </element>
     </define>
   </div>
@@ -3257,7 +3286,7 @@ The value is used to create the content file.</db:para>
         <db:para>The chroot element contains one particular environment
 variable and its value. Shell rules for the names apply.
 The value must not exceed a certain length for sanity.
-reasons Any funny characters like tabs, line break, 
+reasons Any funny characters like tabs, line break,
 carriage return or combinations are converted to spaces
 (one each) which may lead to unexpected contents.</db:para>
         <interleave>
@@ -3719,6 +3748,18 @@ and also depends of the selected image output type.</db:para>
         <interleave>
           <ref name="k.packages.attlist"/>
           <zeroOrMore>
+            <ref name="k.archive"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.ignore"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.namedCollection"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.opensuseproduct"/>
+          </zeroOrMore>
+          <zeroOrMore>
             <ref name="k.package"/>
           </zeroOrMore>
           <zeroOrMore>
@@ -3726,15 +3767,6 @@ and also depends of the selected image output type.</db:para>
           </zeroOrMore>
           <zeroOrMore>
             <ref name="k.rhelgroup"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="k.opensuseproduct"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="k.ignore"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="k.archive"/>
           </zeroOrMore>
         </interleave>
       </element>

--- a/modules/KIWIXMLPreferenceData.pm
+++ b/modules/KIWIXMLPreferenceData.pm
@@ -125,8 +125,9 @@ sub new {
 		$this->{version}              = $init->{version};
 	}
 	# Set default values
-	if (! $this->{packagemanager} ) {
-		$this->{packagemanager}   = 'zypper';
+	if (! $init->{packagemanager} ) {
+		$this->{packagemanager} = 'zypper';
+		$this->{defaultpackagemanager} = 1;
 	}
 	return $this;
 }
@@ -382,12 +383,14 @@ sub getXMLElement {
 		text      => $this -> getLocale()
 	);
 	$element = $this -> __addElement(\%initLoc);
-	my %initPckgM = (
-		parent    => $element,
-		childName => 'packagemanager',
-		text      => $this -> getPackageManager()
-	);
-	$element = $this -> __addElement(\%initPckgM);
+	if (! $this->{defaultpackagemanager}) {
+		my %initPckgM = (
+			parent    => $element,
+			childName => 'packagemanager',
+			text      => $this -> getPackageManager()
+		);
+		$element = $this -> __addElement(\%initPckgM);
+	}
 	my %initRPMCSig = (
 		parent    => $element,
 		childName => 'rpm-check-signatures',

--- a/modules/KIWIXMLProfileData.pm
+++ b/modules/KIWIXMLProfileData.pm
@@ -58,7 +58,9 @@ sub new {
 		return;
 	}
 	my %keywords = map { ($_ => 1) } qw(
-		description import name
+		description
+		import
+		name
 	);
 	$this->{supportedKeywords} = \%keywords;
 	my %boolKW = map { ($_ => 1) } qw( import );
@@ -76,6 +78,10 @@ sub new {
 	$this->{description} = $init->{description};
 	$this->{name}        = $init->{name};
 
+	# Track the defaults
+	if (! $init->{import}) {
+		$this->{defaultimport} = 1;
+	}
 	return $this;
 }
 
@@ -123,9 +129,11 @@ sub getXMLElement {
 	my $element = XML::LibXML::Element -> new('profile');
 	$element -> setAttribute('name', $this -> getName());
 	$element -> setAttribute('description', $this -> getDescription());
-	my $import = $this -> getImportStatus();
-	if ($import) {
-		$element -> setAttribute('import', $import);
+	if (! $this->{defaultimport}) {
+		my $import = $this -> getImportStatus();
+		if ($import) {
+			$element -> setAttribute('import', $import);
+		}
 	}
 	return $element;
 }

--- a/modules/KIWIXMLRepositoryData.pm
+++ b/modules/KIWIXMLRepositoryData.pm
@@ -102,9 +102,10 @@ sub new {
 	$this->{elname}       = 'repository';
 	$this->{status}       = $init->{status};
 	$this->{type}         = $init->{type};
-
-	if (! $this->{status} ) {
+	# Default settings
+	if (! $init->{status} ) {
 		$this->{status} = 'replacable';
+		$this->{defaultstatus} = 1;
 	}
 	return $this;
 }
@@ -230,9 +231,11 @@ sub getXMLElement {
 	if ($prio) {
 		$element -> setAttribute('priority', $prio);
 	}
-	my $status = $this -> getStatus();
-	if ($status) {
-		$element -> setAttribute('status', $status);
+	if (! $this->{defaultstatus}) {
+		my $status = $this -> getStatus();
+		if ($status) {
+			$element -> setAttribute('status', $status);
+		}
 	}
 	$element -> setAttribute('type', $this -> getType());
 	return $element;

--- a/modules/KIWIXMLSplitData.pm
+++ b/modules/KIWIXMLSplitData.pm
@@ -199,7 +199,10 @@ sub getXMLElement {
 			);
 			$this -> __addChildXMLElements(\%args);
 		}
-		$element -> addChild($bElem);
+		my @children = $bElem -> getChildrenByTagName('file');
+		if (@children) {
+			$element -> addChild($bElem);
+		}
 	}
 	return $element;
 }

--- a/modules/KIWIXMLSystemdiskData.pm
+++ b/modules/KIWIXMLSystemdiskData.pm
@@ -228,7 +228,6 @@ sub getXMLElement {
 	$element -> setAttribute('name', $this -> getVGName());
 	my @vIDs = @{$this -> getVolumeIDs()};
 	if (@vIDs) {
-		my $vpElem = XML::LibXML::Element -> new('volumes');
 		for my $id (@vIDs) {
 			my $vElem = XML::LibXML::Element -> new('volume');
 			$vElem -> setAttribute('name', $this -> getVolumeName($id));
@@ -240,9 +239,8 @@ sub getXMLElement {
 			if ($size) {
 				$vElem -> setAttribute('size', $size);
 			}
-			$vpElem -> appendChild($vElem);
+			$element -> appendChild($vElem);
 		}
-		$element -> appendChild($vpElem);
 	}
 	return $element;
 }

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -197,20 +197,28 @@ sub new {
 	$this->{vga}                    = $init->{vga};
 	$this->{volid}                  = $init->{volid};
 	# Set default values
-	if (! $this->{bootloader} ) {
+	if (! $init->{bootloader} ) {
 		$this->{bootloader} = 'grub';
+		$this->{defaultBootloader} = 1;
 	}
 	if (! $init->{installprovidefailsafe} ) {
 		$this->{installprovidefailsafe} = 'true';
+		$this->{defaultinstallprovidefailsafe} = 1;
 	}
 	if (! $init->{firmware} ) {
 		$this->{firmware} = 'bios';
+		$this->{defaultfirmware} = 1;
+	}
+	if (! $init->{primary} ) {
+		$this->{defaultprimary} = 1;
 	}
 	if (! $init->{sizeadd} ) {
 		$this->{sizeadd} = 'false';
+		$this->{defaultsizeadd} = 1;
 	}
 	if (! $init->{sizeunit} ) {
 		$this->{sizeunit} = 'M';
+		$this->{defaultsizeunit} = 1;
 	}
 	return $this;
 }
@@ -669,9 +677,11 @@ sub getXMLElement {
 	if ($bootK) {
 		$element -> setAttribute('bootkernel', $bootK);
 	}
-	my $loader = $this -> getBootLoader();
-	if ($loader) {
-		$element -> setAttribute('bootloader', $loader);
+	if (! $this->{defaultBootloader}) {
+		my $loader = $this -> getBootLoader();
+		if ($loader) {
+			$element -> setAttribute('bootloader', $loader);
+		}
 	}
 	my $bPartSize = $this -> getBootPartitionSize();
 	if ($bPartSize) {
@@ -709,9 +719,11 @@ sub getXMLElement {
 	if ($fileSys) {
 		$element -> setAttribute('filesystem', $fileSys);
 	}
-	my $firmware = $this -> getFirmwareType();
-	if ($firmware) {
-		$element -> setAttribute('firmware', $firmware);
+	if (! $this->{defaultfirmware}) {
+		my $firmware = $this -> getFirmwareType();
+		if ($firmware) {
+			$element -> setAttribute('firmware', $firmware);
+		}
 	}
 	my $flags = $this -> getFlags();
 	if ($flags) {
@@ -753,9 +765,11 @@ sub getXMLElement {
 	if ($instIso) {
 		$element -> setAttribute('installiso', $instIso);
 	}
-	my $instFail = $this -> getInstallFailsafe();
-	if ($instFail) {
-		$element -> setAttribute('installprovidefailsafe', $instFail);
+	if (! $this->{defaultinstallprovidefailsafe}) {
+		my $instFail = $this -> getInstallFailsafe();
+		if ($instFail) {
+			$element -> setAttribute('installprovidefailsafe', $instFail);
+		}
 	}
 	my $instPXE = $this -> getInstallPXE();
 	if ($instPXE) {
@@ -777,9 +791,11 @@ sub getXMLElement {
 	if ($mdraid) {
 		$element -> setAttribute('mdraid',$mdraid);
 	}
-	my $prim = $this -> getPrimary();
-	if ($prim) {
-		$element -> setAttribute('primary', $prim);
+	if (! $this->{defaultprimary}) {
+		my $prim = $this -> getPrimary();
+		if ($prim) {
+			$element -> setAttribute('primary', $prim);
+		}
 	}
 	my $ramO = $this -> getRAMOnly();
 	if ($ramO) {
@@ -789,8 +805,12 @@ sub getXMLElement {
 	if ($size) {
 		my $sElem = XML::LibXML::Element -> new('size');
 		$sElem -> appendText($size);
-		$sElem -> setAttribute('additive', $this -> isSizeAdditive());
-		$sElem -> setAttribute('unit', $this -> getSizeUnit());
+		if (! $this->{defaultsizeadd}) {
+			$sElem -> setAttribute('additive', $this -> isSizeAdditive());
+		}
+		if (! $this->{defaultsizeunit}) {
+			$sElem -> setAttribute('unit', $this -> getSizeUnit());
+		}
 		$element -> appendChild($sElem);
 	}
 	my $vga = $this -> getVGA();

--- a/modules/KIWIXMLUserData.pm
+++ b/modules/KIWIXMLUserData.pm
@@ -103,8 +103,9 @@ sub new {
 	$this->{shell}        = $init->{shell};
 	$this->{userid}       = $init->{userid};
 	# Set the default
-	if (! $this->{passwdformat} ) {
+	if (! $init->{passwdformat} ) {
 		$this->{passwdformat} = 'encrypted';
+		$this->{defaultpasswdformat} = 1;
 	}
 	return $this;
 }
@@ -231,11 +232,13 @@ sub getXMLElement {
 	}
 	my $pass = $this -> getPassword();
 	if ($pass) {
-		$uElem -> setAttribute('pwd', $pass);
+		$uElem -> setAttribute('password', $pass);
 	}
-	my $passF = $this -> getPasswordFormat();
-	if ($passF) {
-		$uElem -> setAttribute('pwdformat', $passF);
+	if (! $this->{defaultpasswdformat}) {
+		my $passF = $this -> getPasswordFormat();
+		if ($passF) {
+			$uElem -> setAttribute('pwdformat', $passF);
+		}
 	}
 	my $rname = $this -> getUserRealName();
 	if ($rname) {

--- a/modules/KIWIXMLVMachineData.pm
+++ b/modules/KIWIXMLVMachineData.pm
@@ -144,10 +144,13 @@ sub new {
 	$this->{vmdisks}       = $init->{vmdisks};
 	$this->{vmdvd}         = $init->{vmdvd};
 	$this->{vmnics}        = $init->{vmnics};
-	if (! $this->{HWversion} ) {
+	# Default settings
+	if (! $init->{HWversion} ) {
 		$this->{HWversion} = '4';
+		$this->{defaultHWversion} = 1;
 	}
-	if (! $this->{guestOS}) {
+	if (! $init->{guestOS}) {
+		$this->{defaultguestOS} = 1;
 		if ($this->{arch} && $this->{arch} =~ /64/smx) {
 			$this->{guestOS} = 'suse-64';
 		} else {
@@ -507,13 +510,17 @@ sub getXMLElement {
 	if ($dom) {
 		$element -> setAttribute('domain', $dom);
 	}
-	my $gOS = $this -> getGuestOS();
-	if ($gOS) {
-		$element -> setAttribute('guestOS', $gOS);
+	if (! $this->{defaultguestOS}) {
+		my $gOS = $this -> getGuestOS();
+		if ($gOS) {
+			$element -> setAttribute('guestOS', $gOS);
+		}
 	}
-	my $hwV = $this -> getHardwareVersion();
-	if ($hwV) {
-		$element -> setAttribute('HWversion', $hwV);
+	if (! $this->{defaultHWversion}) {
+		my $hwV = $this -> getHardwareVersion();
+		if ($hwV) {
+			$element -> setAttribute('HWversion', $hwV);
+		}
 	}
 	my $maxCPU = $this -> getMaxCPUCnt();
 	if ($maxCPU) {
@@ -543,7 +550,7 @@ sub getXMLElement {
 	if ($ovfT) {
 		$element -> setAttribute('ovftype', $ovfT);
 	}
-	$this -> __addVMconfiXMLElements($element);
+	$this -> __addVMconfigXMLElements($element);
 	$this -> __addVMdiskXMLElements($element);
 	$this -> __addVMdvdXMLElements($element);
 	$this -> __addVMnicXMLElements($element);
@@ -1122,20 +1129,23 @@ sub setSystemDiskID {
 # Private helper methods
 #------------------------------------------
 #==========================================
-# __addVMconfiXMLElements
+# __addVMconfigXMLElements
 #------------------------------------------
-sub __addVMconfiXMLElements {
+sub __addVMconfigXMLElements {
 	# ...
 	# Generate XML elements for vmconfig settings and add them to the
 	# given parent.
 	# ---
 	my $this   = shift;
 	my $parent = shift;
-	my @confEntries = @{$this -> getConfigEntries()};
-	for my $conf (@confEntries) {
-		my $cElem = XML::LibXML::Element -> new('vmconfig-entry');
-		$cElem -> appendText($conf);
-		$parent -> appendChild($cElem);
+	my $confEntries = $this -> getConfigEntries();
+	if ($confEntries) {
+		my @confEntries = @{$confEntries};
+		for my $conf (@confEntries) {
+			my $cElem = XML::LibXML::Element -> new('vmconfig-entry');
+			$cElem -> appendText($conf);
+			$parent -> appendChild($cElem);
+		}
 	}
 	return 1;
 }

--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -34,10 +34,6 @@ BuildRequires:  lvm2
 BuildRequires:  gcc-c++
 BuildRequires:  libxslt
 BuildRequires:  module-init-tools
-BuildRequires:  perl-Config-IniFiles
-BuildRequires:  perl-XML-LibXML
-BuildRequires:  perl-libwww-perl
-BuildRequires:  perl-JSON
 BuildRequires:  screen
 BuildRequires:  zlib-devel
 %if 0%{?suse_version} > 1020
@@ -55,8 +51,13 @@ BuildRequires:  btrfsprogs
 BuildRequires:  cdrkit-cdrtools-compat
 BuildRequires:  genisoimage
 BuildRequires:  perl-Class-Singleton
-BuildRequires:  perl-Test-Unit
+BuildRequires:  perl-Config-IniFiles
+BuildRequires:  perl-File-Slurp
+BuildRequires:  perl-libwww-perl
+BuildRequires:  perl-JSON
 BuildRequires:  perl-Readonly
+BuildRequires:  perl-Test-Unit
+BuildRequires:  perl-XML-LibXML
 BuildRequires:  squashfs
 BuildRequires:  zypper
 %endif
@@ -72,9 +73,10 @@ Requires:		perl >= %{perl_version}
 %else
 Requires:		perl = %{perl_version}
 %endif
-Requires:       perl-JSON
 Requires:       perl-Class-Singleton
 Requires:       perl-Config-IniFiles
+Requires:       perl-File-Slurp
+Requires:       perl-JSON
 Requires:       perl-libwww-perl
 Requires:       perl-Readonly
 Requires:       perl-XML-LibXML

--- a/tests/unit/data/kiwiXML/roundtripWrite/config.xml
+++ b/tests/unit/data/kiwiXML/roundtripWrite/config.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="5.6" name="testCase-writing" displayname="xml-write-test">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>Test configuration to verify XML writing produces the expected result, i.e. an identical file to this one (spare whitespace)</specification>
+	</description>
+	<profiles>
+		<profile name="profA" description="Test prof A" import="false"/>
+		<profile name="profB" description="Test prof B"/>
+		<profile name="profC" description="Test prof C"/>
+		<profile name="profD" description="Test prof D"/>
+		<profile name="profE" description="Test prof E"/>
+		<profile name="profF" description="Test prof F"/>
+	</profiles>
+	<preferences>
+		<keytable>us.map.gz</keytable>
+		<locale>en_US</locale>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>false</rpm-force>
+		<version>0.0.1</version>
+		<type image="vmx" boot="vmxboot/suse-12.3" filesystem="ext4" format="vmdk">
+			<machine memory="1024" ncpus="2">
+				<vmdisk device="/dev/sda" disktype="scsi"/>
+				<vmnic interface="eth0"/>
+			</machine>
+		</type>
+	</preferences>
+	<preferences profiles="profA">
+		<hwclock>utc</hwclock>
+		<type image="xfs"/>
+	</preferences>
+	<preferences profiles="profB">
+		<type image="oem" boot="oemboot/suse-12.3" filesystem="btrfs" installstick="true">
+			<systemdisk name="testVG">
+				<volume name="home" size="1048576"/>
+				<volume name="opt" freespace="102400" size="524288"/>
+			</systemdisk>
+		</type>
+	</preferences>
+	<preferences profiles="profD">
+		<type image="split" boot="oemboot/suse-12.3" fsreadonly="squashfs" fsreadwrite="xfs" installiso="true">
+			<split>
+				<persistent>
+					<file name="/etc"/>
+					<file name="/etc/*"/>
+					<file name="/var"/>
+					<file name="/var/*"/>
+					<file name="/boot"/>
+					<file name="/boot/*"/>
+				</persistent>
+			</split>
+		</type>
+	</preferences>
+	<users group="root">
+		<user home="/root" name="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+	</users>
+	<users group="users">
+		<user home="auser" name="auser" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+	</users>
+	<users group="users" profiles="profA">
+		<user home="cuser" name="cuser" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+	</users>
+	<users group="users" profiles="profD">
+		<user home="buser" name="buser" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0"/>
+	</users>
+	<repository priority="2" prefer-license="true" status="fixed" type="yast2">
+		<source path="opensuse://12.1/repo/oss/"/>
+	</repository>
+	<repository alias="update" imageinclude="true" type="rpm-md" profiles="profA">
+		<source path="http://download.opensuse.org/update/12.1"/>
+	</repository>
+	<drivers>
+		<file name="crypto/*"/>
+		<file name="drivers/acpi/*"/>
+	</drivers>
+	<drivers profiles="profB,profC,profD">
+		<file name="drivers/gpu/drm/i915/i915.ko"/>
+		<file name="drivers/gpu/drm/radeon/radeon.ko"/>
+	</drivers>
+	<packages type="image">
+		<archive name="myBins.tar.bz2"/>
+		<archive name="myBootStuff.tar.gz" bootinclude="true"/>
+		<namedCollection name="base"/>
+		<namedCollection name="kde" arch="x86_64"/>
+		<package name="kernel-default"/>
+		<package name="ifplugd"/>
+		<package name="vim"/>
+	</packages>
+	<packages type="image" profiles="profB,profE">
+		<namedCollection name="x11"/>
+		<package name="lvm"/>
+	</packages>
+	<packages type="image" profiles="profA,profD" patternType="plusRecommended">
+		<package name="xfsprogs"/>
+	</packages>
+	<packages type="image" profiles="profC,profF" patternType="onlyRequired">
+		<package name="emacs"/>
+	</packages>
+	<packages type="oem" profiles="profB">
+		<package name="kernel-firmware"/>
+	</packages>
+	<packages type="split" profiles="profD" patternType="plusRecommended">
+		<package name="squashfs"/>
+	</packages>
+	<packages type="delete">
+		<package name="libreoffice-math" arch="ix86"/>
+	</packages>
+	<packages type="delete" profiles="profA">
+		<package name="vim-data"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+	<strip type="delete">
+		<file name="df" arch="s390"/>
+	</strip>
+	<strip type="libs">
+		<file name="libraid"/>
+	</strip>
+	<strip type="tools">
+		<file name="megacli"/>
+	</strip>
+</image>

--- a/tests/unit/data/kiwiXML/userConfigWithProf/config.xml
+++ b/tests/unit/data/kiwiXML/userConfigWithProf/config.xml
@@ -12,7 +12,8 @@
 	</profiles>
 	<preferences>
 		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-12.1" format="ovf">
-			<machine max_memory="2048" memory="1024" min_memory="512" max_cpu="4" ncpus="2" min_cpu="1" ovftype="powervm">				        <vmdisk device="/dev/sda" disktype="scsi"/>
+			<machine max_memory="2048" memory="1024" min_memory="512" max_cpu="4" ncpus="2" min_cpu="1" ovftype="powervm">
+				<vmdisk device="/dev/sda" disktype="scsi"/>
 				<vmnic interface="eth0"/>
 			</machine>
 		</type>
@@ -44,10 +45,10 @@
 	<repository type="rpm-md" alias="update" imageinclude="true" profiles="profA">
 		<source path="http://download.opensuse.org/update/12.1"/>
 	</repository>
-	<repository type="rpm-dir" status="replacable" profiles="profA,profC">
+	<repository type="rpm-dir" status="replaceable" profiles="profA,profC">
 		<source path="/repos/12.1-additional"/>
 	</repository>
-	<repository type="yast2" username="foo" password="bar" status="replacable" profiles="profB">
+	<repository type="yast2" username="foo" password="bar" status="replaceable" profiles="profB">
 		<source path="https://myreposerver/protectedrepos/12.1"/>
 	</repository>
 	<packages type="image">

--- a/tests/unit/lib/Test/kiwiXMLSystemdiskData.pm
+++ b/tests/unit/lib/Test/kiwiXMLSystemdiskData.pm
@@ -984,10 +984,8 @@ sub test_getXMLElement{
 	$this -> assert_not_null($elem);
 	my $xmlstr = $elem -> toString();
 	my $expected = '<systemdisk name="testVG">'
-		. '<volumes>'
 		. '<volume name="test_VOL" freespace="20M" size="30G"/>'
 		. '<volume name="data_VOL" size="100G"/>'
-		. '</volumes>'
 		. '</systemdisk>';
 	$this -> assert_str_equals($expected, $xmlstr);
 	return;

--- a/tests/unit/lib/Test/kiwiXMLUserData.pm
+++ b/tests/unit/lib/Test/kiwiXMLUserData.pm
@@ -551,7 +551,7 @@ sub test_getXMLElement{
 		. 'home="/home/me" '
 		. 'name="me" '
 		. 'id="1111" '
-		. 'pwd="hello" '
+		. 'password="hello" '
 		. 'pwdformat="plain" '
 		. 'realname="Pablo" '
 		. 'shell="/usr/bin/zsh"/>'


### PR DESCRIPTION
- implement writeXML method in XML class
  - write an xml file based on the data in the data structure
- do not write data to the generated XML if a default value was set
  programmatically
- add a "namedCollection" element to the XML
  - this is in preparation for the removal of opensusePattern and rhelGroup
  - the KIWIXMLPackageCollection class already writes the <namedCollection>
    element as there is no way to differentiate one collection from the
    other <opensusePattern> vs. <rhelGroup>. Therefore, the schema has to
    support the new element name prior to the old collection names
    being removed.
- alpha sort the element declarations in the schema
  - benign change, but it aides XML code development
- kiwi now depends on File::Slurp
- implement a writeTest script that can be used to verify that round
  tripping of XML data works
- create a sample config.xml file for round trip testing
