### PR TITLE
Improve squashfs compression for overlayfs option

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -1381,7 +1381,7 @@ sub createImageLiveCD {
 			};
 			/^overlay$/ && do {
 				$kiwi -> info ("Creating overlayfs read only filesystem...\n");
-				if (! $this -> createImageSquashFS ($namero,'-comp xz')) {
+				if (! $this -> createImageSquashFS ($namero,'-comp xz -b 1M -Xbcj x86')) {
 					$this -> restoreSplitExtend ();
 					return;
 				}


### PR DESCRIPTION
Adding '-b 1M -Xbcj x86' options reduced squashfs image size from 355 to 308 MiB. Boot time was reduced too.
I think that it would be better to replace x86 with some kind of $arch variable.
Please refer to 'mksquashfs -h' to find possible -Xbcj parameters.
