### PR TITLE
Issues found during ovf build on private OBS instance

### DIFF
--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -2576,7 +2576,7 @@ div {
 		attribute HWversion { xsd:integer }
 	k.machine.arch.attribute =
 		## the VM architecture type (vmdk only)
-		attribute arch { "ix86" | "x86_64" | "%arch" }
+		attribute arch { "ix86" | "x86_64" }
 	k.machine.domain.attribute =
 		## The domain setup for the VM (xen only)
 		attribute domain { "dom0" | "domU" }

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -3680,7 +3680,6 @@ and setup the system disk</db:para>
         <choice>
           <value>ix86</value>
           <value>x86_64</value>
-          <value>%arch</value>
         </choice>
       </attribute>
     </define>

--- a/modules/KIWIXMLValidator.pm
+++ b/modules/KIWIXMLValidator.pm
@@ -798,6 +798,37 @@ sub __checkNoIDSystemGroups {
 }
 
 #==========================================
+# __checkOVFTypeSet
+#------------------------------------------
+sub __checkOVFTypeSet {
+	# ...
+	# If the format attribute on the <type> is set to ovf the user must
+	# specify the ovftype in the <machine> definition
+	# ---
+	my $this = shift;
+	my $systemTree  = $this->{systemTree};
+	my @types = $systemTree -> getElementsByTagName('type');
+	for my $type (@types) {
+		my $format = $type -> getAttribute('format');
+		if ($format && $format eq 'ovf') {
+			my @vmdef = $type -> getElementsByTagName('machine');
+			# there can only be one <machine> section
+			my $machineDef = $vmdef[0];
+			my $ovfType = $machineDef -> getAttribute('ovftype');
+			if (! $ovfType) {
+				my $kiwi = $this -> {kiwi};
+				my $msg = 'Specified ovf format for the image, but no '
+					. 'ovftype specified on the <machine> definition.';
+				$kiwi -> error($msg);
+				$kiwi -> failed();
+				return;
+			}
+		}
+	}
+	return 1;
+}
+
+#==========================================
 # __checkPackageUnique
 #------------------------------------------
 sub __checkPackageUnique {
@@ -1812,6 +1843,9 @@ sub __validateConsistency {
 		return;
 	}
 	if (! $this -> __checkNoIDSystemGroups()) {
+		return;
+	}
+	if (! $this -> __checkOVFTypeSet()) {
 		return;
 	}
 	if (! $this -> __checkPackageUnique()) {

--- a/tests/unit/data/kiwiXMLValidator/ovftypeInvalid_1.xml
+++ b/tests/unit/data/kiwiXMLValidator/ovftypeInvalid_1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="5.8" name="suse-13.1-oem-preload">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test xml verification of ovf spec condition</specification>
+	</description>
+	<preferences>
+		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-13.1" format="ovf">
+			<machine memory="4096">
+				<vmdisk controller="scsi" id="0"/>
+				<vmnic driver="e1000" interface="1" mode="bridged"/>
+			</machine>
+		</type>
+		<version>1.0.0</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user password="linux" pwdformat="plain" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="/tmp"/>
+	</repository>
+	<packages type="image" patternType="plusRecommended">
+		<package name="kernel-default"/>
+		<package name="vi"/>
+		<namedCollection name="default"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/ovftypeInvalid_2.xml
+++ b/tests/unit/data/kiwiXMLValidator/ovftypeInvalid_2.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="5.8" name="suse-13.1-oem-preload">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test xml verification of ovf spec condition</specification>
+	</description>
+	<preferences>
+		<type image="oem" filesystem="ext4" boot="oemboot/suse-11.3" installiso="true" installboot="install">
+			<oemconfig>
+				<oem-bootwait>true</oem-bootwait>
+				<oem-swap>false</oem-swap>
+				<oem-unattended>true</oem-unattended>
+			</oemconfig>
+		</type>
+		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-13.1" format="ovf">
+			<machine memory="4096">
+				<vmdisk controller="scsi" id="0"/>
+				<vmnic driver="e1000" interface="1" mode="bridged"/>
+			</machine>
+		</type>
+		<version>1.0.0</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user password="linux" pwdformat="plain" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="/tmp"/>
+	</repository>
+	<packages type="image" patternType="plusRecommended">
+		<package name="kernel-default"/>
+		<package name="vi"/>
+		<namedCollection name="default"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/ovftypeInvalid_3.xml
+++ b/tests/unit/data/kiwiXMLValidator/ovftypeInvalid_3.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="5.8" name="suse-13.1-oem-preload">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test xml verification of ovf spec condition</specification>
+	</description>
+	<profiles>
+		<profile name="oemProf" description="test A"/>
+		<profile name="vmxProf" description="test B"/>
+	</profiles>
+	<preferences>
+		<version>1.0.0</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<preferences profiles="oemProf">
+		<type image="oem" filesystem="ext4" boot="oemboot/suse-11.3" installiso="true" installboot="install">
+			<oemconfig>
+				<oem-bootwait>true</oem-bootwait>
+				<oem-swap>false</oem-swap>
+				<oem-unattended>true</oem-unattended>
+			</oemconfig>
+		</type>
+	</preferences>
+	<preferences profiles="vmxProf">
+		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-13.1" format="ovf">
+			<machine memory="4096">
+				<vmdisk controller="scsi" id="0"/>
+				<vmnic driver="e1000" interface="1" mode="bridged"/>
+			</machine>
+		</type>
+	</preferences>
+	<users group="root">
+		<user password="linux" pwdformat="plain" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="/tmp"/>
+	</repository>
+	<packages type="image" patternType="plusRecommended">
+		<package name="kernel-default"/>
+		<package name="vi"/>
+		<namedCollection name="default"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/data/kiwiXMLValidator/ovftypeValid_1.xml
+++ b/tests/unit/data/kiwiXMLValidator/ovftypeValid_1.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="5.8" name="suse-13.1-oem-preload">
+	<description type="system">
+		<author>Robert Schweikert</author>
+		<contact>rjschwei@suse.com</contact>
+		<specification>test xml verification of ovf spec condition</specification>
+	</description>
+	<preferences>
+		<type image="oem" filesystem="ext4" boot="oemboot/suse-11.3" installiso="true" installboot="install">
+			<oemconfig>
+				<oem-bootwait>true</oem-bootwait>
+				<oem-swap>false</oem-swap>
+				<oem-unattended>true</oem-unattended>
+			</oemconfig>
+		</type>
+		<type image="vmx" filesystem="ext4" boot="vmxboot/suse-13.1" format="ovf">
+			<machine memory="4096" ovftype="powervm">
+				<vmdisk controller="scsi" id="0"/>
+				<vmnic driver="e1000" interface="1" mode="bridged"/>
+			</machine>
+		</type>
+		<version>1.0.0</version>
+		<packagemanager>zypper</packagemanager>
+		<rpm-check-signatures>false</rpm-check-signatures>
+		<rpm-force>true</rpm-force>
+		<locale>en_US</locale>
+		<keytable>us.map.gz</keytable>
+	</preferences>
+	<users group="root">
+		<user password="linux" pwdformat="plain" home="/root" name="root"/>
+	</users>
+	<repository type="yast2">
+		<source path="/tmp"/>
+	</repository>
+	<packages type="image" patternType="plusRecommended">
+		<package name="kernel-default"/>
+		<package name="vi"/>
+		<namedCollection name="default"/>
+	</packages>
+	<packages type="bootstrap">
+		<package name="filesystem"/>
+		<package name="glibc-locale"/>
+	</packages>
+</image>

--- a/tests/unit/lib/Test/kiwiXMLValidator.pm
+++ b/tests/unit/lib/Test/kiwiXMLValidator.pm
@@ -822,6 +822,35 @@ sub test_oemPostDump {
 }
 
 #==========================================
+# test_ovfTypeSet
+#------------------------------------------
+sub test_ovfTypeSet {
+	# ...
+	# Test that the ovftype specification requirement is properly enforced
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my @invalidConfigs = $this -> __getInvalidFiles('ovftype');
+	my $expectedMsg = 'Specified ovf format for the image, but no '
+		. 'ovftype specified on the <machine> definition.';
+	for my $iConfFile (@invalidConfigs) {
+		my $validator = $this -> __getValidator($iConfFile);
+		$validator -> validate();
+		my $msg = $kiwi -> getMessage();
+		$this -> assert_str_equals($expectedMsg, $msg);
+		my $msgT = $kiwi -> getMessageType();
+		$this -> assert_str_equals('error', $msgT);
+		my $state = $kiwi -> getState();
+		$this -> assert_str_equals('failed', $state);
+		# Test this condition last to get potential error messages
+		$this -> assert_not_null($validator);
+	}
+	my @validConfigs = $this -> __getValidFiles('ovftype');
+	$this -> __verifyValid(@validConfigs);
+	return;
+}
+
+#==========================================
 # test_packageUnique
 #------------------------------------------
 sub test_packageUnique {


### PR DESCRIPTION
- remove %arch as alowed value for the arch attribute of a <machine> element
  - OBS does not subsitutue this use of %arch
  - kiwi has no substitution mechanism
- Implement consistency check for ovf type
  - when the format of the <type> is specified as ovf the ovftype
    attribute of the <machine> element must be set
