### PR TITLE
switch the settings to use systemd tools

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -374,7 +374,6 @@ my @notClean3 = qw (
 	KIWICache.pm
 	KIWICollect.pm
 	KIWICommandLine.pm
-	KIWIConfigure.pm
 	KIWIContentPlugin.pm
 	KIWIDescrPlugin.pm
 	KIWIEulaPlugin.pm

--- a/doc/examples/suse-12.3/suse-ec2-guest/config.sh
+++ b/doc/examples/suse-12.3/suse-ec2-guest/config.sh
@@ -52,11 +52,6 @@ baseUpdateSysConfig /etc/sysconfig/network/dhcp DHCLIENT_SET_HOSTNAME yes
 suse-ec2-configure --norefresh
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-suseConfig
-
-#======================================
 # clone runlevel 3 to 4
 #--------------------------------------
 suseCloneRunlevel 4

--- a/doc/examples/suse-12.3/suse-live-iso/config.sh
+++ b/doc/examples/suse-12.3/suse-live-iso/config.sh
@@ -42,7 +42,6 @@ suseInsertService boot.device-mapper
 #--------------------------------------
 baseUpdateSysConfig /etc/sysconfig/displaymanager DISPLAYMANAGER kdm
 baseSetRunlevel 5
-suseConfig
 
 #======================================
 # Umount kernel filesystems

--- a/doc/examples/suse-12.3/suse-live-usbstick/config.sh
+++ b/doc/examples/suse-12.3/suse-live-usbstick/config.sh
@@ -42,7 +42,6 @@ suseInsertService boot.device-mapper
 #--------------------------------------
 baseUpdateSysConfig /etc/sysconfig/displaymanager DISPLAYMANAGER kdm
 baseSetRunlevel 5
-suseConfig
 
 #======================================
 # Umount kernel filesystems

--- a/doc/examples/suse-12.3/suse-oem-preload/config.sh
+++ b/doc/examples/suse-12.3/suse-oem-preload/config.sh
@@ -43,7 +43,6 @@ suseInsertService boot.device-mapper
 baseUpdateSysConfig /etc/sysconfig/windowmanager DEFAULT_WM kde
 baseUpdateSysConfig /etc/sysconfig/displaymanager DISPLAYMANAGER kdm
 baseSetRunlevel 5
-suseConfig
 
 #======================================
 # Umount kernel filesystems

--- a/doc/examples/suse-12.3/suse-pxe-client/config.sh
+++ b/doc/examples/suse-12.3/suse-pxe-client/config.sh
@@ -44,7 +44,6 @@ suseInsertService sshd
 baseUpdateSysConfig /etc/sysconfig/windowmanager DEFAULT_WM icewm-session
 baseUpdateSysConfig /etc/sysconfig/displaymanager DISPLAYMANAGER xdm
 baseSetRunlevel 5
-suseConfig
 
 #==========================================
 # set X link

--- a/doc/examples/suse-12.3/suse-vm-guest/config.sh
+++ b/doc/examples/suse-12.3/suse-vm-guest/config.sh
@@ -38,11 +38,6 @@ suseActivateDefaultServices
 suseInsertService boot.device-mapper
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-suseConfig
-
-#======================================
 # Umount kernel filesystems
 #--------------------------------------
 baseCleanMount

--- a/doc/examples/suse-12.3/suse-xen-guest/config.sh
+++ b/doc/examples/suse-12.3/suse-xen-guest/config.sh
@@ -39,11 +39,6 @@ suseInsertService boot.device-mapper
 suseInsertService sshd
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-suseConfig
-
-#======================================
 # clone runlevel 3 to 4
 #--------------------------------------
 suseCloneRunlevel 4

--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -333,6 +333,13 @@ function baseSetupBoot {
 # suseConfig
 #--------------------------------------
 function suseConfig {
+	# Remove this function from the code base once SLE 11 is EOL
+	# June, 2019
+	if [ -x /usr/bin/localectl ];then
+		echo "Deprecated function suseConfig for this distribution version"
+		return 0
+	fi
+
 	#======================================
 	# keytable
 	#--------------------------------------

--- a/modules/KIWIConfigure.pm
+++ b/modules/KIWIConfigure.pm
@@ -2,7 +2,7 @@
 # FILE          : KIWIConfigure.pm
 #----------------
 # PROJECT       : openSUSE Build-Service
-# COPYRIGHT     : (c) 2012 SUSE LINUX Products GmbH, Germany
+# COPYRIGHT     : (c) 2013 SUSE LINUX Products GmbH, Germany
 #               :
 # AUTHOR        : Marcus Schaefer <ms@suse.de>
 #               :
@@ -21,6 +21,10 @@ use strict;
 use warnings;
 use Carp qw (cluck);
 use FileHandle;
+#==========================================
+# KIWI Modules
+#------------------------------------------
+use KIWILocator;
 use KIWILog;
 use KIWIQX qw (qxx);
 
@@ -68,13 +72,361 @@ sub new {
 	#==========================================
 	# Store object data
 	#------------------------------------------
-	my $global = KIWIGlobals -> instance();
 	$this->{kiwi}      = $kiwi;
+	$this->{locator}   = KIWILocator -> new();
 	$this->{imageDesc} = $imageDesc;
 	$this->{imageDest} = $imageDest;
 	$this->{xml}       = $xml;
 	$this->{root}      = $root;
-	$this->{gdata}     = $global -> getKiwiConfig();
+	$this->{gdata}     = KIWIGlobals -> instance() -> getKiwiConfig();
+	return $this;
+}
+
+#==========================================
+# setupAutoYaST
+#------------------------------------------
+sub setupAutoYaST {
+	# ...
+	# This function will make use of the autoyast system and setup
+	# the image to call the autoyast automatically on first boot of
+	# the system. To activate the call of yast on first boot the
+	# file /var/lib/YaST2/runme_at_boot is created. Please note
+	# according to the YaST people this is not the preferred method
+	# of calling YaST to perform tasks on first boot. Use the function
+	# setupFirstBootYaST below which uses yast2-firstboot to do the job
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $root = $this->{root};
+	my $imageDesc = $this->{imageDesc};
+	if (! -f "$imageDesc/config-yast-autoyast.xml") {
+		return $this;;
+	}
+	$kiwi -> info ("Setting up AutoYaST...");
+	my $autodir = "var/lib/autoinstall/autoconf";
+	my $autocnf = "autoconf.xml";
+	if (! -d "$root/$autodir") {
+		$kiwi -> failed ();
+		$kiwi -> error  ("AutoYaST seems not to be installed");
+		$kiwi -> failed ();
+		return;
+	}
+	qxx (
+		"cp $imageDesc/config-yast-autoyast.xml $root/$autodir/$autocnf 2>&1"
+	);
+	my $INFFD = FileHandle -> new();
+	if ( ! $INFFD -> open (">$root/etc/install.inf")) {
+		$kiwi -> failed ();
+		$kiwi -> error ("Failed to create install.inf: $!");
+		$kiwi -> failed ();
+		return;
+	}
+	print $INFFD "AutoYaST: http://192.168.100.99/part2.xml\n";
+	$INFFD -> close();
+	my $AUTOFD = FileHandle -> new();
+	if ( ! $AUTOFD -> open (">$root/var/lib/YaST2/runme_at_boot")) {
+		$kiwi -> failed ();
+		$kiwi -> error ("Failed to create runme_at_boot: $!");
+		$kiwi -> failed ();
+		return;
+	}
+	$AUTOFD -> close();
+	$kiwi -> done ();
+	return $this;
+}
+
+#==========================================
+# setupFirstBootAnaconda
+#------------------------------------------
+sub setupFirstBootAnaconda {
+	# ...
+	# This function activates the RHEL firstboot mechanism.
+	# So far I did not find a way to tell firstboot what
+	# modules it should call. firstboot is activated if the
+	# file config-anaconda-firstboot exists as part of your
+	# image description
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $root = $this->{root};
+	my $imageDesc = $this->{imageDesc};
+	if (! -f "$imageDesc/config-anaconda-firstboot") {
+		return $this;
+	}
+	$kiwi -> info ("Setting up Anaconda firstboot service...");
+	#==========================================
+	# touch/remove some files
+	#------------------------------------------
+	qxx ("touch $root/etc/reconfigSys 2>&1");
+	qxx ("rm -f /etc/sysconfig/firstboot 2>&1");
+	#==========================================
+	# activate service
+	#------------------------------------------
+	my $data = qxx ("chroot $root chkconfig --level 35 firstboot on 2>&1");
+	my $code = $? >> 8;
+	if ($code != 0) {
+		$kiwi -> failed ();
+		$kiwi -> error ("Failed to activate firstboot: $data");
+		$kiwi -> failed ();
+		return;
+	}
+	$kiwi -> done();
+	return $this;
+}
+
+#==========================================
+# setupFirstBootYaST
+#------------------------------------------
+sub setupFirstBootYaST {
+	# ...
+	# This function is based on the yast2-firstboot functionality which
+	# is a service which will be enabled by insserv. The firstboot service
+	# uses a different xml format than the autoyast system. According to
+	# this the input file has a different name. the firstboot input file
+	# is preferred over the config-yast-autoyast.xml file
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $root = $this->{root};
+	my $imageDesc = $this->{imageDesc};
+	if (! -f "$imageDesc/config-yast-firstboot.xml") {
+		return $this;
+	}
+	$kiwi -> info ("Setting up YaST firstboot service...");
+	if (
+		(! -f "$root/etc/init.d/firstboot") &&
+		(! -f "$root/usr/share/YaST2/clients/firstboot.ycp")
+	) {
+		$kiwi -> failed ();
+		$kiwi -> error  ('yast2-firstboot is not installed');
+		$kiwi -> failed ();
+		return;
+	}
+	my $firstboot = "$root/etc/YaST2/firstboot.xml";
+	my $data = qxx ("cp $imageDesc/config-yast-firstboot.xml $firstboot 2>&1");
+	my $code = $? >> 8;
+	if ($code != 0) {
+		$kiwi -> failed ();
+		$kiwi -> error  ("Failed to copy config-yast-firstboot.xml: $data");
+		$kiwi -> failed ();
+		return;
+	}
+	# /.../
+	# keep an existing /etc/sysconfig/firstboot or copy the template
+	# from yast2-firstboot package if both don't exist, write a
+	# generic one (bnc#604705)
+	# ----
+	if ( ! -e "$root/etc/sysconfig/firstboot" ) {
+		my $FBFD = FileHandle -> new();
+		if ( -e "$root/var/adm/fillup-templates/sysconfig.firstboot" ) {
+			my $template = "$root/var/adm/fillup-templates/"
+				. 'sysconfig.firstboot';
+			$data = qxx (
+				"cp $template $root/etc/sysconfig/firstboot 2>&1"
+			);
+			$code = $? >> 8;
+			if ($code != 0) {
+				$kiwi -> failed ();
+				$kiwi -> error  (
+					"Failed to copy firstboot-sysconfig templage: $data"
+				);
+				$kiwi -> failed ();
+				return;
+			}
+		} elsif ( ! $FBFD -> open (">$root/etc/sysconfig/firstboot")) {
+			$kiwi -> failed ();
+			$kiwi -> error ("Failed to create /etc/sysconfig/firstboot: $!");
+			$kiwi -> failed ();
+			return;
+		} else {
+			print $FBFD "## Description: Firstboot Configuration\n";
+			print $FBFD "## Default: /usr/share/firstboot/scripts\n";
+			print $FBFD "SCRIPT_DIR=\"/usr/share/firstboot/scripts\"\n";
+			print $FBFD "FIRSTBOOT_WELCOME_DIR=\"/usr/share/firstboot\"\n";
+			print $FBFD "FIRSTBOOT_WELCOME_PATTERNS=\"\"\n";
+			print $FBFD "FIRSTBOOT_LICENSE_DIR=\"/usr/share/firstboot\"\n";
+			print $FBFD "FIRSTBOOT_NOVELL_LICENSE_DIR=\"/etc/YaST2\"\n";
+			print $FBFD "FIRSTBOOT_FINISH_FILE=";
+			print $FBFD "\"/usr/share/firstboot/congrats.txt\"\n";
+			print $FBFD "FIRSTBOOT_RELEASE_NOTES_PATH=\"\"\n";
+			$FBFD -> close();
+		}
+	}
+	if (-f "$root/etc/init.d/firstboot") {
+		# /.../
+		# old service script based firstboot service. requires some
+		# default services to run
+		# ----
+		my @services = (
+			"boot.rootfsck","boot.localfs",
+			"boot.cleanup","boot.localfs","boot.localnet",
+			"boot.clock","policykitd","dbus","consolekit",
+			"haldaemon","network","atd","syslog","cron",
+			"firstboot"
+		);
+		foreach my $service (@services) {
+			if (! -e "$root/etc/init.d/$service") {
+				next;
+			}
+			$data = qxx (
+				"chroot $root /sbin/insserv /etc/init.d/$service 2>&1"
+			);
+			$code = $? >> 8;
+			if ($code != 0) {
+				$kiwi -> failed ();
+				$kiwi -> error ("Failed to activate service(s): $data");
+				$kiwi -> failed ();
+				return;
+			}
+		}
+		$data = qxx ("touch $root/etc/reconfig_system 2>&1");
+		$code = $? >> 8;
+		if ($code != 0) {
+			$kiwi -> failed ();
+			$kiwi -> error ("Failed to activate firstboot: $data");
+			$kiwi -> failed ();
+			return;
+		}
+	} else {
+		# /.../
+		# current firstboot service works like yast second stage and
+		# is activated by touching /var/lib/YaST2/reconfig_system
+		# ----
+		$data = qxx ("touch $root/var/lib/YaST2/reconfig_system 2>&1");
+		$code = $? >> 8;
+		if ($code != 0) {
+			$kiwi -> failed ();
+			$kiwi -> error ("Failed to activate firstboot: $data");
+			$kiwi -> failed ();
+			return;
+		}
+	}
+	$kiwi -> done();
+	return $this;
+}
+
+#==========================================
+# setupGroups
+#------------------------------------------
+sub setupGroups {
+	my $this  = shift;
+	my $kiwi    = $this->{kiwi};
+	my $locator = $this->{locator};
+	my $root    = $this->{root};
+	my $xml     = $this->{xml};
+	my $users    = $xml -> getUsers();
+	my $addgroup = $locator -> getExecPath('groupadd', $root);
+	my $numUsers = scalar @{$users};
+	if ($numUsers) {
+		if (! $addgroup) {
+			$kiwi -> error ("Missing groupadd command");
+			$kiwi -> failed ();
+			return;
+		}
+	}
+	for my $user (@{$users}) {
+		my $group     = $user -> getGroupName();
+		my $gid       = $user -> getGroupID();
+		if (defined $group) {
+			# create group if it does not exist
+			my $data = qxx (
+				"chroot $root grep -q ^$group: /etc/group 2>&1"
+			);
+			my $code = $? >> 8;
+			$group = quoteshell ($group);
+			if ($code != 0) {
+				$kiwi -> info ("Adding group: $group");
+				if (defined $gid) {
+					$addgroup .= " -g $gid";
+				}
+				$data = qxx ("chroot $root $addgroup \"$group\"");
+				$code = $? >> 8;
+				if ($code != 0) {
+					$kiwi -> failed ();
+					$kiwi -> info ($data);
+					$kiwi -> failed ();
+					return;
+				}
+				$kiwi -> done();
+			}
+		}
+	}
+	return $this;
+}
+
+#==========================================
+# setupHWclock
+#------------------------------------------
+sub setupHWclock {
+	# ...
+	# Setup the configuration for the HW clock timezone
+	# ---
+	my $this = shift;
+	my $kiwi    = $this->{kiwi};
+	my $locator = $this->{locator};
+	my $root    = $this->{root};
+	my $xml     = $this->{xml};
+	my $hwClock = $xml -> getPreferences() -> getHWClock();
+	my $timectl = $locator -> getExecPath('timedatectl', $root);
+	if ($timectl) {
+		if ($hwClock eq 'utc') {
+			qxx("$timectl set-local-rtc false 2>&1");
+		} else {
+			qxx("$timectl set-local-rtc true 2>&1");
+		}
+		my $code = $? >> 8;
+		if ($code != 0) {
+			$kiwi -> loginfo ("warning: unable to set the system clock\n");
+		}
+	}
+	return $this;
+}
+
+#==========================================
+# setupKeyboardMap
+#------------------------------------------
+sub setupKeyboardMap {
+	# ...
+	# Setup the configuration for the keyboard
+	# ---
+	my $this = shift;
+	my $kiwi    = $this->{kiwi};
+	my $locator = $this->{locator};
+	my $root    = $this->{root};
+	my $xml     = $this->{xml};
+	my $keymap = $xml -> getPreferences() -> getKeymap();
+	my $localectl = $locator -> getExecPath('localectl', $root);
+	if ($localectl) {
+		qxx("$localectl set-keymap $keymap 2>&1");
+		my $code = $? >> 8;
+		if ($code != 0) {
+			$kiwi -> loginfo ("warning: unable to set the keyboard map\n");
+		}
+	}
+	return $this;
+}
+
+#==========================================
+# setupLocale
+#------------------------------------------
+sub setupLocale {
+	# ...
+	# Setup the configuration for the locale
+	# ---
+	my $this = shift;
+	my $kiwi    = $this->{kiwi};
+	my $locator = $this->{locator};
+	my $root    = $this->{root};
+	my $xml     = $this->{xml};
+	my $locale = $xml -> getPreferences() -> getLocale();
+	my $localectl = $locator -> getExecPath('localectl', $root);
+	if ($localectl) {
+		qxx("$localectl set-locale $locale 2>&1");
+		my $code = $? >> 8;
+		if ($code != 0) {
+			$kiwi -> loginfo ("warning: unable to set the locale\n");
+		}
+	}
 	return $this;
 }
 
@@ -104,10 +456,9 @@ sub setupRecoveryArchive {
 	#------------------------------------------
 	my $topts  = "--numeric-owner --hard-dereference -cpf";
 	my $excld  = "--exclude ./dev --exclude ./proc --exclude ./sys";
-	my $status = qxx (
-		"cd $root && tar $topts $dest/.recovery.tar . $excld 2>&1 &&
-		mv $dest/.recovery.tar $root/recovery.tar"
-	);
+	my $cmd = "cd $root && tar $topts $dest/.recovery.tar . $excld 2>&1 && "
+		. "mv $dest/.recovery.tar $root/recovery.tar";
+	my $status = qxx ($cmd);
 	my $code = $? >> 8;
 	if ($code != 0) {
 		$kiwi -> failed ();
@@ -194,356 +545,133 @@ sub setupRecoveryArchive {
 }
 
 #==========================================
-# setupUsersGroups
+# setupTimezone
 #------------------------------------------
-sub setupUsersGroups {
-	my $this  = shift;
-	my $kiwi  = $this->{kiwi};
-	my $xml   = $this->{xml};
-	my $root  = $this->{root};
-	my $users = $xml -> getUsers();
-	if ($users) {
-		if (! -x "$root/usr/sbin/useradd") {
-			$kiwi -> error ("Missing useradd command");
-			$kiwi -> failed ();
-			return;
-		}
-		if (! -x "$root/usr/sbin/usermod") {
-			$kiwi -> error ("Missing usermod command");
-			$kiwi -> failed ();
-			return;
-		}
-		if (! -x "$root/usr/sbin/groupadd") {
-			$kiwi -> error ("Missing groupadd command");
-			$kiwi -> failed ();
-			return;
-		}
-		for my $user (@{$users}) {
-			my $adduser   = "/usr/sbin/useradd";
-			my $moduser   = "/usr/sbin/usermod";
-			my $addgroup  = "/usr/sbin/groupadd";
-			my $group     = $user -> getGroupName();
-			my $gid       = $user -> getGroupID();
-			my $logShell  = $user -> getLoginShell();
-			my $pwd       = $user -> getPassword();
-			my $pwdformat = $user -> getPasswordFormat();
-			my $uHome     = $user -> getUserHomeDir();
-			my $uID       = $user -> getUserID();
-			my $uName     = $user -> getUserName();
-			my $uRname    = $user -> getUserRealName();
-
-			if ((defined $pwdformat) && ($pwdformat eq 'plain')) {
-				$pwd = main::createPassword ($pwd);
-			}
-			if (defined $pwd) {
-				$adduser .= " -p '$pwd'";
-				$moduser .= " -p '$pwd'";
-			}
-			if (defined $logShell) {
-				$adduser .= " -s '$logShell'";
-				$moduser .= " -s '$logShell'";
-			}
-			if (defined $uHome) {
-				$uHome = quoteshell ($uHome);
-				$adduser .= " -m -d \"$uHome\"";
-			}
-			if (defined $gid) {
-				# add user to primary group by group ID
-				$adduser .= " -g $gid";
-				$moduser .= " -g $gid";
-			} elsif (defined $group) {
-				# add user to primary group by group name
-				$adduser .= " -g $group";
-				$moduser .= " -g $group";
-			}
-			if (defined $uID) {
-				$adduser .= " -u $uID";
-			}
-			if (defined $group) {
-				# create group if it does not exist
-				my $data = qxx (
-					"chroot $root grep -q ^$group: /etc/group 2>&1"
-				);
-				my $code = $? >> 8;
-				$group = quoteshell ($group);
-				if ($code != 0) {
-					$kiwi -> info ("Adding group: $group");
-					if (defined $gid) {
-						$addgroup .= " -g $gid";
-					}
-					my $data = qxx ("chroot $root $addgroup \"$group\"");
-					my $code = $? >> 8;
-					if ($code != 0) {
-						$kiwi -> failed ();
-						$kiwi -> info   ($data);
-						$kiwi -> failed ();
-						return;
-					}
-					$kiwi -> done();
-				}
-			}
-			if (defined $uRname) {
-				$uRname = quoteshell ($uRname);
-				$adduser .= " -c \"$uRname\"";
-				$moduser .= " -c \"$uRname\"";
-			}
-			my $data = qxx ("chroot $root grep -q ^$uName: /etc/passwd 2>&1");
-			my $code = $? >> 8;
-			if ($code != 0) {
-				$kiwi -> info ("Adding user: $uName [$group]");
-				$data = qxx ( "chroot $root $adduser $uName 2>&1" );
-				$code = $? >> 8;
-			} else {
-				$kiwi -> info ("Modifying user: $uName [$group]");
-				$data = qxx ( "chroot $root $moduser $uName 2>&1" );
-				$code = $? >> 8;
-			}
-			if ($code != 0) {
-				$kiwi -> failed ();
-				$kiwi -> info   ($data);
-				$kiwi -> failed ();
-				return;
-			}
-			$kiwi -> done ();
-			if ((defined $uHome) && (-d "$root/$uHome")) {
-				my $iMsg = "Setting owner/group permissions $uName [$group]";
-				$kiwi -> info($iMsg);
-				$data = qxx("chroot $root chown -R $uName:$group $uHome 2>&1");
-				$code = $? >> 8;
-				if ($code != 0) {
-					$kiwi -> failed ();
-					$kiwi -> info   ($data);
-					$kiwi -> failed ();
-					return;
-				}
-				$kiwi -> done();
-			}
+sub setupTimezone {
+	# ...
+	# Setup the configuration for the timezone
+	# ---
+	my $this = shift;
+	my $kiwi    = $this->{kiwi};
+	my $locator = $this->{locator};
+	my $root    = $this->{root};
+	my $xml     = $this->{xml};
+	my $tz = $xml -> getPreferences() -> getTimezone();
+	my $timectl = $locator -> getExecPath('timedatectl', $root);
+	if ($timectl) {
+		qxx("$timectl set-timezone $tz 2>&1");
+		my $code = $? >> 8;
+		if ($code != 0) {
+			$kiwi -> loginfo ("warning: unable to set the timezone\n");
 		}
 	}
 	return $this;
 }
 
-#==========================================
-# setupAutoYaST
-#------------------------------------------
-sub setupAutoYaST {
-	# ...
-	# This function will make use of the autoyast system and setup
-	# the image to call the autoyast automatically on first boot of
-	# the system. To activate the call of yast on first boot the
-	# file /var/lib/YaST2/runme_at_boot is created. Please note
-	# according to the YaST people this is not the preferred method
-	# of calling YaST to perform tasks on first boot. Use the function
-	# setupFirstBootYaST below which uses yast2-firstboot to do the job
-	# ---
-	my $this = shift;
-	my $kiwi = $this->{kiwi};
-	my $root = $this->{root};
-	my $imageDesc = $this->{imageDesc};
-	if (! -f "$imageDesc/config-yast-autoyast.xml") {
-		return "skipped";
-	}
-	$kiwi -> info ("Setting up AutoYaST...");
-	my $autodir = "var/lib/autoinstall/autoconf";
-	my $autocnf = "autoconf.xml";
-	if (! -d "$root/$autodir") {
-		$kiwi -> failed ();
-		$kiwi -> error  ("AutoYaST seems not to be installed");
-		$kiwi -> failed ();
-		return "failed";
-	}
-	qxx (
-		"cp $imageDesc/config-yast-autoyast.xml $root/$autodir/$autocnf 2>&1"
-	);
-	my $INFFD = FileHandle -> new();
-	if ( ! $INFFD -> open (">$root/etc/install.inf")) {
-		$kiwi -> failed ();
-		$kiwi -> error ("Failed to create install.inf: $!");
-		$kiwi -> failed ();
-		return "failed";
-	}
-	print $INFFD "AutoYaST: http://192.168.100.99/part2.xml\n";
-	$INFFD -> close();
-	my $AUTOFD = FileHandle -> new();
-	if ( ! $AUTOFD -> open (">$root/var/lib/YaST2/runme_at_boot")) {
-		$kiwi -> failed ();
-		$kiwi -> error ("Failed to create runme_at_boot: $!");
-		$kiwi -> failed ();
-		return "failed";
-	}
-	$AUTOFD -> close();
-	$kiwi -> done ();
-	return "success";
-}
 
 #==========================================
-# setupFirstBootYaST
+# setupUsers
 #------------------------------------------
-sub setupFirstBootYaST {
-	# ...
-	# This function is based on the yast2-firstboot functionality which
-	# is a service which will be enabled by insserv. The firstboot service
-	# uses a different xml format than the autoyast system. According to
-	# this the input file has a different name. the firstboot input file
-	# is preferred over the config-yast-autoyast.xml file
-	# ---
-	my $this = shift;
-	my $kiwi = $this->{kiwi};
-	my $root = $this->{root};
-	my $imageDesc = $this->{imageDesc};
-	if (! -f "$imageDesc/config-yast-firstboot.xml") {
-		return "skipped";
-	}
-	$kiwi -> info ("Setting up YaST firstboot service...");
-	if (
-		(! -f "$root/etc/init.d/firstboot") &&
-		(! -f "$root/usr/share/YaST2/clients/firstboot.ycp")
-	) {
-		$kiwi -> failed ();
-		$kiwi -> error  ("yast2-firstboot is not installed");
-		$kiwi -> failed ();
-		return "failed";
-	}
-	my $firstboot = "$root/etc/YaST2/firstboot.xml";
-	my $data = qxx ("cp $imageDesc/config-yast-firstboot.xml $firstboot 2>&1");
-	my $code = $? >> 8;
-	if ($code != 0) {
-		$kiwi -> failed ();
-		$kiwi -> error  ("Failed to copy config-yast-firstboot.xml: $data");
-		$kiwi -> failed ();
-		return "failed"; 
-	}
-	# /.../
-	# keep an existing /etc/sysconfig/firstboot or copy the template
-	# from yast2-firstboot package if both don't exist, write a
-	# generic one (bnc#604705)
-	# ----
-	if ( ! -e "$root/etc/sysconfig/firstboot" ) {
-		my $FBFD = FileHandle -> new();
-		if ( -e "$root/var/adm/fillup-templates/sysconfig.firstboot" ) {
-			my $template = "$root/var/adm/fillup-templates/sysconfig.firstboot";
-			my $data = qxx (
-				"cp $template $root/etc/sysconfig/firstboot 2>&1"
-			);
-			my $code = $? >> 8;
-			if ($code != 0) {
-				$kiwi -> failed ();
-				$kiwi -> error  (
-					"Failed to copy firstboot-sysconfig templage: $data"
-				);
-				$kiwi -> failed ();
-				return "failed";
-			}
-		} elsif ( ! $FBFD -> open (">$root/etc/sysconfig/firstboot")) {
+sub setupUsers {
+	my $this  = shift;
+	my $kiwi    = $this->{kiwi};
+	my $locator = $this->{locator};
+	my $root    = $this->{root};
+	my $xml     = $this->{xml};
+	my $users    = $xml -> getUsers();
+	my $adduser  = $locator -> getExecPath('useradd', $root);
+	my $moduser  = $locator -> getExecPath('usermod', $root);
+	my $numUsers = scalar @{$users};
+	if ($numUsers) {
+		if (! $adduser) {
+			$kiwi -> error ("Missing useradd command");
 			$kiwi -> failed ();
-			$kiwi -> error ("Failed to create /etc/sysconfig/firstboot: $!");
+			return;
+		}
+		if (! $moduser) {
+			$kiwi -> error ("Missing usermod command");
 			$kiwi -> failed ();
-			return "failed";
-		} else {
-			print $FBFD "## Description: Firstboot Configuration\n";
-			print $FBFD "## Default: /usr/share/firstboot/scripts\n";
-			print $FBFD "SCRIPT_DIR=\"/usr/share/firstboot/scripts\"\n";
-			print $FBFD "FIRSTBOOT_WELCOME_DIR=\"/usr/share/firstboot\"\n";
-			print $FBFD "FIRSTBOOT_WELCOME_PATTERNS=\"\"\n";
-			print $FBFD "FIRSTBOOT_LICENSE_DIR=\"/usr/share/firstboot\"\n";
-			print $FBFD "FIRSTBOOT_NOVELL_LICENSE_DIR=\"/etc/YaST2\"\n";
-			print $FBFD "FIRSTBOOT_FINISH_FILE=";
-			print $FBFD "\"/usr/share/firstboot/congrats.txt\"\n";
-			print $FBFD "FIRSTBOOT_RELEASE_NOTES_PATH=\"\"\n";
-			$FBFD -> close();
+			return;
 		}
 	}
-	if (-f "$root/etc/init.d/firstboot") {
-		# /.../
-		# old service script based firstboot service. requires some
-		# default services to run
-		# ----
-		my @services = (
-			"boot.rootfsck","boot.localfs",
-			"boot.cleanup","boot.localfs","boot.localnet",
-			"boot.clock","policykitd","dbus","consolekit",
-			"haldaemon","network","atd","syslog","cron",
-			"firstboot"
-		);
-		foreach my $service (@services) {
-			if (! -e "$root/etc/init.d/$service") {
-				next;
-			}
-			$data = qxx (
-				"chroot $root /sbin/insserv /etc/init.d/$service 2>&1"
-			);
+	for my $user (@{$users}) {
+		my $group     = $user -> getGroupName();
+		my $gid       = $user -> getGroupID();
+		my $logShell  = $user -> getLoginShell();
+		my $pwd       = $user -> getPassword();
+		my $pwdformat = $user -> getPasswordFormat();
+		my $uHome     = $user -> getUserHomeDir();
+		my $uID       = $user -> getUserID();
+		my $uName     = $user -> getUserName();
+		my $uRname    = $user -> getUserRealName();
+
+		if ((defined $pwdformat) && ($pwdformat eq 'plain')) {
+			$pwd = main::createPassword ($pwd);
+		}
+		if (defined $pwd) {
+			$adduser .= " -p '$pwd'";
+			$moduser .= " -p '$pwd'";
+		}
+		if (defined $logShell) {
+			$adduser .= " -s '$logShell'";
+			$moduser .= " -s '$logShell'";
+		}
+		if (defined $uHome) {
+			$uHome = quoteshell ($uHome);
+			$adduser .= " -m -d \"$uHome\"";
+		}
+		if (defined $gid) {
+			# add user to primary group by group ID
+			$adduser .= " -g $gid";
+			$moduser .= " -g $gid";
+		} elsif (defined $group) {
+			# add user to primary group by group name
+			$adduser .= " -g $group";
+			$moduser .= " -g $group";
+		}
+		if (defined $uID) {
+			$adduser .= " -u $uID";
+		}
+		if (defined $uRname) {
+			$uRname = quoteshell ($uRname);
+			$adduser .= " -c \"$uRname\"";
+			$moduser .= " -c \"$uRname\"";
+		}
+		my $data = qxx ("chroot $root grep -q ^$uName: /etc/passwd 2>&1");
+		my $code = $? >> 8;
+		if ($code != 0) {
+			$kiwi -> info ("Adding user: $uName [$group]");
+			$data = qxx ( "chroot $root $adduser $uName 2>&1" );
+			$code = $? >> 8;
+		} else {
+			$kiwi -> info ("Modifying user: $uName [$group]");
+			$data = qxx ( "chroot $root $moduser $uName 2>&1" );
+			$code = $? >> 8;
+		}
+		if ($code != 0) {
+			$kiwi -> failed ();
+			$kiwi -> info ($data);
+			$kiwi -> failed ();
+			return;
+		}
+		$kiwi -> done ();
+		if ((defined $uHome) && (-d "$root/$uHome")) {
+			my $iMsg = "Setting owner/group permissions $uName [$group]";
+			$kiwi -> info($iMsg);
+			$data = qxx("chroot $root chown -R $uName:$group $uHome 2>&1");
 			$code = $? >> 8;
 			if ($code != 0) {
 				$kiwi -> failed ();
-				$kiwi -> error ("Failed to activate service(s): $data");
+				$kiwi -> info ($data);
 				$kiwi -> failed ();
-				return "failed";
+				return;
 			}
-		}
-		$data = qxx ("touch $root/etc/reconfig_system 2>&1");
-		$code = $? >> 8;
-		if ($code != 0) {
-			$kiwi -> failed ();
-			$kiwi -> error ("Failed to activate firstboot: $data");
-			$kiwi -> failed ();
-			return "failed";
-		}
-	} else {
-		# /.../
-		# current firstboot service works like yast second stage and
-		# is activated by touching /var/lib/YaST2/reconfig_system
-		# ----
-		$data = qxx ("touch $root/var/lib/YaST2/reconfig_system 2>&1");
-		$code = $? >> 8;
-		if ($code != 0) {
-			$kiwi -> failed ();
-			$kiwi -> error ("Failed to activate firstboot: $data");
-			$kiwi -> failed ();
-			return "failed";
+			$kiwi -> done();
 		}
 	}
-	$kiwi -> done();
-	return "success";
+	return $this;
 }
 
-#==========================================
-# setupFirstBootAnaconda
-#------------------------------------------
-sub setupFirstBootAnaconda {
-	# ...
-	# This function activates the RHEL firstboot mechanism.
-	# So far I did not find a way to tell firstboot what
-	# modules it should call. firstboot is activated if the
-	# file config-anaconda-firstboot exists as part of your
-	# image description
-	# ---
-	my $this = shift;
-	my $kiwi = $this->{kiwi};
-	my $root = $this->{root};
-	my $imageDesc = $this->{imageDesc};
-	if (! -f "$imageDesc/config-anaconda-firstboot") {
-		return "skipped";
-	}
-	$kiwi -> info ("Setting up Anaconda firstboot service...");
-	#==========================================
-	# touch/remove some files
-	#------------------------------------------
-	qxx ("touch $root/etc/reconfigSys 2>&1");
-	qxx ("rm -f /etc/sysconfig/firstboot 2>&1");
-	#==========================================
-	# activate service
-	#------------------------------------------
-	my $data = qxx ("chroot $root chkconfig --level 35 firstboot on 2>&1");
-	my $code = $? >> 8;
-	if ($code != 0) {
-		$kiwi -> failed ();
-		$kiwi -> error ("Failed to activate firstboot: $data");
-		$kiwi -> failed ();
-		return "failed";
-	}
-	$kiwi -> done();
-	return "success";
-}
 
 #==========================================
 # quoteshell
@@ -556,7 +684,7 @@ sub quoteshell {
 	# expansion is enabled, !.
 	# ----
 	my $name = shift;
-	$name =~ s/([\"\$\!\`\\])/\\$1/g;
+	$name =~ s/([\"\$\!\`\\])/\\$1/gmsx;
 	return $name;
 }
 

--- a/modules/KIWILocator.pm
+++ b/modules/KIWILocator.pm
@@ -271,10 +271,14 @@ sub getExecPath {
 	# ---
 	my $this     = shift;
 	my $execName = shift;
+	my $root     = shift;
 	my $kiwi     = $this->{kiwi};
-	my $execPath = qxx (
-		"bash -c \"PATH=\$PATH:/sbin which $execName\" 2>&1"
-	);
+	my $cmd = q{};
+	if ($root) {
+		$cmd .= "chroot $root ";
+	}
+	$cmd .= 'bash -c "PATH=$PATH:/sbin which ' . $execName .  '" 2>&1';
+	my $execPath = qxx ($cmd);
 	chomp $execPath;
 	my $code = $? >> 8;
 	if ($code != 0) {

--- a/modules/KIWIRoot.pm
+++ b/modules/KIWIRoot.pm
@@ -981,7 +981,7 @@ sub setup {
 	my $manager   = $this->{manager};
 	my $data;
 	my $status;
-	#======================================== 
+	#========================================
 	# Consistency check
 	#----------------------------------------
 	if (! -d "$root/tmp") {
@@ -1148,24 +1148,31 @@ sub setup {
 		}
 	}
 	#========================================
-	# setup users/groups
+	# Apply system configuration
 	#----------------------------------------
-	if (! $configure -> setupUsersGroups()) {
+	if (! $configure -> setupGroups()) {
 		return;
 	}
+	if (! $configure -> setupUsers()) {
+		return;
+	}
+	$configure -> setupHWclock();
+	$configure -> setupKeyboardMap();
+	$configure -> setupLocale();
+	$configure -> setupTimezone();
 	#========================================
 	# check for yast firstboot setup file
 	#----------------------------------------
 	$status = $configure -> setupFirstBootYaST();
-	if ($status eq "failed") {
+	if (! $status) {
 		return;
 	}
 	$status = $configure -> setupAutoYaST();
-	if ($status eq "failed") {
+	if (! $status) {
 		return;
 	}
 	$status = $configure -> setupFirstBootAnaconda();
-	if ($status eq "failed") {
+	if (! $status) {
 		return;
 	}
 	#========================================


### PR DESCRIPTION
- use the localectl and datetimectl implementations provided by
  systemd to set the configuration
  - short circuit the suseConfig function in the shell code
    if localectl exists
  - implement the configuration in Perl code, now all configuration
    settings are implemented in the same class
  - remove the call to suseConfig in the config.sh files of our examples
- clean up the KIWIConfigure implementation to critic level 3
- add deprecation message to the old implementation
