### PR TITLE
Fix installiso for oem image type.

### DIFF
--- a/system/boot/ix86/oemboot/rhel-06.0/config.xml
+++ b/system/boot/ix86/oemboot/rhel-06.0/config.xml
@@ -103,6 +103,7 @@
 		<package name="e2fsprogs"/>
 		<package name="gettext"/>
 		<package name="genisoimage"/>
+		<package name="syslinux"/>
 	</packages>
 	<packages type="delete">
 		<package name="cracklib-dicts"/>


### PR DESCRIPTION
either build will fail on isolinux.bin, that isn't put into 'image/loader' initrd.
