### PR TITLE
Add PostgreSQL support to KIWIAnalyseCustomData.pm (export) and KIWIConfig.sh (import)

### DIFF
--- a/modules/KIWIAnalyseCustomData.pm
+++ b/modules/KIWIAnalyseCustomData.pm
@@ -314,7 +314,7 @@ sub createDatabaseDump {
 	my $status;
 	$dest .= "/root/var/cache/dbs";
 	$kiwi -> info ("Checking for running databases...\n");
-	foreach my $db_type ('mysql') {
+	foreach my $db_type ('mysql','postgresql') {
 		#========================================
 		# initialize db values
 		#----------------------------------------
@@ -322,7 +322,11 @@ sub createDatabaseDump {
 			$db_test_cmd = "mysqladmin ping";
 			$dump_cmd    = "mysqldump -p -u root --all-databases --events";
 			$dump_ext    = 'sql';
-		} else { 
+		} elsif ($db_type eq 'postgresql') {
+			$db_test_cmd = 'su - postgres -c "psql -l"';
+			$dump_cmd    = 'su - postgres -c "pg_dumpall -U postgres"';
+			$dump_ext    = 'sql';
+		} else {
 			$kiwi -> error  ("DB $db_type unknown.");
 			$kiwi -> failed ();
 			return;

--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -1820,6 +1820,24 @@ function importDatabases {
 			fi
 			mysqladmin shutdown
 		;;
+		'postgresql')
+			# bring up db
+			su - postgres -c 'initdb'
+			su - postgres -c "pg_ctl start -o '-h \"\"' "
+			local i
+			for((i=0; i<150; i++)); do
+				sleep 0.2
+				su - postgres -c 'psql -l' 2>/dev/null && break
+			done
+			# import content
+			if su - postgres -c "zcat $file | psql -U postgres"; then
+				echo "Import of $db_type successfull!"
+			else
+				echo "Import of $db_type failed!"
+			fi
+			# stop db
+			su - postgres -c "pg_ctl stop"
+		;;
 		*)
 			echo "Ignoring unknown database type $db_type!"
 		;;


### PR DESCRIPTION
- add PostgreSQL support to KIWIAnalyseCustomData to check for running
  databases and if they are available try to export the entire content.
- add PostgreSQL support to KIWIConfig.sh to import previously dumped
  databases during image building.
