### PR TITLE
EC2 example

### DIFF
--- a/doc/examples/suse-12.3/suse-ec2-guest/config.xml
+++ b/doc/examples/suse-12.3/suse-ec2-guest/config.xml
@@ -32,12 +32,10 @@
 		<source path="opensuse://12.3/repo/non-oss"/>
 	</repository>
 	<packages type="image">
-		<package name="plymouth-branding-openSUSE" bootinclude="true"/>
 		<package name="ifplugd"/>
 		<package name="kernel-ec2"/>
 		<package name="suse-ami-tools"/>
 		<package name="vim"/>
-		<package name="plymouth"/>
 		<package name="xen-tools-domU"/>
 		<package name="xen"/>
 		<package name="grub"/>


### PR DESCRIPTION
- update EC2 example
  - it makes no sense to include plymouth, the branding of the boot
    screens is not visible in a cloud image
