### PR TITLE
Dramatically reduce creation time of persistent storage. 

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -22,7 +22,7 @@ export BOOTABLE_FLAG="$(echo -ne '\x80')"
 export ELOG_FILE=/var/log/boot.kiwi
 export TRANSFER_ERRORS_FILE=/tmp/transfer.errors
 export UFONT=/usr/share/fbiterm/fonts/b16.pcf.gz
-export HYBRID_PERSISTENT_FS=ext3
+export HYBRID_PERSISTENT_FS=ext4
 export HYBRID_PERSISTENT_ID=83
 export HYBRID_PERSISTENT_DIR=/read-write
 export UTIMER_INFO=/dev/utimer
@@ -8212,7 +8212,7 @@ function createHybridPersistent {
 	#======================================
 	# create filesystem on write partition
 	#--------------------------------------
-	if ! mkfs.$HYBRID_PERSISTENT_FS -L hybrid $(ddn $device $pID);then
+	if ! mkfs.$HYBRID_PERSISTENT_FS -L hybrid -O ^has_journal,uninit_bg -E lazy_itable_init $(ddn $device $pID);then
 		Echo "Failed to create hybrid persistent filesystem"
 		Echo "Persistent writing deactivated"
 		unset kiwi_hybridpersistent


### PR DESCRIPTION
Also disable journal and use ext4 instead of ext3 to enable unibit_bg option.
Loading iso image without these options takes up to 7 minutes (!!!) from my 32Gb USB flash.
With these options it takes about few seconds.
