### PR TITLE
Here's the rename

### DIFF
--- a/modules/KIWIConfigWriterFactory.pm
+++ b/modules/KIWIConfigWriterFactory.pm
@@ -88,8 +88,7 @@ sub getConfigWriter {
 	my $this = shift;
 	my $confDir = $this->{confDir};
 	my $xml  = $this->{xml};
-	my $type = $xml -> getImageType();
-	my $typeName = $type -> getImageType();
+	my $typeName = $xml -> getImageType() -> getTypeName();
 	SWITCH: for ($typeName) {
 		/^lxc/smx && do {
 			my $writer = KIWIContainerConfigWriter -> new($xml, $confDir);

--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -3594,7 +3594,7 @@ sub writeImageConfig {
 		# IMAGE information
 		#------------------------------------------
 		my $compressed = $bldType -> getCompressed();
-		my $imgType = $bldType -> getImageType();
+		my $imgType = $bldType -> getTypeName();
 		if ($compressed && $compressed eq 'true') {
 			print $FD "IMAGE='${device}${targetPartition};";
 			print $FD "$namecd;$server;$blocks;compressed'";

--- a/modules/KIWIImageBuildFactory.pm
+++ b/modules/KIWIImageBuildFactory.pm
@@ -81,8 +81,7 @@ sub getImageBuilder {
 	my $this = shift;
 	my $cmdL = $this->{cmdL};
 	my $xml  = $this->{xml};
-	my $type = $xml -> getImageType();
-	my $typeName = $type -> getImageType();
+	my $typeName = $xml -> getImageType() -> getTypeName();
 	SWITCH: for ($typeName) {
 		/^lxc/smx && do {
 			my $builder = KIWIContainerBuilder -> new($xml, $cmdL);

--- a/modules/KIWIImageBuilder.pm
+++ b/modules/KIWIImageBuilder.pm
@@ -110,7 +110,7 @@ sub __createBuildDir {
 	my $kiwi = $this->{kiwi};
 	my $xml  = $this->{xml};
 	my $destination = $cmdL -> getImageTargetDir();
-	my $typeName = $xml -> getImageType() -> getImageType();
+	my $typeName = $xml -> getImageType() -> getTypeName();
 	my $profileNames = $xml -> getActiveProfileNames();
 	my $workDirName = $typeName;
 	for my $prof (@{$profileNames}) {

--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -508,8 +508,7 @@ sub createEC2 {
 	#==========================================
 	# create initrd
 	#------------------------------------------
-	my $type = $xml -> getImageType();
-	my $imgType = $type -> getImageType();
+	my $imgType = $xml -> getImageType() -> getTypeName();
 	my $IRDFD = FileHandle -> new();
 	if (! $IRDFD -> open (">$tmpdir/create_initrd.sh")) {
 		$kiwi -> error  ("Failed to open $tmpdir/create_initrd.sh: $!");

--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -170,8 +170,7 @@ sub __checkContainerHasLXC {
 	# ---
 	my $this = shift;
 	my $xml = $this -> {xml};
-	my $type = $xml -> getImageType();
-	my $name = $type -> getImageType();
+	my $name = $xml -> getImageType() -> getTypeName();
 	if ($name =~ /^lxc/smx) {
 		my $pckgs = $xml -> getPackages();
 		push @{$pckgs}, @{$xml -> getBootstrapPackages()};
@@ -258,8 +257,8 @@ sub __checkFilesystemTool {
 	my $cmdL = $this -> {cmdArgs};
 	my $xml  = $this -> {xml};
 	my $type = $xml -> getImageType();
-	my $typeName = $type -> getImageType();
-	my $flag     = $type -> getFlags;
+	my $typeName = $type -> getTypeName();
+	my $flag     = $type -> getFlags();
 	my $toolError;
 	my $checkedFS;
 	my @knownFsTypes = qw (
@@ -459,8 +458,7 @@ sub __checkVMscsiCapable {
 	# ---
 	my $this = shift;
 	my $xml = $this -> {xml};
-	my $typeObj = $xml -> getImageType();
-	my $type = $typeObj -> getImageType();
+	my $type = $xml -> getImageType() -> getTypeName();
 	if ($type ne 'vmx') {
 		# Nothing to do
 		return 1;
@@ -695,7 +693,7 @@ sub __isoHybridCapable {
 	my $locator = $this->{locator};
 	my $xml = $this->{xml};
 	my $bldType = $xml -> getImageType();
-	my $imgType = $bldType -> getImageType();
+	my $imgType = $bldType -> getTypeName();
 	if ($imgType ne 'iso' && $imgType ne 'oem') {
 		return 1;
 	}

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -3728,7 +3728,7 @@ sub __getInstallData {
 	my $arch = $this->{arch};
 	my @selected = @{$this->{selectedProfiles}};
 	my $type = $this->{selectedType}{type};
-	my $typeName = $type -> getImageType();
+	my $typeName = $type -> getTypeName();
 	my @names;
 	for my $prof (@selected) {
 		my $baseData = $this->{imageConfig}{$prof}{$access};

--- a/modules/KIWIXMLInfo.pm
+++ b/modules/KIWIXMLInfo.pm
@@ -382,7 +382,7 @@ sub __getTree {
 			/^types/         && do {
 				# output default or primary built type first
 				my $tData = $xml -> getImageType();
-				my $defTypeName = $tData -> getImageType();
+				my $defTypeName = $tData -> getTypeName();
 				my $type = XML::LibXML::Element -> new('type');
 				$type -> setAttribute('name', $defTypeName);
 				$type -> setAttribute('primary', 'true');

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -489,17 +489,6 @@ sub getHybridPersistent {
 }
 
 #==========================================
-# getImageType
-#------------------------------------------
-sub getImageType {
-	# ...
-	# Return the image type
-	# ---
-	my $this = shift;
-	return $this->{image};
-}
-
-#==========================================
 # getInstallBoot
 #------------------------------------------
 sub getInstallBoot {
@@ -641,6 +630,17 @@ sub getSizeUnit {
 }
 
 #==========================================
+# getTypeName
+#------------------------------------------
+sub getTypeName {
+	# ...
+	# Return the image type
+	# ---
+	my $this = shift;
+	return $this->{image};
+}
+
+#==========================================
 # getVGA
 #------------------------------------------
 sub getVGA {
@@ -682,7 +682,7 @@ sub getXMLElement {
 	# ---
 	my $this = shift;
 	my $element = XML::LibXML::Element -> new('type');
-	$element -> setAttribute('image', $this -> getImageType());
+	$element -> setAttribute('image', $this -> getTypeName());
 	my $bootIm = $this -> getBootImageDescript();
 	if ($bootIm) {
 		$element -> setAttribute('boot', $bootIm);
@@ -1258,22 +1258,6 @@ sub setHybridPersistent {
 }
 
 #==========================================
-# setImageType
-#------------------------------------------
-sub setImageType {
-	# ...
-	# Set the image type
-	# ---
-	my $this = shift;
-	my $type = shift;
-	if (! $this -> __isValidImage($type, 'setImageType') ) {
-		return;
-	}
-	$this->{image} = $type;
-	return $this;
-}
-
-#==========================================
 # setInstallBoot
 #------------------------------------------
 sub setInstallBoot {
@@ -1526,6 +1510,23 @@ sub setSizeUnit {
 	$this->{sizeunit} = $unit;
 	return $this;
 }
+
+#==========================================
+# setTypeName
+#------------------------------------------
+sub setTypeName {
+	# ...
+	# Set the image type
+	# ---
+	my $this = shift;
+	my $type = shift;
+	if (! $this -> __isValidImage($type, 'setTypeName') ) {
+		return;
+	}
+	$this->{image} = $type;
+	return $this;
+}
+
 
 #==========================================
 # setVGA
@@ -1817,43 +1818,6 @@ sub __isValidFilesystem {
 }
 
 #==========================================
-# __isValidRaidType
-#------------------------------------------
-sub __isValidRaidType {
-	# ...
-	# Verify that the given raid type is supported
-	# ---
-	my $this   = shift;
-	my $mdtype = shift;
-	my $caller = shift;
-	my $kiwi = $this->{kiwi};
-	if (! $caller ) {
-		my $msg = 'Internal error __isValidRaidType called without '
-			. 'call origin argument.';
-		$kiwi -> info($msg);
-		$kiwi -> oops();
-	}
-	if (! $mdtype ) {
-		my $msg = "$caller: no raid type specified, retaining "
-			. 'current data.';
-		$kiwi -> error($msg);
-		$kiwi -> failed();
-		return;
-	}
-	my %supported = map { ($_ => 1) } qw(
-		mirroring striping
-	);
-	if (! $supported{$mdtype} ) {
-		my $msg = "$caller: specified raid type '$mdtype' is not "
-			. 'supported.';
-		$kiwi -> error($msg);
-		$kiwi -> failed();
-		return;
-	}
-	return 1;
-}
-
-#==========================================
 # __isValidFirmware
 #------------------------------------------
 sub __isValidFirmware {
@@ -1989,8 +1953,23 @@ sub __isValidImage {
 		return;
 	}
 	my %supported = map { ($_ => 1) } qw(
-		btrfs clicfs cpio ext2 ext3 ext4 iso lxc oem product pxe reiserfs
-		split squashfs tbz vmx xfs
+		btrfs
+		clicfs
+		cpio
+		ext2
+		ext3
+		ext4
+		iso
+		lxc
+		oem
+		product
+		pxe
+		reiserfs
+		split
+		squashfs
+		tbz
+		vmx
+		xfs
 	);
 	if (! $supported{$image} ) {
 		my $msg = "$caller: specified image '$image' is not "
@@ -2031,6 +2010,43 @@ sub __isValidInstBoot {
 	);
 	if (! $supported{$instB} ) {
 		my $msg = "$caller: specified installboot option '$instB' is not "
+			. 'supported.';
+		$kiwi -> error($msg);
+		$kiwi -> failed();
+		return;
+	}
+	return 1;
+}
+
+#==========================================
+# __isValidRaidType
+#------------------------------------------
+sub __isValidRaidType {
+	# ...
+	# Verify that the given raid type is supported
+	# ---
+	my $this   = shift;
+	my $mdtype = shift;
+	my $caller = shift;
+	my $kiwi = $this->{kiwi};
+	if (! $caller ) {
+		my $msg = 'Internal error __isValidRaidType called without '
+			. 'call origin argument.';
+		$kiwi -> info($msg);
+		$kiwi -> oops();
+	}
+	if (! $mdtype ) {
+		my $msg = "$caller: no raid type specified, retaining "
+			. 'current data.';
+		$kiwi -> error($msg);
+		$kiwi -> failed();
+		return;
+	}
+	my %supported = map { ($_ => 1) } qw(
+		mirroring striping
+	);
+	if (! $supported{$mdtype} ) {
+		my $msg = "$caller: specified raid type '$mdtype' is not "
 			. 'supported.';
 		$kiwi -> error($msg);
 		$kiwi -> failed();

--- a/tests/unit/lib/Test/kiwiImageBuildFactory.pm
+++ b/tests/unit/lib/Test/kiwiImageBuildFactory.pm
@@ -166,7 +166,7 @@ sub test_ctor_noArg2 {
 #------------------------------------------
 sub test_expectContBuilder {
 	# ...
-	# Test the KIWIImageBuildFactory with no argument
+	# Test the getImageBuilder method
 	# ---
 	my $this = shift;
 	my $kiwi = $this -> {kiwi};

--- a/tests/unit/lib/Test/kiwiXML.pm
+++ b/tests/unit/lib/Test/kiwiXML.pm
@@ -4320,7 +4320,7 @@ sub test_ctor_NoTypeDefaultPref {
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	$this -> assert_not_null($type);
-	my $imageT = $type -> getImageType();
+	my $imageT = $type -> getTypeName();
 	$this -> assert_str_equals('oem', $imageT);
 	return;
 }
@@ -5526,7 +5526,7 @@ sub test_getImageType {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	# Verify that we got the expected type
-	my $imageType = $typeInfo -> getImageType();
+	my $imageType = $typeInfo -> getTypeName();
 	$this -> assert_str_equals('vmx', $imageType);
 	return;
 }
@@ -5559,7 +5559,7 @@ sub test_getImageTypeProfiles {
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	# Verify that we got the expected type
-	my $imageType = $typeInfo -> getImageType();
+	my $imageType = $typeInfo -> getTypeName();
 	$this -> assert_str_equals('oem', $imageType);
 	return;
 }
@@ -5593,7 +5593,7 @@ sub test_getImageTypeProfilesNoPrimaryType {
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	$this -> assert_not_null($type);
-	my $imageT = $type -> getImageType();
+	my $imageT = $type -> getTypeName();
 	$this -> assert_str_equals('vmx', $imageT);
 	return;
 }
@@ -8932,7 +8932,7 @@ sub test_setBuildType {
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	# Verify that we got the expected type
-	my $imageType = $typeInfo -> getImageType();
+	my $imageType = $typeInfo -> getTypeName();
 	$this -> assert_str_equals('vmx', $imageType);
 	return;
 }
@@ -8974,7 +8974,7 @@ sub test_setBuildTypeInvalidArg {
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	# Verify that we got the expected type
-	my $imageType = $typeInfo -> getImageType();
+	my $imageType = $typeInfo -> getTypeName();
 	$this -> assert_str_equals('oem', $imageType);
 	return;
 }
@@ -9016,7 +9016,7 @@ sub test_setBuildTypeNoArg {
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	# Verify that we got the expected type
-	my $imageType = $typeInfo -> getImageType();
+	my $imageType = $typeInfo -> getTypeName();
 	$this -> assert_str_equals('oem', $imageType);
 	return;
 }

--- a/tests/unit/lib/Test/kiwiXMLTypeData.pm
+++ b/tests/unit/lib/Test/kiwiXMLTypeData.pm
@@ -1327,27 +1327,6 @@ sub test_getHybridPersistent {
 }
 
 #==========================================
-# test_getImageType
-#------------------------------------------
-sub test_getImageType {
-	# ...
-	# Test the getImageType method
-	# ---
-	my $this = shift;
-	my $kiwi = $this -> {kiwi};
-	my $typeDataObj = $this -> __getTypeObj();
-	my $type = $typeDataObj -> getImageType();
-	my $msg = $kiwi -> getMessage();
-	$this -> assert_str_equals('No messages set', $msg);
-	my $msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('none', $msgT);
-	my $state = $kiwi -> getState();
-	$this -> assert_str_equals('No state set', $state);
-	$this -> assert_str_equals('oem', $type);
-	return;
-}
-
-#==========================================
 # test_getInstallBoot
 #------------------------------------------
 sub test_getInstallBoot {
@@ -1536,6 +1515,7 @@ sub test_getMDRaid {
 	$this -> assert_str_equals('striping', $raidt);
 	return;
 }
+
 #==========================================
 # test_getPrimary
 #------------------------------------------
@@ -1642,6 +1622,27 @@ sub test_getSizeUnitDefault {
 	my $state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	$this -> assert_str_equals('M', $unit);
+	return;
+}
+
+#==========================================
+# test_getTypeName
+#------------------------------------------
+sub test_getTypeName {
+	# ...
+	# Test the getImageType method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $typeDataObj = $this -> __getTypeObj();
+	my $type = $typeDataObj -> getTypeName();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('oem', $type);
 	return;
 }
 
@@ -3600,97 +3601,6 @@ sub test_setHybridPersistentUnknownArg {
 }
 
 #==========================================
-# test_setImageType
-#------------------------------------------
-sub test_setImageType {
-	# ...
-	# Test the setImageType method
-	# ---
-	my $this = shift;
-	my $kiwi = $this -> {kiwi};
-	my $typeDataObj = $this -> __getTypeObj();
-	$typeDataObj = $typeDataObj -> setImageType('tbz');
-	my $msg = $kiwi -> getMessage();
-	$this -> assert_str_equals('No messages set', $msg);
-	my $msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('none', $msgT);
-	my $state = $kiwi -> getState();
-	$this -> assert_str_equals('No state set', $state);
-	$this -> assert_not_null($typeDataObj);
-	my $type = $typeDataObj -> getImageType();
-	$msg = $kiwi -> getMessage();
-	$this -> assert_str_equals('No messages set', $msg);
-	$msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('none', $msgT);
-	$state = $kiwi -> getState();
-	$this -> assert_str_equals('No state set', $state);
-	$this -> assert_str_equals('tbz', $type);
-	return;
-}
-
-#==========================================
-# test_setImageTypeInvalidArg
-#------------------------------------------
-sub test_setImageTypeInvalidArg {
-	# ...
-	# Test the setImageType method with an invalid argument
-	# ---
-	my $this = shift;
-	my $kiwi = $this -> {kiwi};
-	my $typeDataObj = $this -> __getTypeObj();
-	my $res = $typeDataObj -> setImageType('foo');
-	my $msg = $kiwi -> getMessage();
-	my $expected = 'setImageType: specified image '
-		. "'foo' is not supported.";
-	$this -> assert_str_equals($expected, $msg);
-	my $msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('error', $msgT);
-	my $state = $kiwi -> getState();
-	$this -> assert_str_equals('failed', $state);
-	$this -> assert_null($res);
-	my $type = $typeDataObj -> getImageType();
-	$msg = $kiwi -> getMessage();
-	$this -> assert_str_equals('No messages set', $msg);
-	$msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('none', $msgT);
-	$state = $kiwi -> getState();
-	$this -> assert_str_equals('No state set', $state);
-	$this -> assert_str_equals('oem', $type);
-	return;
-}
-
-#==========================================
-# test_setImageTypeNoArg
-#------------------------------------------
-sub test_setImageTypeNoArg {
-	# ...
-	# Test the setImageType method with no argument
-	# ---
-	my $this = shift;
-	my $kiwi = $this -> {kiwi};
-	my $typeDataObj = $this -> __getTypeObj();
-	my $res = $typeDataObj -> setImageType();
-	my $msg = $kiwi -> getMessage();
-	my $expected = 'setImageType: no image argument specified, '
-		. 'retaining current data.';
-	$this -> assert_str_equals($expected, $msg);
-	my $msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('error', $msgT);
-	my $state = $kiwi -> getState();
-	$this -> assert_str_equals('failed', $state);
-	$this -> assert_null($res);
-	my $type = $typeDataObj -> getImageType();
-	$msg = $kiwi -> getMessage();
-	$this -> assert_str_equals('No messages set', $msg);
-	$msgT = $kiwi -> getMessageType();
-	$this -> assert_str_equals('none', $msgT);
-	$state = $kiwi -> getState();
-	$this -> assert_str_equals('No state set', $state);
-	$this -> assert_str_equals('oem', $type);
-	return;
-}
-
-#==========================================
 # test_setInstallBoot
 #------------------------------------------
 sub test_setInstallBoot {
@@ -4762,6 +4672,97 @@ sub test_setSizeUnitNoArg {
 	$state = $kiwi -> getState();
 	$this -> assert_str_equals('No state set', $state);
 	$this -> assert_str_equals('M', $unit);
+	return;
+}
+
+#==========================================
+# test_setTypeName
+#------------------------------------------
+sub test_setTypeName {
+	# ...
+	# Test the setTypeName method
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $typeDataObj = $this -> __getTypeObj();
+	$typeDataObj = $typeDataObj -> setTypeName('tbz');
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_not_null($typeDataObj);
+	my $type = $typeDataObj -> getTypeName();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('tbz', $type);
+	return;
+}
+
+#==========================================
+# test_setTypeNameInvalidArg
+#------------------------------------------
+sub test_setTypeNameInvalidArg {
+	# ...
+	# Test the setTypeName method with an invalid argument
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $typeDataObj = $this -> __getTypeObj();
+	my $res = $typeDataObj -> setTypeName('foo');
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'setTypeName: specified image '
+		. "'foo' is not supported.";
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	$this -> assert_null($res);
+	my $type = $typeDataObj -> getTypeName();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('oem', $type);
+	return;
+}
+
+#==========================================
+# test_setTypeNameNoArg
+#------------------------------------------
+sub test_setTypeNameNoArg {
+	# ...
+	# Test the setTypeName method with no argument
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $typeDataObj = $this -> __getTypeObj();
+	my $res = $typeDataObj -> setTypeName();
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'setTypeName: no image argument specified, '
+		. 'retaining current data.';
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	$this -> assert_null($res);
+	my $type = $typeDataObj -> getTypeName();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('oem', $type);
 	return;
 }
 


### PR DESCRIPTION
- rename the getImageType method on the KIWIXMLTypeData object
  - the name had an unfortunate overlap with the same name on the XML
    class
