### PR TITLE
new user feature

### DIFF
--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -241,10 +241,6 @@ function baseSetupOEMPartition {
 		echo "Setting up OEM_REBOOT_INTERACTIVE=1"
 		echo "OEM_REBOOT_INTERACTIVE=1" >> $oemfile
 	fi
-	if [ ! -z "$kiwi_oemsilentboot" ];then
-		echo "Setting up OEM_SILENTBOOT=1"
-		echo "OEM_SILENTBOOT=1" >> $oemfile
-	fi
 	if [ ! -z "$kiwi_oemshutdown" ];then
 		echo "Setting up OEM_SHUTDOWN=1"
 		echo "OEM_SHUTDOWN=1" >> $oemfile
@@ -252,6 +248,18 @@ function baseSetupOEMPartition {
 	if [ ! -z "$kiwi_oemshutdowninteractive" ];then
 		echo "Setting up OEM_SHUTDOWN_INTERACTIVE=1"
 		echo "OEM_SHUTDOWN_INTERACTIVE=1" >> $oemfile
+	fi
+	if [ ! -z "$kiwi_oemsilentboot" ];then
+		echo "Setting up OEM_SILENTBOOT=1"
+		echo "OEM_SILENTBOOT=1" >> $oemfile
+	fi
+	if [ ! -z "$kiwi_oemsilentinstall" ];then
+		echo "Setting up OEM_SILENTINSTALL=1"
+		echo "OEM_SILENTINSTALL=1" >> $oemfile
+	fi
+	if [ ! -z "$kiwi_oemsilentverify" ];then
+		echo "Setting up OEM_SILENTVERIFY=1"
+		echo "OEM_SILENTVERIFY=1" >> $oemfile
 	fi
 	if [ ! -z "$kiwi_oemalign" ];then
 		echo "Setting up OEM_ALIGN=1"

--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -422,12 +422,16 @@ sub updateDescription {
 		$src_xml->getOEMReboot_legacy();
 	$changeset{"oem-reboot-interactive"}   =
 		$src_xml->getOEMRebootInter_legacy();
-	$changeset{"oem-silent-boot"}          =
-		$src_xml->getOEMSilentBoot_legacy();
 	$changeset{"oem-shutdown"}             =
 		$src_xml->getOEMShutdown_legacy();
 	$changeset{"oem-shutdown-interactive"} =
 		$src_xml->getOEMShutdownInter_legacy();
+	$changeset{"oem-silent-boot"}          =
+		$src_xml->getOEMSilentBoot_legacy();
+	$changeset{"oem-silent-install"}          =
+		$src_xml->getOEMSilentInstall_legacy();
+	$changeset{"oem-silent-verify"}          =
+		$src_xml->getOEMSilentVerify_legacy();
 	$changeset{"oem-bootwait"}             =
 		$src_xml->getOEMBootWait_legacy();
 	$changeset{"oem-unattended"}           =

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -901,6 +901,48 @@ div {
 }
 
 #==========================================
+# common element <oem-silent-install>
+#
+div {
+	k.oem-silent-install.content = xsd:boolean
+	k.oem-silent-install.attlist = empty
+	k.oem-silent-install =
+		## For oemboot driven images: do not show progress of the image
+        ## dump process, true/false
+		[
+		db:para [
+			"For oemboot driven images: do not show progress of the image "~
+            "dump process, true/false (default is false.) "
+		]
+		]
+		element oem-silent-install {
+            k.oem-silent-install.attlist,
+			k.oem-silent-install.content
+		}
+}
+
+#==========================================
+# common element <oem-silent-verify>
+#
+div {
+	k.oem-silent-verify.content = xsd:boolean
+	k.oem-silent-verify.attlist = empty
+	k.oem-silent-verify =
+		## For oemboot driven images: do not show progress of the image
+        ## verification process, true/false
+		[
+		db:para [
+			"For oemboot driven images: do not show progress of the image "~
+            "verification process, true/false (default is false.) "
+		]
+		]
+		element oem-silent-verify {
+            k.oem-silent-verify.attlist,
+			k.oem-silent-verify.content
+		}
+}
+
+#==========================================
 # common element <oem-swap>
 #
 div {
@@ -2431,9 +2473,11 @@ div {
 			k.oem-reboot-interactive? &
 			k.oem-recovery? &
 			k.oem-recoveryID? &
-			k.oem-silent-boot? &
 			k.oem-shutdown? &
 			k.oem-shutdown-interactive? &
+			k.oem-silent-boot? &
+			k.oem-silent-install? &
+			k.oem-silent-verify? &
 			k.oem-swap? &
 			k.oem-swapsize? &
 			k.oem-systemsize? &

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -1149,6 +1149,50 @@ true/false</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <oem-silent-install>
+    
+  -->
+  <div>
+    <define name="k.oem-silent-install.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.oem-silent-install.attlist">
+      <empty/>
+    </define>
+    <define name="k.oem-silent-install">
+      <element name="oem-silent-install">
+        <a:documentation>For oemboot driven images: do not show progress of the image
+dump process, true/false</a:documentation>
+        <db:para>For oemboot driven images: do not show progress of the image dump process, true/false (default is false.) </db:para>
+        <ref name="k.oem-silent-install.attlist"/>
+        <ref name="k.oem-silent-install.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <oem-silent-verify>
+    
+  -->
+  <div>
+    <define name="k.oem-silent-verify.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.oem-silent-verify.attlist">
+      <empty/>
+    </define>
+    <define name="k.oem-silent-verify">
+      <element name="oem-silent-verify">
+        <a:documentation>For oemboot driven images: do not show progress of the image
+verification process, true/false</a:documentation>
+        <db:para>For oemboot driven images: do not show progress of the image verification process, true/false (default is false.) </db:para>
+        <ref name="k.oem-silent-verify.attlist"/>
+        <ref name="k.oem-silent-verify.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <oem-swap>
     
   -->
@@ -3474,13 +3518,19 @@ and setup the system disk</db:para>
             <ref name="k.oem-recoveryID"/>
           </optional>
           <optional>
-            <ref name="k.oem-silent-boot"/>
-          </optional>
-          <optional>
             <ref name="k.oem-shutdown"/>
           </optional>
           <optional>
             <ref name="k.oem-shutdown-interactive"/>
+          </optional>
+          <optional>
+            <ref name="k.oem-silent-boot"/>
+          </optional>
+          <optional>
+            <ref name="k.oem-silent-install"/>
+          </optional>
+          <optional>
+            <ref name="k.oem-silent-verify"/>
           </optional>
           <optional>
             <ref name="k.oem-swap"/>

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -2674,6 +2674,10 @@ sub __createOEMConfig {
 		$this -> __getChildNodeTextValue($config, 'oem-shutdown-interactive');
 	$oemConfig{oem_silent_boot}          =
 		$this -> __getChildNodeTextValue($config, 'oem-silent-boot');
+	$oemConfig{oem_silent_install}          =
+		$this -> __getChildNodeTextValue($config, 'oem-silent-install');
+	$oemConfig{oem_silent_verify}          =
+		$this -> __getChildNodeTextValue($config, 'oem-silent-verify');
 	$oemConfig{oem_swap}                 =
 		$this -> __getChildNodeTextValue($config, 'oem-swap');
 	$oemConfig{oem_swapsize}             =
@@ -6306,12 +6310,16 @@ sub getImageConfig_legacy {
 			-> getElementsByTagName ("oem-reboot");
 		my $oemrebootinter= $node
 			-> getElementsByTagName ("oem-reboot-interactive");
-		my $oemsilentboot = $node
-			-> getElementsByTagName ("oem-silent-boot");
 		my $oemshutdown= $node
 			-> getElementsByTagName ("oem-shutdown");
 		my $oemshutdowninter= $node
 			-> getElementsByTagName ("oem-shutdown-interactive");
+		my $oemsilentboot = $node
+			-> getElementsByTagName ("oem-silent-boot");
+		my $oemsilentinstall = $node
+			-> getElementsByTagName ("oem-silent-install");
+		my $oemsilentverify = $node
+			-> getElementsByTagName ("oem-silent-verify");
 		my $oemwait  = $node
 			-> getElementsByTagName ("oem-bootwait");
 		my $oemnomsg = $node
@@ -6357,14 +6365,20 @@ sub getImageConfig_legacy {
 		if ((defined $oemrebootinter) && ("$oemrebootinter" eq "true")) {
 			$result{kiwi_oemrebootinteractive} = $oemrebootinter;
 		}
-		if ((defined $oemsilentboot) && ("$oemsilentboot" eq "true")) {
-			$result{kiwi_oemsilentboot} = $oemsilentboot;
-		}
 		if ((defined $oemshutdown) && ("$oemshutdown" eq "true")) {
 			$result{kiwi_oemshutdown} = $oemshutdown;
 		}
 		if ((defined $oemshutdowninter) && ("$oemshutdowninter" eq "true")) {
 			$result{kiwi_oemshutdowninteractive} = $oemshutdowninter;
+		}
+		if ((defined $oemsilentboot) && ("$oemsilentboot" eq "true")) {
+			$result{kiwi_oemsilentboot} = $oemsilentboot;
+		}
+		if ((defined $oemsilentinstall) && ("$oemsilentinstall" eq "true")) {
+			$result{kiwi_oemsilentinstall} = $oemsilentinstall;
+		}
+		if ((defined $oemsilentverify) && ("$oemsilentverify" eq "true")) {
+			$result{kiwi_oemsilentverify} = $oemsilentverify;
 		}
 		if ((defined $oemwait) && ("$oemwait" eq "true")) {
 			$result{kiwi_oembootwait} = $oemwait;
@@ -7752,6 +7766,46 @@ sub getOEMSilentBoot_legacy {
 		return;
 	}
 	my $silent = $node -> getElementsByTagName ("oem-silent-boot");
+	if ((! defined $silent) || ("$silent" eq "")) {
+		return;
+	}
+	return "$silent";
+}
+
+#==========================================
+# getOEMSilentInstall_legacy
+#------------------------------------------
+sub getOEMSilentInstall_legacy {
+	# ...
+	# Obtain the oem-silent-install value or return undef
+	# ---
+	my $this = shift;
+	my $tnode= $this->{typeNode};
+	my $node = $tnode -> getElementsByTagName ("oemconfig") -> get_node(1);
+	if (! defined $node) {
+		return;
+	}
+	my $silent = $node -> getElementsByTagName ("oem-silent-install");
+	if ((! defined $silent) || ("$silent" eq "")) {
+		return;
+	}
+	return "$silent";
+}
+
+#==========================================
+# getOEMSilentVerify_legacy
+#------------------------------------------
+sub getOEMSilentVerify_legacy {
+	# ...
+	# Obtain the oem-silent-verify value or return undef
+	# ---
+	my $this = shift;
+	my $tnode= $this->{typeNode};
+	my $node = $tnode -> getElementsByTagName ("oemconfig") -> get_node(1);
+	if (! defined $node) {
+		return;
+	}
+	my $silent = $node -> getElementsByTagName ("oem-silent-verify");
 	if ((! defined $silent) || ("$silent" eq "")) {
 		return;
 	}

--- a/modules/KIWIXMLOEMConfigData.pm
+++ b/modules/KIWIXMLOEMConfigData.pm
@@ -52,6 +52,8 @@ sub new {
 	#    oem_shutdown             = ''
 	#    oem_shutdown_interactive = ''
 	#    oem_silent_boot          = ''
+	#    oem_silent_install       = ''
+	#    oem_silent_verify        = ''
 	#    oem_swap                 = ''
 	#    oem_swapsize             = ''
 	#    oem_systemsize           = ''
@@ -85,6 +87,8 @@ sub new {
 		oem_shutdown
 		oem_shutdown_interactive
 		oem_silent_boot
+		oem_silent_install
+		oem_silent_verify
 		oem_swap
 		oem_swapsize
 		oem_systemsize
@@ -104,6 +108,8 @@ sub new {
 		oem_shutdown
 		oem_shutdown_interactive
 		oem_silent_boot
+		oem_silent_install
+		oem_silent_verify
 		oem_swap
 		oem_unattended
 	);
@@ -272,6 +278,28 @@ sub getSilentBoot {
 }
 
 #==========================================
+# getSilentInstall
+#------------------------------------------
+sub getSilentInstall {
+	# ...
+	# Return the setting for the oem-silent-install configuration
+	# ---
+	my $this = shift;
+	return $this->{oem_silent_install};
+}
+
+#==========================================
+# getSilentVerify
+#------------------------------------------
+sub getSilentVerify {
+	# ...
+	# Return the setting for the oem-silent-verify configuration
+	# ---
+	my $this = shift;
+	return $this->{oem_silent_verify};
+}
+
+#==========================================
 # getSwap
 #------------------------------------------
 sub getSwap {
@@ -413,6 +441,18 @@ sub getXMLElement {
 		text      => $this -> getSilentBoot ()
 	);
 	$element = $this -> __addElement(\%initSBoot);
+	my %initSInst = (
+		parent    => $element,
+		childName => 'oem-silent-install',
+		text      => $this -> getSilentInstall ()
+	);
+	$element = $this -> __addElement(\%initSInst);
+	my %initSVerify = (
+		parent    => $element,
+		childName => 'oem-silent-verify',
+		text      => $this -> getSilentVerify ()
+	);
+	$element = $this -> __addElement(\%initSVerify);
 	my %initSwap = (
 		parent    => $element,
 		childName => 'oem-swap',
@@ -729,6 +769,42 @@ sub setSilentBoot {
 		attr   => 'oem_silent_boot',
 		value  => $val,
 		caller => 'setSilentBoot'
+	);
+	return $this -> __setBooleanValue(\%settings);
+}
+
+#==========================================
+# setSilentInstall
+#------------------------------------------
+sub setSilentInstall {
+	# ...
+	# Set the oem_silent_install attribute, if called with no argument the
+	# value is set to false.
+	# ---
+	my $this = shift;
+	my $val  = shift;
+	my %settings = (
+		attr   => 'oem_silent_install',
+		value  => $val,
+		caller => 'setSilentInstall'
+	);
+	return $this -> __setBooleanValue(\%settings);
+}
+
+#==========================================
+# setSilentVerify
+#------------------------------------------
+sub setSilentVerify {
+	# ...
+	# Set the oem_silent_verify attribute, if called with no argument the
+	# value is set to false.
+	# ---
+	my $this = shift;
+	my $val  = shift;
+	my %settings = (
+		attr   => 'oem_silent_verify',
+		value  => $val,
+		caller => 'setSilentVerify'
 	);
 	return $this -> __setBooleanValue(\%settings);
 }

--- a/system/boot/ix86/oemboot/suse-dump
+++ b/system/boot/ix86/oemboot/suse-dump
@@ -813,7 +813,7 @@ function OEMInstall {
 				dump="$dump | dcounter -s $needMByte -l \"$TEXT_LOAD \""
 			fi
 			Echo "Loading $Source [$Target] "
-			if [ -x /usr/bin/dcounter ];then
+			if [ -x /usr/bin/dcounter ] && [ ! -z "$OEM_SILENTINSTALL" ];then
 				test -e /progress || mkfifo /progress
 				Echo "Calling: eval $dump 2>/progress|dd bs=32k of=$Target"
 				errorLogStop
@@ -828,14 +828,14 @@ function OEMInstall {
 				)&
 				dump_pid=$!
 				echo "cat /progress | dialog \
-					--backtitle \"$TEXT_INSTALLTITLE\" \
-					--progressbox 3 65
+				    --backtitle \"$TEXT_INSTALLTITLE\" \
+				    --progressbox 3 65
 				" > /tmp/progress.sh
 				if [ -e /dev/fb0 ] && which fbiterm &>/dev/null;then
-					fbiterm -m $UFONT -- bash -e /tmp/progress.sh || \
+				    fbiterm -m $UFONT -- bash -e /tmp/progress.sh || \
 					bash -e /tmp/progress.sh
 				else
-					bash -e /tmp/progress.sh
+				    bash -e /tmp/progress.sh
 				fi
 				wait $dump_pid
 				clear
@@ -875,7 +875,7 @@ function OEMInstall {
 		Echo "Install complete, checking data..."
 		verifyBytes=$((blocks * blocksize))
 		verifyMByte=$((verifyBytes / 1048576))
-		if [ -x /usr/bin/dcounter ];then
+		if [ -x /usr/bin/dcounter ] && [ ! -z "$OEM_SILENTVERIFY" ];then
 			test -e /progress || mkfifo /progress
 			TEXT_VERIFY=$(getText "Verifying %1" $(basename $imageDevice))
 			echo "$TEXT_VERIFY ( 0% )" > /progress &
@@ -888,14 +888,14 @@ function OEMInstall {
 			)&
 			dump_pid=$!
 			echo "cat /progress | dialog \
-				--backtitle \"$TEXT_INSTALLTITLE\" \
+			    --backtitle \"$TEXT_INSTALLTITLE\" \
 				--progressbox 3 65
 			" > /tmp/progress.sh
 			if [ -e /dev/fb0 ] && which fbiterm &>/dev/null;then
-				fbiterm -m $UFONT -- bash -e /tmp/progress.sh || \
+			    fbiterm -m $UFONT -- bash -e /tmp/progress.sh || \
 				bash -e /tmp/progress.sh
 			else
-				bash -e /tmp/progress.sh
+			    bash -e /tmp/progress.sh
 			fi
 			wait $dump_pid
 			clear
@@ -1015,7 +1015,7 @@ function OEMInstall {
 	# Check for bootwait request
 	#--------------------------------------
 	if [ ! -z "$OEM_BOOTWAIT" ];then
-        if [ "$OEMInstallType" = "CD" ];then
+		if [ "$OEMInstallType" = "CD" ];then
 			TEXT_DUMP=$TEXT_CDPULL
 		else
 			TEXT_DUMP=$TEXT_USBPULL
@@ -1026,8 +1026,8 @@ function OEMInstall {
 		Dialog \
 			--backtitle \"$TEXT_INSTALLTITLE\" \
 			--msgbox "\"$TEXT_DUMP\"" 5 70
-        systemException "Reboot requested after image installation" \
-            "user_reboot"
+		systemException "Reboot requested after image installation" \
+			"user_reboot"
 	fi
 }
 

--- a/tests/unit/lib/Test/kiwiXMLOEMConfigData.pm
+++ b/tests/unit/lib/Test/kiwiXMLOEMConfigData.pm
@@ -666,6 +666,66 @@ sub test_getSilentBoot {
 }
 
 #==========================================
+# test_getSilentInstall
+#------------------------------------------
+sub test_getSilentInstall {
+	# ...
+	# Test the getSilentInstall method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $init = $this -> __getBaseInitHash();
+	my $confDataObj = KIWIXMLOEMConfigData -> new($init);
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $sBoot = $confDataObj -> getSilentInstall();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('true', $sBoot);
+	return;
+}
+
+#==========================================
+# test_getSilentVerify
+#------------------------------------------
+sub test_getSilentVerify {
+	# ...
+	# Test the getSilentVerify method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $init = $this -> __getBaseInitHash();
+	my $confDataObj = KIWIXMLOEMConfigData -> new($init);
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $sBoot = $confDataObj -> getSilentVerify();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('true', $sBoot);
+	return;
+}
+
+#==========================================
 # test_getSwap
 #------------------------------------------
 sub test_getSwap {
@@ -852,6 +912,8 @@ sub test_getXMLElement{
 		. '<oem-recovery>true</oem-recovery>'
 		. '<oem-recoveryID>1234</oem-recoveryID>'
 		. '<oem-silent-boot>true</oem-silent-boot>'
+		. '<oem-silent-install>true</oem-silent-install>'
+		. '<oem-silent-verify>true</oem-silent-verify>'
 		. '<oem-swap>true</oem-swap>'
 		. '<oem-swapsize>2048</oem-swapsize>'
 		. '<oem-systemsize>8192</oem-systemsize>'
@@ -2075,6 +2137,176 @@ sub test_setSilentBootNoArg {
 }
 
 #==========================================
+# test_setSilentInstall
+#------------------------------------------
+sub test_setSilentInstall {
+	# ...
+	# Test the setSilentInstall method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $confDataObj = KIWIXMLOEMConfigData -> new();
+	$confDataObj = $confDataObj -> setSilentInstall('true');
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $silent = $confDataObj -> getSilentInstall();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('true', $silent);
+	return;
+}
+
+#==========================================
+# test_setSilentInstallInvalidArg
+#------------------------------------------
+sub test_setSilentInstallInvalidArg {
+	# ...
+	# Test the setSilentInstall method with anunrecognized bool value
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $confDataObj = KIWIXMLOEMConfigData -> new();
+	my $res = $confDataObj -> setSilentInstall(1);
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'KIWIXMLOEMConfigData:setSilentInstall: unrecognized '
+		. 'argument expecting "true" or "false".';
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_null($res);
+	return;
+}
+
+#==========================================
+# test_setSilentInstallNoArg
+#------------------------------------------
+sub test_setSilentInstallNoArg {
+	# ...
+	# Test the setSilentInstall method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $init = $this -> __getBaseInitHash();
+	my $confDataObj = KIWIXMLOEMConfigData -> new($init);
+	$confDataObj = $confDataObj -> setSilentInstall();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $silent = $confDataObj -> getSilentInstall();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('false', $silent);
+	return;
+}
+
+#==========================================
+# test_setSilentVerify
+#------------------------------------------
+sub test_setSilentVerify {
+	# ...
+	# Test the setSilentVerify method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $confDataObj = KIWIXMLOEMConfigData -> new();
+	$confDataObj = $confDataObj -> setSilentVerify('true');
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $silent = $confDataObj -> getSilentVerify();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('true', $silent);
+	return;
+}
+
+#==========================================
+# test_setSilentVerifyInvalidArg
+#------------------------------------------
+sub test_setSilentVerifyInvalidArg {
+	# ...
+	# Test the setSilentVerify method with anunrecognized bool value
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $confDataObj = KIWIXMLOEMConfigData -> new();
+	my $res = $confDataObj -> setSilentVerify(1);
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'KIWIXMLOEMConfigData:setSilentVerify: unrecognized '
+		. 'argument expecting "true" or "false".';
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_null($res);
+	return;
+}
+
+#==========================================
+# test_setSilentVerifyNoArg
+#------------------------------------------
+sub test_setSilentVerifyNoArg {
+	# ...
+	# Test the setSilentVerify method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $init = $this -> __getBaseInitHash();
+	my $confDataObj = KIWIXMLOEMConfigData -> new($init);
+	$confDataObj = $confDataObj -> setSilentVerify();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $silent = $confDataObj -> getSilentVerify();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('false', $silent);
+	return;
+}
+
+#==========================================
 # test_setSwap
 #------------------------------------------
 sub test_setSwap {
@@ -2459,6 +2691,8 @@ sub __getBaseInitHash {
 				oem_recovery          => 'true',
 				oem_recoveryID        => '1234',
 				oem_silent_boot       => 'true',
+				oem_silent_install    => 'true',
+				oem_silent_verify     => 'true',
 				oem_swap              => 'true',
 				oem_swapsize          => '2048',
 				oem_systemsize        => '8192',


### PR DESCRIPTION
- allow the user to hide the install and verify ncurses progress dialogs during OEM image installation #791291
  - this is needed by Tyco
  - implement oem-silent-install and oem-silent-verify elements
    both are childeren of oemconfig
