### PR TITLE
Switch to kmod-compat

### DIFF
--- a/system/boot/armv7l/oemboot/suse-13.2/config.xml
+++ b/system/boot/armv7l/oemboot/suse-13.2/config.xml
@@ -106,7 +106,7 @@
 		<package name="kpartx"/>
 		<package name="lvm2"/>
 		<package name="make"/>
-		<package name="module-init-tools"/>
+		<package name="kmod-compat"/>
 		<package name="net-tools"/>
 		<package name="netcfg"/>
 		<package name="parted"/>

--- a/system/boot/ix86/isoboot/suse-13.2/config.xml
+++ b/system/boot/ix86/isoboot/suse-13.2/config.xml
@@ -145,7 +145,7 @@
 		<package name="syslinux"/>
 		<package name="tar"/>
 		<package name="timezone"/>
-		<package name="module-init-tools"/>
+		<package name="kmod-compat"/>
 		<package name="which"/>
 		<package name="udev"/>
 	</packages>

--- a/system/boot/ix86/netboot/suse-13.2/config.xml
+++ b/system/boot/ix86/netboot/suse-13.2/config.xml
@@ -220,7 +220,7 @@
 		<package name="glibc-locale"/>
 		<package name="rsync"/>
 		<package name="timezone"/>
-		<package name="module-init-tools"/>
+		<package name="kmod-compat"/>
 		<package name="which"/>
 		<package name="udev"/>
 	</packages>

--- a/system/boot/ix86/oemboot/suse-13.2/config.xml
+++ b/system/boot/ix86/oemboot/suse-13.2/config.xml
@@ -147,7 +147,7 @@
 		<package name="lvm2"/>
 		<package name="make"/>
 		<package name="mdadm"/>
-		<package name="module-init-tools"/>
+		<package name="kmod-compat"/>
 		<package name="net-tools"/>
 		<package name="netcfg"/>
 		<package name="parted"/>

--- a/system/boot/ix86/vmxboot/suse-13.2/config.xml
+++ b/system/boot/ix86/vmxboot/suse-13.2/config.xml
@@ -122,7 +122,7 @@
 		<package name="kiwi-tools"/>
 		<package name="lvm2"/>
 		<package name="make"/>
-		<package name="module-init-tools"/>
+		<package name="kmod-compat"/>
 		<package name="net-tools"/>
 		<package name="netcfg"/>
 		<package name="parted"/>


### PR DESCRIPTION
Otherwise you'll get a conflict in the build service:
conflict for provider of module-init-tools needed by
kiwi-desc-oemboot-requires, (provider module-init-tools is conflicted by
installed kmod-compat)
