### PR TITLE
ANd that's a wrap for bnc #887801

### DIFF
--- a/system/boot/ix86/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/vmxboot/suse-SLES12/config.xml
@@ -82,12 +82,14 @@
         <package name="kernel-default" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
+        <package name="grub2-x86_64-xen"/>
 <!-- xen kernel only supported on x86_64 -->
         <package name="kernel-xen" arch="x86_64"/>
 <!-- xen dom0 support only on x86_64 -->
         <package name="xen" arch="x86_64"/>
     </packages>
     <packages type="image" profiles="ec2k">
+        <package name="grub2-x86_64-xen"/>
         <package name="kernel-ec2"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>


### PR DESCRIPTION
- Use the x86-64-xen or i386-xen format for the grub2 image creation on EC2
  - this is a follow up change for b1be72f59f5f4498 addressing bnc #887801
    we avoid the hacky symlink introduced by the previous commit.
    This change requires a grub release that contains
    http://git.savannah.gnu.org/cgit/grub.git/commit/ChangeLog?id=9612ebc0
