### PR TITLE
make it clear which directory couldn't be created

### DIFF
--- a/modules/KIWILocator.pm
+++ b/modules/KIWILocator.pm
@@ -83,6 +83,10 @@ sub createTmpDirectory {
             }
             if (mkdir $root) {
                 $rootError = 0;
+            } else {
+                $kiwi -> failed();
+                $kiwi -> error ("Couldn't mkdir '$root': $!");
+                $kiwi -> failed();
             }
         }
     } else {


### PR DESCRIPTION
If a previous build failed, it might have left the root directory
behind.  Giving the path in the error will help the user clean it up.
