### PR TITLE
second stage of VMX boot never gets kernel vga= parameter when using GRUB 2

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -2669,6 +2669,9 @@ function setupBootLoaderGrub2 {
 	#======================================
 	# write vesa vga setup
 	#--------------------------------------
+	if [ -z "$vga" ];then
+		vga=$DEFAULT_VGA
+	fi
 	if [ ! -z "${vesa[$vga]}" ];then
 		echo "GRUB_GFXMODE=${vesa[$vga]}" >> $inst_default_grub
 	fi


### PR DESCRIPTION
Explanation:  On VirtualBox (and possibly other emulation environments) the second stage of the boot doesn't get any vga= parameter due to the use of gfxpayload (explained in GRUB2 info under a Linux sub-chapter).  Consequently the set up of the Boot Loader has no graphics mode specified when the initrd.vmx runs it's linuxrc.  Rebooting the image, gives a boot loader menu at a completely different (and inferior) resolution to what was seen on initial boot of the image.

This defaults the value to DEFAULT_VGA and sets DEFAULT_VGA to the configured typeinfo vga setting (if any) and resolves the above issue (I think - it's successful on my test image).

Retrospectively, I think this might be be made considerably simpler if migrated to KIWIRoot.pm.
