### PR TITLE
raw format......

### DIFF
--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -197,6 +197,9 @@ sub createFormat {
 	} elsif ($format eq "ova") {
 		$kiwi -> info ("Starting raw => $format conversion\n");
 		return $this -> createOVA();
+	} elsif ($format eq "raw") {
+		$kiwi -> info ("No conversion necessary raw format already exists\n");
+		return $this;
 	} elsif ($format eq "qcow2") {
 		$kiwi -> info ("Starting raw => $format conversion\n");
 		return $this -> createQCOW2();
@@ -220,7 +223,7 @@ sub createMachineConfiguration {
 	my $xml    = $this->{xml};
 	my $bootp  = $this->{bootp};
 	my $vconf  = $this->{vmdata};
-	if ((! $vconf) && ($format =~ /qcow2|vagrant/)) {
+	if ((! $vconf) && ($format =~ /qcow2|raw|vagrant/)) {
 		# a machine configuration doesn't make sense with these
 		# formats requested. Thus we can silently return here
 		return;

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -2157,7 +2157,7 @@ sub __isValidFormat {
 		return;
 	}
 	my %supported = map { ($_ => 1) } qw(
-		ec2 ovf ova qcow2 vmdk vdi vhd vhd-fixed vagrant
+		ec2 ovf ova qcow2 raw vmdk vdi vhd vhd-fixed vagrant
 	);
 	if (! $supported{$format} ) {
 		my $msg = "$caller: specified format '$format' is not "


### PR DESCRIPTION
- allow "raw" as a format specifier.
  - raw is the default image creation format and kiwi always creates a
    .raw file. However the user may want to specify the default as the
    format and we should not error out when the default is explicitly
    specified, as is the case today.
