### PR TITLE
And another singleton

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -2,3 +2,5 @@
 [-Modules::RequireVersionVar]
 [-NamingConventions::Capitalization]
 [-InputOutput::RequireBriefOpen]
+[Subroutines::ProhibitUnusedPrivateSubroutines]
+    allow = _new_instance

--- a/kiwi.pl
+++ b/kiwi.pl
@@ -57,9 +57,9 @@ binmode(STDOUT, ":encoding(UTF-8)");
 #============================================
 # Globals
 #--------------------------------------------
-my $kiwi     = KIWILog -> instance();
-my $global   = KIWIGlobals -> instance();
-our $locator = KIWILocator -> new ();
+my $kiwi    = KIWILog -> instance();
+my $global  = KIWIGlobals -> instance();
+my $locator = KIWILocator -> instance();
 $kiwi -> setLogServer (
 	$global -> getKiwiConfig() -> {LogServerPort}
 );

--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -282,7 +282,7 @@ sub new {
 		#==========================================
 		# read and validate XML description
 		#------------------------------------------
-		my $locator = KIWILocator -> new();
+		my $locator = KIWILocator -> instance();
 		my $controlFile = $locator -> getControlFile ($rootpath."/image");
 		my $validator = KIWIXMLValidator -> new (
 			$controlFile,
@@ -3484,7 +3484,7 @@ sub setupBootLoaderStages {
 		#------------------------------------------
 		if ($firmware eq "efi") {
 			$kiwi -> info ("Creating grub2 efi boot image");
-			my $locator = KIWILocator -> new();
+			my $locator = KIWILocator -> instance();
 			my $grub2_mkimage = $locator -> getExecPath ("grub2-efi-mkimage");
 			if (! $grub2_mkimage) {
 				$grub2_mkimage = $locator -> getExecPath ("grub2-mkimage");
@@ -4999,7 +4999,7 @@ sub installBootLoader {
 	my $xml      = $this->{xml};
 	my $firmware = $this->{firmware};
 	my $system   = $this->{system};
-	my $locator  = KIWILocator -> new();
+	my $locator  = KIWILocator -> instance();
 	my $bootdev;
 	my $result;
 	my $status;
@@ -5573,7 +5573,7 @@ sub getGeometry {
 	my $status;
 	my $result;
 	my $parted;
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $parted_exec = $locator -> getExecPath("parted");
 	$status = qxx ("dd if=/dev/zero of=$disk bs=512 count=1 2>&1");
 	$result = $? >> 8;
@@ -5685,7 +5685,7 @@ sub initGeometry {
 	my $align  = $cmdL->getDiskAlignment();
 	my $secsz  = $cmdL->getDiskBIOSSectorSize();
 	my $align_sectors = int ($align / $secsz);
-	my $locator= KIWILocator -> new();
+	my $locator= KIWILocator -> instance();
 	if (! defined $this->{pStart}) {
 		$this->{pStart} = $cmdL->getDiskStartSector();
 	} else {
@@ -5731,7 +5731,7 @@ sub setStoragePartition {
 	my $status;
 	my $ignore;
 	my $action;
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $parted_exec = $locator -> getExecPath("parted");
 	if (! defined $tool) {
 		$tool = "parted";
@@ -6556,7 +6556,7 @@ sub __expandFS {
 	my $diskType  = shift;
 	my $mapper    = shift;
 	my $kiwi      = $this->{kiwi};
-	my $locator   = KIWILocator -> new();
+	my $locator   = KIWILocator -> instance();
 	my $result    = 1;
 	my $status;
 	$kiwi->loginfo ("Resize Operation: Device: $mapper\n");

--- a/modules/KIWICommandLine.pm
+++ b/modules/KIWICommandLine.pm
@@ -553,7 +553,7 @@ sub setCacheDir {
 		return;
 	}
 	if ( $dir !~ /^\//) {
-		my $locator = KIWILocator -> new($this -> {kiwi});
+		my $locator = KIWILocator -> instance();
 		$dir = $locator -> getDefaultCacheDir() . '/' . $dir;
 		my $msg = 'Specified relative path as cache location; moving cache to '
 		. "$dir\n";

--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -770,7 +770,7 @@ sub callContained {
 		$kiwi -> failed ();
 		return;
 	}
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $lxcexec = $locator -> getExecPath('lxc-execute');
 	my $lxcbase = $root."/usr/lib/lxc/";
 	if (-d $root."/usr/lib64") {
@@ -1012,7 +1012,7 @@ sub _new_instance {
 	# Globals (Supported filesystem names)
 	#------------------------------------------
 	my %KnownFS;
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	$KnownFS{ext4}{tool}      = $locator -> getExecPath("mkfs.ext4");
 	$KnownFS{ext3}{tool}      = $locator -> getExecPath("mkfs.ext3");
 	$KnownFS{ext2}{tool}      = $locator -> getExecPath("mkfs.ext2");

--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -471,7 +471,7 @@ sub checkAndSetupPrebuiltBootImage {
 	#==========================================
 	# open boot image XML object
 	#------------------------------------------
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $controlFile = $locator -> getControlFile ($bootpath);
 	if (! $controlFile) {
 		return;
@@ -2159,7 +2159,7 @@ sub createImageLiveCD {
 		#------------------------------------------
 		if ($firmware eq "efi") {
 			$kiwi -> info ("Creating grub2 efi boot image");
-			my $locator = KIWILocator -> new();
+			my $locator = KIWILocator -> instance();
 			my $grub2_mkimage = $locator -> getExecPath ("grub2-efi-mkimage");
 			if (! $grub2_mkimage) {
 				$grub2_mkimage = $locator -> getExecPath ("grub2-mkimage");
@@ -4581,7 +4581,7 @@ sub setupSquashFS {
 	my $xml  = $this->{xml};
 	my %type = %{$xml->getImageTypeAndAttributes_legacy()};
 	my $imageTree = $this->{imageTree};
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	if (! defined $tree) {
 		$tree = $imageTree;
 	}

--- a/modules/KIWIImageCreator.pm
+++ b/modules/KIWIImageCreator.pm
@@ -191,7 +191,7 @@ sub upgradeImage {
 	# Setup the image XML description
 	#------------------------------------------
 	$configDir .= "/image";
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $controlFile = $locator -> getControlFile ($configDir);
 	if (! $controlFile) {
 		return;
@@ -254,7 +254,7 @@ sub prepareImage {
 	#==========================================
 	# Setup the image XML description
 	#------------------------------------------
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $controlFile = $locator -> getControlFile ($configDir);;
 	if (! $controlFile) {
 		return;
@@ -342,7 +342,7 @@ sub createBootImage {
 	#==========================================
 	# Setup the image XML description
 	#------------------------------------------
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $controlFile = $locator -> getControlFile ($configDir);;
 	if (! $controlFile) {
 		return;
@@ -434,7 +434,7 @@ sub createImage {
 	#==========================================
 	# Setup the image XML description
 	#------------------------------------------
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $controlFile = $locator -> getControlFile ($configDir);;
 	if (! $controlFile) {
 		return;

--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -664,7 +664,7 @@ sub createEC2 {
 	#==========================================
 	# Check for Amazon EC2 toolkit
 	#------------------------------------------
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $bundleCmd = $locator -> getExecPath ('ec2-bundle-image');
 	if (! $bundleCmd ) {
 		$kiwi -> error (

--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -91,7 +91,7 @@ sub new {
 	#==========================================
 	# Find iso tool to use on this system
 	#------------------------------------------
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $genTool = $locator -> getExecPath('genisoimage');
 	my $mkTool = $locator -> getExecPath('mkisofs');
 	if ($genTool && -x $genTool) {
@@ -1032,7 +1032,7 @@ sub createHybrid {
 		$kiwi -> skipped ();
 		return $this;
 	}
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $isoHybrid = $locator -> getExecPath ('isohybrid');
 	if (! $isoHybrid) {
 		$kiwi -> error ("Can't find isohybrid, check your syslinux version");

--- a/modules/KIWIManager.pm
+++ b/modules/KIWIManager.pm
@@ -89,7 +89,7 @@ sub new {
 	if ($manager eq "apt-get") {
 		$manager = "apt";
 	}
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $dataDir = "/var/cache/kiwi/$manager";
 	my @channelList = ();
 	#==========================================

--- a/modules/KIWIRoot.pm
+++ b/modules/KIWIRoot.pm
@@ -223,7 +223,7 @@ sub new {
 	#==========================================
 	# Create root directory
 	#------------------------------------------
-	my $locator = KIWILocator -> new ($this -> {kiwi});
+	my $locator = KIWILocator -> instance ();
 	my $root = $locator -> createTmpDirectory (
 		$useRoot,$selfRoot,$cmdL
 	);

--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -82,7 +82,7 @@ sub new {
 	# Store module parameters
 	#------------------------------------------
 	$this->{cmdArgs} = $cmdArgs;
-	$this->{locator} = KIWILocator -> new();
+	$this->{locator} = KIWILocator -> instance();
 	$this->{kiwi}    = $kiwi;
 	$this->{xml}     = $xml;
 	return $this;

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -296,7 +296,7 @@ sub new {
 	#==========================================
 	# Lookup XML configuration file
 	#------------------------------------------
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $controlFile = $locator -> getControlFile ( $imageDesc );
 	if (! $controlFile) {
 		return;

--- a/modules/KIWIXMLInfo.pm
+++ b/modules/KIWIXMLInfo.pm
@@ -608,7 +608,7 @@ sub __xmlSetup {
 	#------------------------------------------
 	my $buildProfs = $this -> {buildProfiles};
 	my $configDir  = $this -> {configDir};
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $controlFile = $locator -> getControlFile ($configDir);
 	if (! $controlFile) {
 		return;

--- a/modules/KIWIXMLValidator.pm
+++ b/modules/KIWIXMLValidator.pm
@@ -1815,7 +1815,7 @@ sub __validateXML {
 			print $UPCNTFL $upgradedStr;
 			close ( $UPCNTFL );
 		}
-		my $locator = KIWILocator -> new();
+		my $locator = KIWILocator -> instance();
 		my $jingExec = $locator -> getExecPath('jing');
 		if ($jingExec) {
 			qxx ("$jingExec $this->{schema} $upgradedContolFile 1>&2");

--- a/tests/unit/lib/Test/kiwiLocator.pm
+++ b/tests/unit/lib/Test/kiwiLocator.pm
@@ -47,7 +47,7 @@ sub test_ctor {
 	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $msg = $kiwi -> getMessage();
 	$this -> assert_str_equals('No messages set', $msg);
 	my $msgT = $kiwi -> getMessageType();
@@ -736,7 +736,7 @@ sub __getLocator {
 	# Helper method to create a KIWILocator object
 	# ---
 	my $this = shift;
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	return $locator;
 }
 

--- a/tests/unit/lib/Test/kiwiRuntimeChecker.pm
+++ b/tests/unit/lib/Test/kiwiRuntimeChecker.pm
@@ -469,7 +469,7 @@ sub test_fsToolCheckSplitImg {
 	my $xml = $this -> __getXMLObj($configPath);
 	my $checker = KIWIRuntimeChecker -> new($cmd, $xml);
 	my $res = $checker -> createChecks();
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $haveBtrfs = $locator -> getExecPath('mkfs.btrfs');
 	if ($haveBtrfs) {
 		# Filesystem tool is present
@@ -513,7 +513,7 @@ sub test_isohybrid {
 	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $arch = KIWIGlobals -> instance() -> getArch();
 	my $isoHybrid;
 	if ($arch eq 'ix86' || $arch eq 'x86_64') {
@@ -577,7 +577,7 @@ sub test_noEFIIsohybridOEMImg {
 	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $arch = KIWIGlobals -> instance() -> getArch();
 	my $isoHybrid;
 	if ($arch eq 'ix86' || $arch eq 'x86_64') {
@@ -709,7 +709,7 @@ sub test_packageManagerCheck_ens {
 	$xml -> setPreferences($prefObj);
 	my $checker = KIWIRuntimeChecker -> new($cmd, $xml);
 	my $res = $checker -> prepareChecks();
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $haveEnsconce = $locator -> getExecPath('ensconce');
 	if ($haveEnsconce) {
 		my $msg = $kiwi -> getMessage();
@@ -755,7 +755,7 @@ sub test_packageManagerCheck_zypp {
 	my $checker = KIWIRuntimeChecker -> new($cmd, $xml);
 	my $res = $checker -> prepareChecks();
 
-	my $locator = KIWILocator -> new();
+	my $locator = KIWILocator -> instance();
 	my $haveZypper = $locator -> getExecPath('zypper');
 	if ($haveZypper) {
 		my $msg = $kiwi -> getMessage();


### PR DESCRIPTION
- add critic exception for the _new_instance private method in all singletons.
  - The method is called from the base class only and thus does not
    appear to be called when perlcritic parses the code.
- convert the Locator to a singleton
  - the locator holds no state and we really only need one per kiwi
    invocation
