### PR TITLE
Added support for creating vagrant boxes

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -78,6 +78,7 @@ my @kiwiModules = qw (
 	KIWIXMLInfo.pm
 	KIWIXMLInstRepositoryData.pm
 	KIWIXMLOEMConfigData.pm
+	KIWIXMLVagrantConfigData.pm
 	KIWIXMLPXEDeployConfigData.pm
 	KIWIXMLPXEDeployData.pm
 	KIWIXMLPackageArchiveData.pm
@@ -146,6 +147,7 @@ my @kiwiModules = qw (
 	KTXMLUserData.t
 	KTXMLVMachineData.t
 	KTXMLValidator.t
+	KTXMLVagrantConfigData.t
 	ktLog.pm
 	ktTestCase.pm
 	kiwiCommandLine.pm
@@ -171,6 +173,7 @@ my @kiwiModules = qw (
 	kiwiXMLInfo.pm
 	kiwiXMLInstRepositoryData.pm
 	kiwiXMLOEMConfigData.pm
+	kiwiXMLVagrantConfigData.pm
 	kiwiXMLPXEDeployConfigData.pm
 	kiwiXMLPXEDeployData.pm
 	kiwiXMLPackageArchiveData.pm
@@ -262,6 +265,7 @@ my @notClean1 = qw (
 	KIWIXMLInfo.pm
 	KIWIXMLInstRepositoryData.pm
 	KIWIXMLOEMConfigData.pm
+	KIWIXMLVagrantConfigData.pm
 	KIWIXMLPXEDeployConfigData.pm
 	KIWIXMLPXEDeployData.pm
 	KIWIXMLPackageArchiveData.pm
@@ -308,6 +312,7 @@ my @notClean1 = qw (
 	KTXMLInfo.t
 	KTXMLInstRepositoryData.t
 	KTXMLOEMConfigData.t
+	KTXMLVagrantConfigData.t
 	KTXMLPXEDeployConfigData.t
 	KTXMLPXEDeployData.t
 	KTXMLPackageArchiveData.t
@@ -355,6 +360,7 @@ my @notClean1 = qw (
 	kiwiXMLInfo.pm
 	kiwiXMLInstRepositoryData.pm
 	kiwiXMLOEMConfigData.pm
+	kiwiXMLVagrantConfigData.pm
 	kiwiXMLPXEDeployConfigData.pm
 	kiwiXMLPXEDeployData.pm
 	kiwiXMLPackageArchiveData.pm

--- a/kiwi.pl
+++ b/kiwi.pl
@@ -160,6 +160,9 @@ sub main {
 		$cmdL -> setOperationMode ("prepare", $cmdL->getConfigDir());
 		mkdir $imageTarget;
 		$kic = KIWIImageCreator -> new ($cmdL);
+		if (! $kic) {
+			kiwiExit (1);
+		}
 		my $selectedType = $kic -> getSelectedBuildType();
 		if ($selectedType && $selectedType eq 'cpio') {
 			if (! $kic -> prepareBootImage(

--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -111,10 +111,10 @@ sub new {
 	# find image type...
 	#------------------------------------------
 	if (($system) && (! defined $cmdL->getBuildType())) {
-		if ($initrd =~ /oemboot/) {
+		if (($initrd) && ($initrd =~ /oemboot/)) {
 			$cmdL -> setBuildType ("oem");
 		}
-		if ($initrd =~ /vmxboot/) {
+		if (($initrd) && ($initrd =~ /vmxboot/)) {
 			$cmdL -> setBuildType ("vmx");
 		}
 	}

--- a/modules/KIWIImageCreator.pm
+++ b/modules/KIWIImageCreator.pm
@@ -136,7 +136,7 @@ sub initialize {
 	#==========================================
 	# Store selected image type
 	#------------------------------------------
-	if ($this->{buildType}) {
+	if (($this->{buildType}) && (! $cmdL->getOperationMode("convert"))) {
 		my $configDir = $this->{configDir};
 		if (! $configDir) {
 			$configDir = $cmdL -> getSystemLocation();

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -1666,7 +1666,7 @@ div {
 		## Error message than we receive from the parser.
 		## To be remove from here by the end of 2014
 		attribute format {
-			"ec2" | "ovf" | "ova" | "qcow2" | "vmdk" |
+			"ec2" | "ovf" | "ova" | "qcow2" | "vagrant" | "vmdk" |
 			"vdi" | "vhd" | "vhd-fixed"
 		}
 	k.type.fsnocheck.attribute =
@@ -1821,7 +1821,8 @@ div {
 			k.pxedeploy? &
 			k.size? &
 			k.split? &
-			k.systemdisk?
+			k.systemdisk? &
+			k.vagrantconfig?
 		}
 }
 
@@ -2526,6 +2527,32 @@ div {
 			k.oem-systemsize? &
 			k.oem-unattended? &
 			k.oem-unattended-id?
+		}
+}
+
+#==========================================
+# main block: <vagrantconfig>
+#
+div {
+	k.vagrantconfig.provider.attribute =
+		## The vagrant provider for this box
+		attribute provider { "libvirt" | "virtualbox" }
+	k.vagrantconfig.virtualsize.attribute =
+		## The vagrant virtual image size in GB
+		attribute virtualsize { xsd:nonNegativeInteger }
+	k.vagrantconfig.attlist =
+		k.vagrantconfig.provider.attribute &
+		k.vagrantconfig.virtualsize.attribute
+	k.vagrantconfig =
+		## Specifies the Vagrant configuration section
+		[
+		db:para [
+			"The vagrantconfig element specifies the Vagrant meta"
+			"configuration options which are used inside a vagrant box"
+		]
+		]
+		element vagrantconfig {
+			k.vagrantconfig.attlist
 		}
 }
 

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -2230,6 +2230,7 @@ To be remove from here by the end of 2014</a:documentation>
           <value>ovf</value>
           <value>ova</value>
           <value>qcow2</value>
+          <value>vagrant</value>
           <value>vmdk</value>
           <value>vdi</value>
           <value>vhd</value>
@@ -2562,6 +2563,9 @@ into the master block. There is space for 32 characters.</a:documentation>
           </optional>
           <optional>
             <ref name="k.systemdisk"/>
+          </optional>
+          <optional>
+            <ref name="k.vagrantconfig"/>
           </optional>
         </interleave>
       </element>
@@ -3604,6 +3608,41 @@ and setup the system disk</db:para>
             <ref name="k.oem-unattended-id"/>
           </optional>
         </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <vagrantconfig>
+    
+  -->
+  <div>
+    <define name="k.vagrantconfig.provider.attribute">
+      <attribute name="provider">
+        <a:documentation>The vagrant provider for this box</a:documentation>
+        <choice>
+          <value>libvirt</value>
+          <value>virtualbox</value>
+        </choice>
+      </attribute>
+    </define>
+    <define name="k.vagrantconfig.virtualsize.attribute">
+      <attribute name="virtualsize">
+        <a:documentation>The vagrant virtual image size in GB</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+    </define>
+    <define name="k.vagrantconfig.attlist">
+      <interleave>
+        <ref name="k.vagrantconfig.provider.attribute"/>
+        <ref name="k.vagrantconfig.virtualsize.attribute"/>
+      </interleave>
+    </define>
+    <define name="k.vagrantconfig">
+      <element name="vagrantconfig">
+        <a:documentation>Specifies the Vagrant configuration section</a:documentation>
+        <db:para>The vagrantconfig element specifies the Vagrant metaconfiguration options which are used inside a vagrant box</db:para>
+        <ref name="k.vagrantconfig.attlist"/>
       </element>
     </define>
   </div>

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -113,9 +113,10 @@ sub new {
 	if (! $this -> p_hasInitArg($init) ) {
 		return;
 	}
-	# While <ec2config>, <machine>, <oemconfig>, <pxedeploy>, <split>, and
-	# <systemdisk> are children of <type> the data is not in this class
-	# the child relationship is enforced at the XML level.
+	# While <ec2config>, <machine>, <oemconfig>, <pxedeploy>, <split>,
+	# <vagrantconfig> and <systemdisk> are children of <type> the data
+	# is not in this class the child relationship is enforced at the
+	# XML level.
 	my %keywords = map { ($_ => 1) } qw(
 	    boot
 		bootfilesystem
@@ -2155,7 +2156,7 @@ sub __isValidFormat {
 		return;
 	}
 	my %supported = map { ($_ => 1) } qw(
-		ec2 ovf ova qcow2 vmdk vdi vhd vhd-fixed
+		ec2 ovf ova qcow2 vmdk vdi vhd vhd-fixed vagrant
 	);
 	if (! $supported{$format} ) {
 		my $msg = "$caller: specified format '$format' is not "

--- a/modules/KIWIXMLVagrantConfigData.pm
+++ b/modules/KIWIXMLVagrantConfigData.pm
@@ -1,0 +1,157 @@
+#================
+# FILE          : KIWIXMLVagrantConfigData.pm
+#----------------
+# PROJECT       : openSUSE Build-Service
+# COPYRIGHT     : (c) 20012 SUSE LLC
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : This module represents the data contained in the KIWI
+#               : configuration file marked with the <vagrantconfig> element
+#               : and it's children.
+#               :
+# STATUS        : Development
+#----------------
+package KIWIXMLVagrantConfigData;
+#==========================================
+# Modules
+#------------------------------------------
+use strict;
+use warnings;
+use Scalar::Util qw /looks_like_number/;
+use XML::LibXML;
+require Exporter;
+
+use base qw /KIWIXMLDataBase/;
+#==========================================
+# Exports
+#------------------------------------------
+our @EXPORT_OK = qw ();
+
+#==========================================
+# Constructor
+#------------------------------------------
+sub new {
+	# ...
+	# Create the KIWIXMLVagrantConfigData object
+	#
+	# Internal data structure
+	#
+	# this = {
+	#    provider = ''
+	#    virtual_size = ''
+	# }
+	# ---
+	#==========================================
+	# Object setup
+	#------------------------------------------
+	my $class = shift;
+	my $this  = $class->SUPER::new(@_);
+	#==========================================
+	# Module Parameters
+	#------------------------------------------
+	my $init = shift;
+	#==========================================
+	# Argument checking and object data store
+	#------------------------------------------
+	my %keywords = map { ($_ => 1) } qw(
+		provider
+		virtual_size
+	);
+	$this->{supportedKeywords} = \%keywords;
+	if (! $this -> p_isInitHashRef($init) ) {
+		return;
+	}
+	if (! $this -> p_areKeywordArgsValid($init) ) {
+		return;
+	}
+	$this->{provider} = $init->{provider};
+	$this->{virtual_size} = $init->{virtual_size};
+	return $this;
+}
+
+#==========================================
+# getProvider
+#------------------------------------------
+sub getProvider {
+	# ...
+	# Return the setting for the provider configuration
+	# ---
+	my $this = shift;
+	return $this->{provider};
+}
+
+#==========================================
+# setProvider
+#------------------------------------------
+sub setProvider {
+	# ...
+	# Set the provider attribute, if called with no argument the
+	# attribute is erased
+	# ---
+	my $this = shift;
+	my $val  = shift;
+	if (! $val) {
+		if ($this->{provider}) {
+			delete $this->{provider};
+		}
+	} else {
+		$this->{provider} = $val;
+	}
+	return $this;
+}
+
+#==========================================
+# getVirtualSize
+#------------------------------------------
+sub getVirtualSize {
+	# ...
+	# Return the setting for the virtual size configuration
+	# ---
+	my $this = shift;
+	return $this->{virtual_size};
+}
+
+#==========================================
+# setVirtualSize
+#------------------------------------------
+sub setVirtualSize {
+	# ...
+	# Set the virtual_size attribute, if called with no argument the
+	# attribute is erased
+	# ---
+	my $this = shift;
+	my $val  = shift;
+	if (! $val) {
+		if ($this->{virtual_size}) {
+			delete $this->{virtual_size};
+		}
+	} else {
+		$this->{virtual_size} = $val;
+	}
+	return $this;
+}
+
+#==========================================
+# getXMLElement
+#------------------------------------------
+sub getXMLElement {
+	# ...
+	# Return an XML Element representing the object's data
+	# ---
+	my $this = shift;
+	my $element = XML::LibXML::Element -> new('vagrantconfig');
+	my $provider = $this -> getProvider();
+	my $vsize = $this -> getVirtualSize();
+	if ($provider) {
+		$element -> setAttribute('provider', $provider);
+	}
+	if ($vsize) {
+		$element -> setAttribute('virtualsize', $vsize);
+	}
+	return $element;
+}
+
+1;

--- a/modules/KIWIXMLValidator.pm
+++ b/modules/KIWIXMLValidator.pm
@@ -1217,12 +1217,13 @@ sub __checkTypeConfigConsist {
 	# relevant inside the initrd
 	# ----
 	my %typeChildDeps = (
-		'machine'    => 'image:cpio,lxc,docker,oem,vmx,split',
-		'oemconfig'  => 'image:cpio,oem,split',
-		'pxedeploy'  => 'image:cpio,pxe',
-		'size'       => ':', # generic
-		'split'      => ':', # generic
-		'systemdisk' => ':'  # generic
+		'machine'       => 'image:cpio,lxc,docker,oem,vmx,split',
+		'oemconfig'     => 'image:cpio,oem,split',
+		'vagrantconfig' => 'image:vmx',
+		'pxedeploy'     => 'image:cpio,pxe',
+		'size'          => ':', # generic
+		'split'         => ':', # generic
+		'systemdisk'    => ':'  # generic
 	);
 	for my $typeNode (@types) {
 		if (! $typeNode -> hasChildNodes()) {
@@ -1255,7 +1256,7 @@ sub __checkTypeConfigConsist {
 						}
 					}
 				} else {
-					my $msg = "Unknown type configuration section '$optName'"
+					my $msg = "Unknown type configuration section '$optName' "
 					. 'found. Please report to the kiwi mailing list';
 					$kiwi -> warning($msg);
 					$kiwi -> skipped();
@@ -1264,7 +1265,6 @@ sub __checkTypeConfigConsist {
 			}
 		}
 	}
-
 	return 1;
 }
 

--- a/tests/unit/KTXMLVagrantConfigData.t
+++ b/tests/unit/KTXMLVagrantConfigData.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+#================
+# FILE          : KTXMLVagrantConfigData.t
+#----------------
+# PROJECT       : openSUSE Build-Service
+# COPYRIGHT     : (c) 2012 SUSE LLC
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.com
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : Unit test driver for the KIWIXMLVagrantConfigData module.
+#               :
+# STATUS        : Development
+#----------------
+package KTXMLVagrantConfigData;
+use strict;
+use warnings;
+use FindBin;
+use Test::Unit::Lite;
+
+# Location of test cases according to program path
+use lib "$FindBin::Bin/lib";
+
+# Location of Kiwi modules relative to test
+use lib "$FindBin::Bin/../../modules";
+
+my $runner = Test::Unit::HarnessUnit->new();
+$runner->start( 'Test::kiwiXMLVagrantConfigData');
+
+1;

--- a/tests/unit/lib/Test/kiwiXMLVagrantConfigData.pm
+++ b/tests/unit/lib/Test/kiwiXMLVagrantConfigData.pm
@@ -1,0 +1,191 @@
+#================
+# FILE          : kiwiXMLVagrantConfigData.pm
+#----------------
+# PROJECT       : openSUSE Build-Service
+# COPYRIGHT     : (c) 2012 SUSE LLC
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : Unit test implementation for the KIWIXMLVagrantConfigData
+#               : module.
+#               :
+# STATUS        : Development
+#----------------
+package Test::kiwiXMLVagrantConfigData;
+
+use strict;
+use warnings;
+use XML::LibXML;
+
+use Common::ktLog;
+use Common::ktTestCase;
+use Readonly;
+use base qw /Common::ktTestCase/;
+
+use KIWIXMLVagrantConfigData;
+
+
+#==========================================
+# Constructor
+#------------------------------------------
+sub new {
+	# ...
+	# Construct new test case
+	# ---
+	my $this = shift -> SUPER::new(@_);
+	return $this;
+}
+
+#==========================================
+# test_ctor
+#------------------------------------------
+sub test_ctor {
+	# ...
+	# Test the VagrantConfigData constructor
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDataObj = KIWIXMLVagrantConfigData -> new();
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	return;
+}
+
+#==========================================
+# test_ctor_improperArg
+#------------------------------------------
+sub test_ctor_improperArg {
+	# ...
+	# Test the VagrantConfigData constructor with an improper argument type
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my $confDataObj = KIWIXMLVagrantConfigData -> new('foo');
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'Expecting a hash ref as first argument if provided';
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_null($confDataObj);
+	return;
+}
+
+#==========================================
+# test_ctor_initUnsupportedData
+#------------------------------------------
+sub test_ctor_initUnsupportedData {
+	# ...
+	# Test the VagrantConfigData constructor with an initialization hash
+	# that contains unsupported data
+	# ---
+	my $this = shift;
+	my $kiwi = $this -> {kiwi};
+	my %init = (
+		firmwaredriver => 'b43'
+	);
+	my $confDataObj = KIWIXMLVagrantConfigData -> new(\%init);
+	my $msg = $kiwi -> getMessage();
+	my $expected = 'KIWIXMLVagrantConfigData: Unsupported keyword argument '
+		. "'firmwaredriver' in initialization structure.";
+	$this -> assert_str_equals($expected, $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('error', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('failed', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_null($confDataObj);
+	return;
+}
+
+#==========================================
+# test_getProvider
+#------------------------------------------
+sub test_getProvider {
+	# ...
+	# Test the getProvider method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $init = $this -> __getBaseInitHash();
+	my $confDataObj = KIWIXMLVagrantConfigData -> new($init);
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $scan = $confDataObj -> getProvider();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('libvirt', $scan);
+	return;
+}
+
+#==========================================
+# test_getVirtualSize
+#------------------------------------------
+sub test_getVirtualSize {
+	# ...
+	# Test the getVirtualSize method
+	# ---
+	my $this = shift;
+	my $kiwi = $this->{kiwi};
+	my $init = $this -> __getBaseInitHash();
+	my $confDataObj = KIWIXMLVagrantConfigData -> new($init);
+	my $msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	my $msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	my $state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	# Test this condition last to get potential error messages
+	$this -> assert_not_null($confDataObj);
+	my $scan = $confDataObj -> getVirtualSize();
+	$msg = $kiwi -> getMessage();
+	$this -> assert_str_equals('No messages set', $msg);
+	$msgT = $kiwi -> getMessageType();
+	$this -> assert_str_equals('none', $msgT);
+	$state = $kiwi -> getState();
+	$this -> assert_str_equals('No state set', $state);
+	$this -> assert_str_equals('42', $scan);
+	return;
+}
+
+#==========================================
+# Private helper methods
+#------------------------------------------
+#==========================================
+# __getBaseInitHash
+#------------------------------------------
+sub __getBaseInitHash {
+	# ...
+	# Setup a basic initialization hash for the VagrantConfigData object.
+	# This method does not configure any of the potentially conflicting
+	# settings.
+	# ---
+	my $this = shift;
+	my %init = (
+		provider  => 'libvirt',
+		virtual_size => '42'
+	);
+	return \%init;
+}
+
+1;


### PR DESCRIPTION
In order to create a vagrant box the format parameter in the
image type acts as trigger to start the box creation. Vagrant
boxes requires some metadata in order to allow adding the box
for a specific provider. Thus the following minimal type spec
is needed e.g:

  <type image="vmx" ... format="vagrant">
    <vagrantconfig provider="libvirt" virtualsize="16"/>
  </type>

The result .box file can be added to vagrant as follows

  vagrant box add <name> /path/to/file.box

Once added vagrant can run the box using the specified provider
Please note the kiwi image for vagrant needs to provide some
configuration like the existence of a user vagrant and ssh
keys. All this can be achieved in a kiwi image description.
For details visit:

  http://docs.vagrantup.com/v2/boxes/base.html
