### PR TITLE
Round minutes to int

### DIFF
--- a/modules/KIWICollect.pm
+++ b/modules/KIWICollect.pm
@@ -1044,6 +1044,7 @@ sub setupPackageFiles
 			if ( $last_progress_time < time() ){
 				my $str;
 				$str = (time() - $this->{m_startUpTime}) / 60;
+				$str = sprintf "%.0f", $str;
 				my $msg = "  process $usedPackages->{_name}->{label} package "
 				    . "links: ($count_packs/$num_packs), running $str minutes";
 				$this->logMsg('I', $msg);
@@ -1810,6 +1811,7 @@ sub lookUpAllPackages
 					if ( $last_progress_time < time() ){
 						my $str;
 						$str = (time() - $this->{m_startUpTime}) / 60;
+						$str = sprintf "%.0f", $str;
 						my $msg = 'read package progress: '
 						    . "($count_repos/$num_repos | "
 						    . "$count_dirs/$num_dirs | "


### PR DESCRIPTION
Print this kind of messages nicer.
[  239s] [I] read package progress: (1/2 | 1/7 | 453/8883) running 0.166666666666667 minutes 
[  239s] [I] read package progress: (1/2 | 1/7 | 978/8883) running 0.266666666666667 minutes 
[  239s] [I] read package progress: (1/2 | 1/7 | 1636/8883) running 0.366666666666667 minutes 
[  239s] [I] read package progress: (1/2 | 1/7 | 2232/8883) running 0.466666666666667 minutes 
[  239s] [I] read package progress: (1/2 | 1/7 | 2761/8883) running 0.566666666666667 minutes 

Signed-off-by: Dinar Valeev dvaleev@suse.com
