### PR TITLE
- Removed done statement from last Kiwi message

### DIFF
--- a/kiwi.pl
+++ b/kiwi.pl
@@ -1966,11 +1966,9 @@ sub kiwiExit {
 			$kiwi -> printBackTrace();
 		}
 		$kiwi -> printLogExcerpt();
-		$kiwi -> error  ("KIWI exited with error(s)");
-		$kiwi -> done ();
+		$kiwi -> error  ("KIWI exited with error(s)\n");
 	} else {
-		$kiwi -> info ("KIWI exited successfully");
-		$kiwi -> done ();
+		$kiwi -> info ("KIWI exited successfully\n");
 	}
 	#==========================================
 	# Move process log to final logfile name...


### PR DESCRIPTION
- The Done message at the last line was confusing, especially when
  KIWI exited with errors.
  To keep consistency and since the done message wasn't really needed
  because the last message is not a task it was also removed for
  the success messages.
