### PR TITLE
Set sudoers secure_path for vagrant examples

### DIFF
--- a/doc/examples/extras/suse-13.1/suse-vagrant-box/root/etc/sudoers
+++ b/doc/examples/extras/suse-13.1/suse-vagrant-box/root/etc/sudoers
@@ -28,6 +28,8 @@ Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_ME
 # account if they are allowed to run commands without authentication.
 #Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_TIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE XMODIFIERS GTK_IM_MODULE QT_IM_MODULE QT_IM_SWITCHER"
 
+Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # In the default (unconfigured) configuration, sudo asks for the root password.
 # This allows use of an ordinary user account for administration of a freshly
 # installed system. When configuring sudo, delete the two

--- a/doc/examples/extras/suse-SLES11/suse-vagrant-box/root/etc/sudoers
+++ b/doc/examples/extras/suse-SLES11/suse-vagrant-box/root/etc/sudoers
@@ -28,6 +28,8 @@ Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_ME
 # account if they are allowed to run commands without authentication.
 #Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_TIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE XMODIFIERS GTK_IM_MODULE QT_IM_MODULE QT_IM_SWITCHER"
 
+Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # In the default (unconfigured) configuration, sudo asks for the root password.
 # This allows use of an ordinary user account for administration of a freshly
 # installed system. When configuring sudo, delete the two


### PR DESCRIPTION
secure_path is needed to find executables under i.e.
/sbin/ when vagrant uses sudo.
This fixes the problem when using vagrant-libvirt and
sync a folder via 9p which leads currently to:

==> devstack1: mounting p9 share in guest
modprobe 9p
bash: line 2: modprobe: command not found
