### PR TITLE
Diskmode

### DIFF
--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -122,6 +122,9 @@ sub createChecks {
 	if (! $this -> __checkPackageManagerExists()) {
 		return;
 	}
+	if (! $this -> __checkVMConverterExist()) {
+		return;
+	}
 	if (! $this -> __checkVMControllerCapable()) {
 		return;
 	}
@@ -897,6 +900,11 @@ sub __checkVMdiskmodeCapable {
 		# no machine config requested, ok
 		return 1;
 	}
+	my $converter = $vmConfig -> getSystemDiskConverter();
+	if ($converter eq 'ovftool') {
+		# no need in check
+		return 1;
+	}
 	my $diskMode = $vmConfig -> getSystemDiskMode();
 	if ($diskMode) {
 		my $QEMU_IMG_CAP;
@@ -1193,6 +1201,35 @@ sub __isoHybridCapable {
 		}
 	}
 	return 1;
+}
+
+#==========================================
+# __checkVMConverterExist
+#------------------------------------------
+sub __checkVMConverterExist {
+	# ...
+	# Check that the specified converter exists
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $xml  = $this->{xml};
+	my $sysDisk = $xml -> getSystemDiskConfig();
+	if (! $sysDisk ) {
+		return 1;
+	}
+	my $converter = $sysDisk -> getSystemDiskConverter();
+	if (! $converter ) {
+		# default converter
+		$converter='qemu-img';
+	}
+	my $convCmd = $this->{locator}->getExecPath($converter);
+	if (! $convCmd) {
+		my $msg = "$converter tool not found on system.";
+		$kiwi -> error  ($msg);
+		$kiwi -> failed ();
+		return;
+	}
+	return 1;	
 }
 
 1;

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -1970,12 +1970,16 @@ div {
 	k.vmdisk.diskmode.attribute = 
 		## The disk mode (vmdk only)
 		attribute diskmode { "monolithicSparse" | "monolithicFlat" | "twoGbMaxExtentSparse" | "twoGbMaxExtentFlat" | "streamOptimized" }
+	k.vmdisk.converter.attribute = 
+		## Utility that will be used during conversions (vmdk only)
+		attribute converter { "qemu-img" | "ovftool" }
 	k.vmdisk.attlist =
 		k.vmdisk.disktype.attribute? &
 		k.vmdisk.controller.attribute? &
 		k.vmdisk.id.attribute? &
 		k.vmdisk.device.attribute? &
-		k.vmdisk.diskmode.attribute?
+		k.vmdisk.diskmode.attribute? &
+		k.vmdisk.converter.attribute?
 	k.vmdisk =
 		## The VM disk definition.
 		element vmdisk {

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -2796,6 +2796,15 @@ by the VM (ovf only)</a:documentation>
         </choice>
       </attribute>
     </define>
+    <define name="k.vmdisk.converter.attribute">
+      <attribute name="converter">
+        <a:documentation>Utility that will be used during conversions (vmdk only)</a:documentation>
+        <choice>
+          <value>qemu-img</value>
+          <value>ovftool</value>
+        </choice>
+      </attribute>
+    </define>
     <define name="k.vmdisk.attlist">
       <interleave>
         <optional>
@@ -2812,6 +2821,9 @@ by the VM (ovf only)</a:documentation>
         </optional>
         <optional>
           <ref name="k.vmdisk.diskmode.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.vmdisk.converter.attribute"/>
         </optional>
       </interleave>
     </define>

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -3361,6 +3361,7 @@ sub __createVMachineConfig {
 		$diskSet{disktype}   = $disk -> getAttribute('disktype');
 		$diskSet{diskmode}   = $disk -> getAttribute('diskmode');
 		$diskSet{id}         = $disk -> getAttribute('id');
+		$diskSet{converter}  = $disk -> getAttribute('converter');
 		# Currently there is only one disk, the system disk
 		$diskData{system} = \%diskSet;
 	}


### PR DESCRIPTION
Maybe better put converter into root tag? Because it can only do ova generation and not vmdk.
But --diskMode can't be used then for both: vmdisk and ova, because qemu-img can't create streamOptimized vmdk, that is default for ovftool for ova generation...
