### PR TITLE
Prevent DiskStartSector values below the global default

### DIFF
--- a/kiwi.pl
+++ b/kiwi.pl
@@ -782,6 +782,7 @@ sub init {
 	if (! $cmdL) {
 		kiwiExit (1);
 	}
+	my $gdata = $global -> getKiwiConfig();
 	#==========================================
 	# get options and call non-root tasks
 	#------------------------------------------
@@ -907,6 +908,10 @@ sub init {
 		$DiskStartSector = int (
 			$cmdL -> getDiskAlignment * 1024 / $cmdL -> getDiskBIOSSectorSize()
 		);
+		my $defaultStartSector = $gdata -> {DiskStartSector};
+		if ($DiskStartSector < $defaultStartSector) {
+			$DiskStartSector = $defaultStartSector;
+		}
 	}
 	$cmdL -> setDiskStartSector (
 		$DiskStartSector
@@ -1266,7 +1271,6 @@ sub init {
 	#========================================
 	# turn destdir into absolute path
 	#----------------------------------------
-	my $gdata = $global -> getKiwiConfig();
 	if (defined $Destination) {
 		$Destination = File::Spec->rel2abs ($Destination);
 		$cmdL -> setImageTargetDir ($Destination);


### PR DESCRIPTION
Since the DiskAlignment value is used to calculate the DiskStartSector
it is possible to have a too small value.
To prevent this the global DiskStartSector default is used if the
DiskAlignment value is smaller.

This behavior can be overwritten by using the parameter
--disk-start-sector.
