### PR TITLE
Don't generate TRANS.TBL for POWER iso

### DIFF
--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -372,7 +372,6 @@ sub ppc64_default {
 	$para.= "/metadata/KIWIIsoLinux-AppleFileMapping.map";
 	$para.= " --netatalk";
 	$para.= " -part";
-	$para.= " -T";
 	$para.= " -U";
 	$this -> {params} = $para;
 	return $this;


### PR DESCRIPTION
It seems only POWER does TRANS.TBL generation. Let be consentive with
other architectures.

Signed-off-by: Dinar Valeev dvaleev@suse.com
