### PR TITLE
remove pointless $xmlsize assignment

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -4743,7 +4743,6 @@ sub getSize {
         $minsize = sprintf ("%.0f",$minsize);
     }
     $minsize+= $spare;
-    $xmlsize = $minsize;
     $kiwi -> loginfo ("getSize: minsz: $minsize Bytes\n");
     #==========================================
     # XML size calculated in Byte


### PR DESCRIPTION
This assignment is pointless since `$xmlsize` will always get set to another value soon after.

I just noticed this whilst reading the sizing code and trying to understand it.
