### PR TITLE
Fix David's use case

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -1904,7 +1904,7 @@ sub createImageLiveCD {
 		print $FD 'fi'."\n";
 		my $bootTimeout = 10;
 		my $xmlboottimeout = $xmltype -> getBootTimeout();
-		if ($xmlboottimeout) {
+		if (defined $xmlboottimeout) {
 			$bootTimeout = $xmlboottimeout;
 		}
 		print $FD "set timeout=$bootTimeout\n";
@@ -2068,7 +2068,7 @@ sub createImageLiveCD {
 	my $syslinux_new_format = 0;
 	my $bootTimeout = 200;
 	my $xmlboottimeout = $xmltype -> getBootTimeout();
-	if ($xmlboottimeout) {
+	if (defined $xmlboottimeout) {
 		$bootTimeout = $xmlboottimeout;
 	}
 	if (-f "$gfx/gfxboot.com" || -f "$gfx/gfxboot.c32") {

--- a/modules/KIWIImageCreator.pm
+++ b/modules/KIWIImageCreator.pm
@@ -1982,7 +1982,7 @@ sub __addTypeToBootXML {
 	# boottimeout
 	#------------------------------------------
 	my $boottimeout = $systemType -> getBootTimeout();
-	if ($boottimeout) {
+	if (defined $boottimeout) {
 		$kiwi -> info ("--> boottimout: $boottimeout");
 		$bootType -> setBootTimeout($boottimeout);
 		$kiwi -> done();


### PR DESCRIPTION
- support a boottimeout value of 0
- at present we checked for boottimeout value to evaluate to true, but in
  Perl the string "0" evaluates to false although the string is not empty,
  thus the truth test failed an we used the default of 10
