### PR TITLE
Allow preconfiguring of s390 network cards

### DIFF
--- a/system/boot/s390/oemboot/suse-preinit
+++ b/system/boot/s390/oemboot/suse-preinit
@@ -145,6 +145,19 @@ fi
 setupConsole
 
 #======================================
+# 11.1) load network module
+#--------------------------------------
+if loadNetworkCardS390 "0.0.0191";then
+	#======================================
+	# 11.2) Setup network interface and DNS
+	#--------------------------------------
+	setupNetworkInterfaceS390
+	udevPending
+	setupNetworkStatic 1
+	setupNetworkStatic 0
+fi
+
+#======================================
 # 12) create origin snapshot if possible
 #--------------------------------------
 createOriginSnapshot

--- a/system/boot/s390/vmxboot/suse-preinit
+++ b/system/boot/s390/vmxboot/suse-preinit
@@ -97,6 +97,19 @@ fi
 setupConsole
 
 #======================================
+# 10.1) load network module
+#--------------------------------------
+if loadNetworkCardS390 "0.0.0191";then
+	#======================================
+	# 10.2) Setup network interface and DNS
+	#--------------------------------------
+	setupNetworkInterfaceS390
+	udevPending
+	setupNetworkStatic 1
+	setupNetworkStatic 0
+fi
+
+#======================================
 # 11) create origin snapshot if possible
 #--------------------------------------
 createOriginSnapshot

--- a/template/s390/suse-SLE11-JeOS/config.xml
+++ b/template/s390/suse-SLE11-JeOS/config.xml
@@ -38,6 +38,7 @@
 	<packages type="image">
 		<namedCollection name="base"/>
 		<opensuseProduct name="SUSE_SLES"/>
+		<package name="cmsfs"/>
 		<package name="kernel-default"/>
 		<package name="ifplugd"/>
 		<package name="iputils"/>


### PR DESCRIPTION
The default configuration DASD 191 is checked for a parm file with the
name <LINUX_USER_ID>.PARM-S11.
If it is found the parameters are exported and used to set up the
network with setupNetworkInterfaceS390.
