### PR TITLE
- fail when a product plugin dir is configured, but does not exist

### DIFF
--- a/modules/KIWIRepoMetaHandler.pm
+++ b/modules/KIWIRepoMetaHandler.pm
@@ -110,7 +110,7 @@ sub loadPlugins {
 	unshift @INC, $dir;
 	if (not opendir(PLUGINDIR, "$dir")) {
 		$this->collect()->logMsg(
-			"W", "loadPlugins: cannot open directory $dir"
+			"E", "loadPlugins: cannot open directory $dir"
 		);
 		return ($loaded, $avail);
 	}


### PR DESCRIPTION
avoids wrong configuration which happens quite often, using wrong instsource plugins package in project configuration.
