### PR TITLE
the beginning of the example migration

### DIFF
--- a/doc/examples/suse-13.1/suse-live-usbstick.readme
+++ b/doc/examples/suse-13.1/suse-live-usbstick.readme
@@ -1,0 +1,30 @@
+KIWI Image Description Example
+==============================
+* A live OEM stick is a virtual disk. In this example the OEM
+  is created as ramonly system using the clicfs filesystem.
+  Additionally it uses the syslinux bootloader and allows to
+  specify the size of the first (fat) partition. That way the
+  stick can be used as live OS as well as as data container
+  under Linux and Windows. Compared to the hybrid iso image
+  which you can also dump on a stick the advantage is that
+  also Windows can see the stick as data because the oem added
+  a fat partition at the beginning of the stick
+
+How to build this Example
+==============================
+
+   kiwi -p /usr/share/doc/packages/kiwi/examples/suse-13.1/suse-live-usbstick \
+        --root /tmp/myoem
+
+   kiwi --create /tmp/myoem --type oem -d /tmp/myoem-result --fat-storage 300
+
+How to test this Example
+==============================
+* Testing an oem can be done with any full virtual system or simply
+  by dumping the .raw file on the stick. For example:
+
+    qemu /tmp/myoem-result/suse-13.1-live.i686-2.5.2.raw -m 512
+
+Login Details
+==============================
+* User root pwd: linux

--- a/doc/examples/suse-13.1/suse-live-usbstick/config-yast-firstboot.xml
+++ b/doc/examples/suse-13.1/suse-live-usbstick/config-yast-firstboot.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0"?>
+<!DOCTYPE productDefines SYSTEM "/usr/share/YaST2/control/control.dtd">
+<productDefines  xmlns="http://www.suse.com/1.0/yast2ns"
+    xmlns:config="http://www.suse.com/1.0/configns">
+
+    <!--
+    $Id: firstboot.xml 35106 2007-01-05 13:42:15Z jsrain $
+    Work around for the text domain
+    textdomain="firstboot"
+    -->
+
+    <textdomain>firstboot</textdomain>
+
+    <proposals config:type="list">
+        <proposal>
+            <name>firstboot_hardware</name>
+            <mode>installation</mode>
+            <stage>firstboot</stage>
+            <label>Hardware Configuration</label>
+            <proposal_modules config:type="list">
+                <proposal_module>x11</proposal_module>
+                <proposal_module>printer</proposal_module>
+                <proposal_module>sound</proposal_module>
+		<proposal_module>bluetooth</proposal_module>
+            </proposal_modules>
+        </proposal>
+        <proposal>
+            <name>firstboot_network</name>
+            <mode>installation</mode>
+            <stage>firstboot</stage>
+            <label>Network Configuration II</label>
+            <proposal_modules config:type="list">
+                <proposal_module>lan</proposal_module>
+            </proposal_modules>
+        </proposal>
+    </proposals>
+    <workflows  config:type="list">
+        <workflow>
+            <defaults>
+                <enable_back>yes</enable_back>
+                <enable_next>yes</enable_next>
+                <archs>all</archs>
+            </defaults>
+            <stage>firstboot</stage>
+            <label>Configuring Your System</label>
+            <mode>installation</mode>
+            <modules  config:type="list">
+                <module>
+                    <label>Language</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_language</name>
+                </module>
+                <module>
+                    <label>Welcome</label>
+                    <name>firstboot_welcome</name>
+                </module>
+                <module>
+                    <label>License Agreement</label>
+                    <name>firstboot_license_novell</name>
+                </module>
+                <module>
+                    <label>License Agreement</label>
+                    <name>firstboot_license</name>
+                </module>
+                <module>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_ssh</name>
+                </module>
+                <module>
+                    <label>Time and Date</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_timezone</name>
+                </module>
+                <module>
+                    <label>Keyboard Layout</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_keyboard</name>
+                </module>
+                <module>
+                    <label>Host Name</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>inst_hostname</name>
+                </module>
+                <module>
+                    <label>Network</label>
+                    <name>inst_proposal</name>
+                    <enabled config:type="boolean">true</enabled>
+                    <proposal>firstboot_network</proposal>
+                </module>
+                <module>
+                    <label>Desktop</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_desktop</name>
+                </module>
+                <module>
+                    <label>Network</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_network_write</name>
+                </module>
+                <module>
+                    <label>Root Password</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>inst_root</name>
+                </module>
+                <module>
+                    <label>Hardware</label>
+                    <name>inst_proposal</name>
+                    <enabled config:type="boolean">true</enabled>
+                    <proposal>firstboot_hardware</proposal>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>firstboot_write</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>no</enable_next>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>inst_congratulate</name>
+                </module>
+            </modules>
+        </workflow>
+    </workflows>
+</productDefines>

--- a/doc/examples/suse-13.1/suse-live-usbstick/config.sh
+++ b/doc/examples/suse-13.1/suse-live-usbstick/config.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.de>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for SUSE based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Activate services
+#--------------------------------------
+suseActivateDefaultServices
+suseInsertService boot.device-mapper
+
+#======================================
+# SuSEconfig
+#--------------------------------------
+baseUpdateSysConfig /etc/sysconfig/displaymanager DISPLAYMANAGER kdm
+baseSetRunlevel 5
+
+#======================================
+# Umount kernel filesystems
+#--------------------------------------
+baseCleanMount
+
+exit 0

--- a/doc/examples/suse-13.1/suse-live-usbstick/config.xml
+++ b/doc/examples/suse-13.1/suse-live-usbstick/config.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="5.8" name="suse-13.1-live">
+	<description type="system">
+		<author>Marcus Schäfer</author>
+		<contact>ms@novell.com</contact>
+		<specification>openSUSE 13.1 Live system for CD/DVD and USB Stick</specification>
+	</description>
+	<preferences>
+		<type image="oem" boot="oemboot/suse-13.1" filesystem="btrfs" fsmountoptions="compress=lzo" bootfilesystem="fat16" bootloader="grub2">
+			<size unit="G">3</size>
+			<oemconfig>
+				<oem-swapsize>512</oem-swapsize>
+				<oem-swap>true</oem-swap>
+				<oem-silent-boot>true</oem-silent-boot>
+			</oemconfig>
+			<systemdisk/>
+		</type>
+		<version>2.5.3</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+	</users>
+	<users group="users">
+		<user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/tux" name="tux"/>
+	</users>
+	<repository type="yast2">
+		<source path="opensuse://13.1/repo/oss/"/>
+	</repository>
+	<packages type="image" patternType="plusRecommended">
+		<package name="plymouth-branding-openSUSE" bootinclude="true"/>
+		<package name="grub2-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+		<package name="kernel-default"/>
+		<package name="ifplugd"/>
+		<package name="plymouth"/>
+		<package name="vim"/>
+		<package name="yast2-firstboot"/>
+		<package name="syslinux"/>
+		<namedCollection name="base"/>
+		<namedCollection name="kde4"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+		<package name="module-init-tools"/>
+	</packages>
+</image>

--- a/doc/examples/suse-13.1/suse-live-usbstick/root/etc/init.d/boot.local
+++ b/doc/examples/suse-13.1/suse-live-usbstick/root/etc/init.d/boot.local
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function dn {
+	local part=$1
+	local part_new=$(echo $part | sed -e 's@\(^.*\)\(p.*$\)@\1@')
+	if [ $part = $part_new ];then
+		part_new=$(echo $part | sed -e 's@\(^.*\)\([0-9].*$\)@\1@')
+	fi
+	echo $part_new
+}
+
+bootdev=$(dn $(pvdisplay -c | cut -f1 -d:))
+if [ ! -e ${bootdev}1 ];then
+	return
+fi
+
+mkdir -p /media/stickstorage
+mount ${bootdev}1 /media/stickstorage
+mkdir -p /media/stickstorage/Storage
+chmod 777 /media/stickstorage/Storage

--- a/doc/examples/suse-13.1/suse-live-usbstick/root/etc/sysconfig/network/ifcfg-eth0
+++ b/doc/examples/suse-13.1/suse-live-usbstick/root/etc/sysconfig/network/ifcfg-eth0
@@ -1,0 +1,4 @@
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='auto'

--- a/modules/KIWIConfigure.pm
+++ b/modules/KIWIConfigure.pm
@@ -202,8 +202,11 @@ sub setupFirstBootYaST {
 	}
 	$kiwi -> info ("Setting up YaST firstboot service...");
 	if (
-		(! -f "$root/etc/init.d/firstboot") &&
-		(! -f "$root/usr/share/YaST2/clients/firstboot.ycp")
+		((! -f "$root/etc/init.d/firstboot") &&
+		(! -f "$root/usr/share/YaST2/clients/firstboot.ycp"))
+		&&
+		((!-f "$root/usr/lib/systemd/system/YaST2-Firstboot.service") &&
+		(! -f "$root/usr/share/YaST2/clients/firstboot.rb"))
 	) {
 		$kiwi -> failed ();
 		$kiwi -> error  ('yast2-firstboot is not installed');

--- a/system/boot/armv7l/oemboot/suse-13.1/config.xml
+++ b/system/boot/armv7l/oemboot/suse-13.1/config.xml
@@ -95,7 +95,6 @@
 		<package name="dmraid"/>
 		<package name="dosfstools"/>
 		<package name="e2fsprogs"/>
-		<package name="eject"/>
 		<package name="fbiterm"/>
 		<package name="file"/>
 		<package name="fribidi"/>

--- a/system/boot/ix86/oemboot/suse-13.1/config.xml
+++ b/system/boot/ix86/oemboot/suse-13.1/config.xml
@@ -127,7 +127,6 @@
 		<package name="dmraid"/>
 		<package name="dosfstools"/>
 		<package name="e2fsprogs"/>
-		<package name="eject"/>
 		<package name="fbiterm"/>
 		<package name="file"/>
 		<package name="fribidi"/>


### PR DESCRIPTION
- add the live USB stick example for openSUSE 13.1
- adjust verification for firstboot logic install check
  - in 13.1 YaST has been converted to Ruby and firstboot is now a
    systemd service, thus we need to check for the new implementations
    as well
