### PR TITLE
Fixes the package build

### DIFF
--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -35,6 +35,7 @@ BuildRequires:  lxc
 BuildRequires:  gcc-c++
 BuildRequires:  libxslt
 BuildRequires:  module-init-tools
+BuildRequires:       rsync
 BuildRequires:  screen
 BuildRequires:  zlib-devel
 %if 0%{?suse_version} > 1020
@@ -53,6 +54,7 @@ BuildRequires:  cdrkit-cdrtools-compat
 BuildRequires:  genisoimage
 BuildRequires:  perl-Class-Singleton
 BuildRequires:  perl-Config-IniFiles
+BuildRequires:  perl-Digest-SHA1
 BuildRequires:  perl-File-Slurp
 BuildRequires:  perl-libwww-perl
 BuildRequires:  perl-JSON
@@ -76,6 +78,7 @@ Requires:		perl = %{perl_version}
 %endif
 Requires:       perl-Class-Singleton
 Requires:       perl-Config-IniFiles
+Requires:       perl-Digest-SHA1
 Requires:       perl-File-Slurp
 Requires:       perl-JSON
 Requires:       perl-libwww-perl

--- a/tests/unit/lib/Common/ktTestCase.pm
+++ b/tests/unit/lib/Common/ktTestCase.pm
@@ -147,12 +147,23 @@ sub removeTestTmpDir {
 	my $this = shift;
 	# Before removing anything make sure there are no dangling mounts that
 	# might have a negative imapct on the system we run on
-	my $mounts;
-	if (! open $mounts, '<', '/proc/mounts' ) {
-		return 0;
+	my @mountInfo;
+	if (! -f '/proc/mounts') {
+	    my $chld_in;
+	    my $chld_out;
+	    my $pid = open2($chld_out, $chld_in, 'mount');
+	    waitpid $pid, 0;
+	    while (<$chld_out>) {
+			push @mountInfo, $_;
+	    }
+	} else {
+	    my $mounts;
+	    if (! open $mounts, '<', '/proc/mounts' ) {
+			return 0;
+	    }
+	    @mountInfo = <$mounts>;
+	    close $mounts;
 	}
-	my @mountInfo = <$mounts>;
-	close $mounts;
 	for my $line (@mountInfo) {
 		if ($line =~ /.*kiwi.*/x) {
 			my ($source, $mntPnt, $rest) = split /\s/x, $line;


### PR DESCRIPTION
- update build and runtime requirements
  - add rsync as build requires, new test uses code path that requires rsync
  - add perl-Digest as build requires and requires, new test generates
    a checksum
- add code to handle absence of /proc/mounts
  - this is useful when working in a local osc sandbox with osc chroot
    where /proc/mounts does not exist
