### PR TITLE
fix yes/no issue in this branch as well

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -3820,7 +3820,7 @@ function setupHybridPersistent {
 	# create a write partition for hybrid images if requested
 	# and store the device name in HYBRID_RW
 	# ----
-	if [ ! "$kiwi_hybridpersistent" = "yes" ];then
+	if [ ! "$kiwi_hybridpersistent" = "true" ];then
 		return
 	fi
 	local diskDevice=$(dn $biosBootDevice)
@@ -5832,8 +5832,8 @@ function mountSystemClicFS {
 		haveMByte=$((haveBytes / 1024 / 1024))
 		wantCowFS=0
 		if \
-			[ "$kiwi_hybrid" = "yes" ] && \
-			[ "$kiwi_hybridpersistent" = "yes" ]
+			[ "$kiwi_hybrid" = "true" ] && \
+			[ "$kiwi_hybridpersistent" = "true" ]
 		then
 			# write into a cow file on a filesystem, for hybrid iso's
 			wantCowFS=1
@@ -9715,7 +9715,7 @@ function updatePartitionTable {
 	#======================================
 	# check for hybrid iso
 	#--------------------------------------
-	if [ "$kiwi_hybridpersistent" = "yes" ];then
+	if [ "$kiwi_hybridpersistent" = "true" ];then
 		# /.../
 		# The partition table written into an iso doesn't
 		# like the resync, so we return early here
@@ -9871,7 +9871,7 @@ function setupKernelLinks {
 	#======================================
 	# setup if overlay filesystem is used
 	#--------------------------------------
-	if  [ "$OEM_KIWI_INITRD" = "yes" ] || \
+	if  [ "$OEM_KIWI_INITRD" = "true" ] || \
 		[ "$PXE_KIWI_INITRD" = "yes" ] || \
 		isFSTypeReadOnly
 	then

--- a/system/boot/armv7l/oemboot/suse-linuxrc
+++ b/system/boot/armv7l/oemboot/suse-linuxrc
@@ -325,7 +325,7 @@ if [ "$LOCAL_BOOT" = "no" ];then
 			resizeFilesystem $deviceResize
 		fi
 	fi
-	if [ "$OEM_KIWI_INITRD" = "yes" ];then
+	if [ "$OEM_KIWI_INITRD" = "true" ];then
 		if ! echo $KIWI_INITRD_PARAMS | grep -qi LOCAL_BOOT;then
 			KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
 		fi

--- a/system/boot/armv7l/oemboot/suse-preinit
+++ b/system/boot/armv7l/oemboot/suse-preinit
@@ -53,7 +53,7 @@ createFramebufferDevices
 #--------------------------------------
 if \
 	[ -z "$UNIONFS_CONFIG" ] && [ -z "$COMBINED_IMAGE" ] && \
-	[ ! "$OEM_KIWI_INITRD" = "yes" ]
+	[ ! "$OEM_KIWI_INITRD" = "true" ]
 then
 	#======================================
 	# use distro initrd via mkinitrd

--- a/system/boot/ix86/oemboot/rhel-linuxrc
+++ b/system/boot/ix86/oemboot/rhel-linuxrc
@@ -325,7 +325,7 @@ if [ "$LOCAL_BOOT" = "no" ];then
 			resizeFilesystem $deviceResize
 		fi
 	fi
-	if [ "$OEM_KIWI_INITRD" = "yes" ];then
+	if [ "$OEM_KIWI_INITRD" = "true" ];then
 		if ! echo $KIWI_INITRD_PARAMS | grep -qi LOCAL_BOOT;then
 			KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
 		fi

--- a/system/boot/ix86/oemboot/rhel-preinit
+++ b/system/boot/ix86/oemboot/rhel-preinit
@@ -53,7 +53,7 @@ createFramebufferDevices
 #--------------------------------------
 if \
 	[ -z "$UNIONFS_CONFIG" ] && [ -z "$COMBINED_IMAGE" ] && \
-	[ ! "$OEM_KIWI_INITRD" = "yes" ]
+	[ ! "$OEM_KIWI_INITRD" = "true" ]
 then
 	#======================================
 	# use distro initrd via mkinitrd

--- a/system/boot/ix86/oemboot/suse-linuxrc
+++ b/system/boot/ix86/oemboot/suse-linuxrc
@@ -325,7 +325,7 @@ if [ "$LOCAL_BOOT" = "no" ];then
 			resizeFilesystem $deviceResize
 		fi
 	fi
-	if [ "$OEM_KIWI_INITRD" = "yes" ];then
+	if [ "$OEM_KIWI_INITRD" = "true" ];then
 		if ! echo $KIWI_INITRD_PARAMS | grep -qi LOCAL_BOOT;then
 			KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
 		fi

--- a/system/boot/ix86/oemboot/suse-preinit
+++ b/system/boot/ix86/oemboot/suse-preinit
@@ -53,7 +53,7 @@ createFramebufferDevices
 #--------------------------------------
 if \
 	[ -z "$UNIONFS_CONFIG" ] && [ -z "$COMBINED_IMAGE" ] && \
-	[ ! "$OEM_KIWI_INITRD" = "yes" ]
+	[ ! "$OEM_KIWI_INITRD" = "true" ]
 then
 	#======================================
 	# use distro initrd via mkinitrd

--- a/system/boot/ppc/oemboot/suse-linuxrc
+++ b/system/boot/ppc/oemboot/suse-linuxrc
@@ -325,7 +325,7 @@ if [ "$LOCAL_BOOT" = "no" ];then
 			resizeFilesystem $deviceResize
 		fi
 	fi
-	if [ "$OEM_KIWI_INITRD" = "yes" ];then
+	if [ "$OEM_KIWI_INITRD" = "true" ];then
 		if ! echo $KIWI_INITRD_PARAMS | grep -qi LOCAL_BOOT;then
 			KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
 		fi

--- a/system/boot/ppc/oemboot/suse-preinit
+++ b/system/boot/ppc/oemboot/suse-preinit
@@ -53,7 +53,7 @@ createFramebufferDevices
 #--------------------------------------
 if \
 	[ -z "$UNIONFS_CONFIG" ] && [ -z "$COMBINED_IMAGE" ] && \
-	[ ! "$OEM_KIWI_INITRD" = "yes" ]
+	[ ! "$OEM_KIWI_INITRD" = "true" ]
 then
 	#======================================
 	# use distro initrd via mkinitrd

--- a/system/boot/s390/oemboot/suse-linuxrc
+++ b/system/boot/s390/oemboot/suse-linuxrc
@@ -329,7 +329,7 @@ if [ "$LOCAL_BOOT" = "no" ];then
 			resizeFilesystem $deviceResize
 		fi
 	fi
-	if [ "$OEM_KIWI_INITRD" = "yes" ];then
+	if [ "$OEM_KIWI_INITRD" = "true" ];then
 		if ! echo $KIWI_INITRD_PARAMS | grep -qi LOCAL_BOOT;then
 			KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
 		fi

--- a/system/boot/s390/oemboot/suse-preinit
+++ b/system/boot/s390/oemboot/suse-preinit
@@ -66,7 +66,7 @@ fi
 #--------------------------------------
 if \
 	[ -z "$UNIONFS_CONFIG" ] && [ -z "$COMBINED_IMAGE" ] && \
-	[ ! "$OEM_KIWI_INITRD" = "yes" ]
+	[ ! "$OEM_KIWI_INITRD" = "true" ]
 then
 	#======================================
 	# use distro initrd via mkinitrd


### PR DESCRIPTION
- fix the evaluation of kiwi initrd behavior
- the <oem-kiwi-initrd> element accepts true|false values. These settings
  are propagated without changes to the shell code that evaluates the
  variable to decide whether or not to create a new initrd. The evaluation
  in the shell code was based on yes|no and old relic that used to be
  use in the XML a long time ago. This update changes the evaluation in
  the shell code to true|false.
