### PR TITLE
- Print epoch for .packages listing

### DIFF
--- a/modules/KIWIImageCreator.pm
+++ b/modules/KIWIImageCreator.pm
@@ -925,7 +925,7 @@ sub createImage {
 	if (-f "$tree/var/lib/rpm/Packages") {
 		$kiwi -> info ("Creating unpacked image tree meta data");
 		my $idest = $cmdL -> getImageIntermediateTargetDir();
-		my $query = '%{NAME}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}\n';
+		my $query = '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}\n';
 		my $name  = KIWIGlobals
 			-> instance() -> generateBuildImageName($xml);
 		my $path = File::Spec->rel2abs ($tree);


### PR DESCRIPTION
Without epoch value, version and release has no sense :) This is critical for tools that want make comparison between two .packages files. Broke backward compatibility, but better now...
