### PR TITLE
EC2 fix

### DIFF
--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -596,7 +596,8 @@ sub createEC2 {
 	$GCFD -> close();
 	# boot/grub/menu.lst
 	my $title= $xml -> getImageDisplayName();
-	my $args = "xencons=xvc0 console=xvc0 splash=silent showopts";
+	my $args = 'xencons=xvc0 console=xvc0 multipath=off '
+		. 'splash=silent showopts';
 	my $GMFD = FileHandle -> new();
 	if (! $GMFD -> open (">$tmpdir/create_bootmenu.sh")) {
 		$kiwi -> error  ("Failed to open $tmpdir/create_bootmenu.sh: $!");


### PR DESCRIPTION
- need to turn off multipath setup in device-mapper for EC2 images
  - with multipath enabled EC2 images will not boot

Could you please propagate this to the 13.1 and 12.3 branches?

Thanks,
Robert
