### PR TITLE
the examples, follow our own advice ;)

### DIFF
--- a/doc/examples/suse-12.3/suse-live-iso/config.xml
+++ b/doc/examples/suse-12.3/suse-live-iso/config.xml
@@ -39,5 +39,6 @@
 	<packages type="bootstrap">
 		<package name="filesystem"/>
 		<package name="glibc-locale"/>
+		<package name="module-init-tools"/> 
 	</packages>
 </image>

--- a/doc/examples/suse-12.3/suse-live-usbstick/config.xml
+++ b/doc/examples/suse-12.3/suse-live-usbstick/config.xml
@@ -47,5 +47,6 @@
 	<packages type="bootstrap">
 		<package name="filesystem"/>
 		<package name="glibc-locale"/>
+		<package name="module-init-tools"/> 
 	</packages>
 </image>

--- a/doc/examples/suse-12.3/suse-oem-preload/config.xml
+++ b/doc/examples/suse-12.3/suse-oem-preload/config.xml
@@ -38,5 +38,6 @@
 	<packages type="bootstrap">
 		<package name="filesystem"/>
 		<package name="glibc-locale"/>
+		<package name="module-init-tools"/> 
 	</packages>
 </image>

--- a/doc/examples/suse-12.3/suse-pxe-client/config.xml
+++ b/doc/examples/suse-12.3/suse-pxe-client/config.xml
@@ -66,5 +66,6 @@
 	<packages type="bootstrap">
 		<package name="filesystem"/>
 		<package name="glibc-locale"/>
+		<package name="module-init-tools"/> 
 	</packages>
 </image>

--- a/doc/examples/suse-12.3/suse-vm-guest/config.xml
+++ b/doc/examples/suse-12.3/suse-vm-guest/config.xml
@@ -39,5 +39,6 @@
 	<packages type="bootstrap">
 		<package name="filesystem"/>
 		<package name="glibc-locale"/>
+		<package name="module-init-tools"/> 
 	</packages>
 </image>

--- a/doc/examples/suse-12.3/suse-xen-guest/config.xml
+++ b/doc/examples/suse-12.3/suse-xen-guest/config.xml
@@ -40,5 +40,6 @@
 	<packages type="bootstrap">
 		<package name="filesystem"/>
 		<package name="glibc-locale"/>
+		<package name="module-init-tools"/> 
 	</packages>
 </image>


### PR DESCRIPTION
- fix the openSUSE 12.3 examples, add module-init-tools to bootstrap package list
