### PR TITLE
- Don't force ovftool for ova.

### DIFF
--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -917,9 +917,8 @@ sub __checkVMConverterExist {
 	my $convCmd = $this->{locator}->getExecPath($converter);
 	if (! $convCmd) {
 		my $msg = "$converter tool not found on system.";
-		$kiwi -> error  ($msg);
-		$kiwi -> failed ();
-		return;
+		$kiwi -> info  ("$msg\n");
+		return 1;
 	}
 	return 1;
 }


### PR DESCRIPTION
not tested.
This come from half merged patch where i introduced "converter" option, but then you rework patch and did implicit usage for ovftool if it exist.
In geenral part about .ova, ovf and vmware is strange now.
