### PR TITLE
Test fixes

### DIFF
--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -9950,12 +9950,15 @@ sub __populateProfiledTypeInfo_legacy {
 	#==========================================
 	# select record(s) according to selection
 	#------------------------------------------
+	my $first = 1;
 	foreach my $record (@{$typeList}) {
 		my $found = 0;
-		my $first = 1;
+
+	PROFILESEARCH:
 		foreach my $p (@{$record->{assigned}}) {
 			if ($select{$p}) {
-				$found = 1; last;
+				$found = 1;
+				last PROFILESEARCH;
 			}
 		}
 		next if ! $found;

--- a/tests/unit/lib/Test/kiwiRuntimeChecker.pm
+++ b/tests/unit/lib/Test/kiwiRuntimeChecker.pm
@@ -503,10 +503,10 @@ sub test_fsToolCheckSplitImg {
 	my $cmd = $this -> __getCommandLineObj();
 	my $configPath = $this -> {dataDir} . '/splitImg';
 	my $xml = $this -> __getXMLObj($configPath);
-	my $checker = KIWIRuntimeChecker -> new($cmd, $xml);
-	my $res = $checker -> createChecks();
 	my $locator = KIWILocator -> instance();
 	my $haveBtrfs = $locator -> getExecPath('mkfs.btrfs');
+	my $checker = KIWIRuntimeChecker -> new($cmd, $xml);
+	my $res = $checker -> createChecks();
 	if ($haveBtrfs) {
 		# Filesystem tool is present
 		my $msg = $kiwi -> getMessage();


### PR DESCRIPTION
- fix test in factory
  - fix logic error in XML processing, only mark the first type found
    as the first type. While the flag indicator was set to 0 at the end of
    the loop it was re-initialized with 1 at the beginning of the loop
- fix latent test bug
  - the order of calls was incorrect, thus when a file system tool
    was not present the test reacted to the output from the test itself,
    rather than from the code under test
