### PR TITLE
- do not ignore addarch, if also the base architecture got added

### DIFF
--- a/modules/KIWICollect.pm
+++ b/modules/KIWICollect.pm
@@ -2055,13 +2055,11 @@ sub getArchList
 	if(defined($packOptions->{'addarch'})) {
 		# addarch is a modifier, use default list as base
 		@archs = $this->{m_archlist}->headList();
-		if( not (grep {$packOptions->{'addarch'}} @archs eq $_)) {
-			$packOptions->{'addarch'} =~ s{,\s*,}{,}g;
-			$packOptions->{'addarch'} =~ s{,\s*}{,}g;
-			$packOptions->{'addarch'} =~ s{,\s*$}{};
-			$packOptions->{'addarch'} =~ s{^\s*,}{};
-			push @archs, split(/,\s*/, $packOptions->{'addarch'});
-		}
+		$packOptions->{'addarch'} =~ s{,\s*,}{,}g;
+		$packOptions->{'addarch'} =~ s{,\s*}{,}g;
+		$packOptions->{'addarch'} =~ s{,\s*$}{};
+		$packOptions->{'addarch'} =~ s{^\s*,}{};
+		push @archs, split(/,\s*/, $packOptions->{'addarch'});
 	}
 	if(defined($packOptions->{'removearch'})) {
 		# removearch is a modifier, use default list as base


### PR DESCRIPTION
This solves the issue that glibc i686 gets not added in 13.1. Coolo has a workaround for that but it should be also fixed for future products.
