### PR TITLE
follow up for lxc

### DIFF
--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -2568,7 +2568,7 @@ div {
 #
 div {
 	k.packages.type.attribute = attribute type {
-		"bootstrap" | "delete" | "image" | "iso" | "oem" | "pxe" |
+		"bootstrap" | "delete" | "image" | "iso" | "lxc" | "oem" | "pxe" |
 		"split" | "testsuite" | "vmx"
 	}
 	k.packages.profiles.attribute = k.profiles.attribute

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -3722,6 +3722,7 @@ virtual machine when running the image.</db:para>
           <value>delete</value>
           <value>image</value>
           <value>iso</value>
+          <value>lxc</value>
           <value>oem</value>
           <value>pxe</value>
           <value>split</value>


### PR DESCRIPTION
- allow lxc as a value for the packages type attribute to support
  container specific package specification
