### PR TITLE
Remove lxc package from the docker example

### DIFF
--- a/doc/examples/suse-13.1/suse-docker-container/config.xml
+++ b/doc/examples/suse-13.1/suse-docker-container/config.xml
@@ -30,7 +30,6 @@
 	</repository>
 	<packages type="image">
 		<package name="coreutils"/>
-		<package name="lxc"/>
 		<package name="iputils"/>
 	</packages>
 	<packages type="bootstrap">


### PR DESCRIPTION
The lxc pacakge is not required by docker images, hence it can be removed from the template shipped with the examples.
