### PR TITLE
Make kiwi work again in Factory

### DIFF
--- a/modules/KIWILocator.pm
+++ b/modules/KIWILocator.pm
@@ -354,11 +354,11 @@ sub getExecPath {
 	if ($root) {
 		$cmd .= "chroot $root ";
 	}
-	$cmd .= 'bash -c "PATH=$PATH:/sbin which ' . $execName .  '" 2>&1';
+	$cmd .= 'bash -c "PATH=$PATH:/sbin:/usr/sbin type -p ' . $execName .  '" 2>&1';
 	my $execPath = KIWIQX::qxx ($cmd);
 	chomp $execPath;
 	my $code = $? >> 8;
-	if ($code != 0) {
+	if ($code != 0 || !$execPath) {
 		if ($kiwi) {
 			$kiwi -> loginfo ("warning: $execName not found\n");
 		}


### PR DESCRIPTION
various commands have been moved to /usr/sbin, which
is not in path for kiwi, so KIWILocator does not find it.

Also "which" got splitted into a separate package, which
is not required by kiwi, so it might not be installed.
Simply use "type -p", which is a bash builtin and does the
job as well.
