### PR TITLE
Added support for custom qemu-img format options

### DIFF
--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -1679,6 +1679,13 @@ div {
             "ec2" | "gce" | "ovf" | "ova" | "qcow2" | "vagrant" | "vmdk" |
             "vdi" | "vhd" | "vhd-fixed"
         }
+    k.type.formatoptions.attribute =
+        ## Specifies additional format options passed on to qemu-img
+        ## formatoptions is a comma separated list of format specific
+        ## options in a name=value format like qemu-img expects it.
+        ## kiwi will take the information and pass it as parameter to
+        ## the -o option in the qemu-img call
+        attribute formatoptions { text }
     k.type.fsnocheck.attribute =
         ## Turn off periodic filesystem checks on ext2/3/4.
         attribute fsnocheck { xsd:boolean }
@@ -1801,6 +1808,7 @@ div {
         k.type.filesystem.attribute? &
         k.type.flags.attribute? &
         k.type.format.attribute? &
+        k.type.formatoptions.attribute? &
         k.type.fsnocheck.attribute? &
         k.type.fsreadonly.attribute? &
         k.type.fsreadwrite.attribute? &

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -20,7 +20,7 @@
   STATUS        : Development
   ****************
 -->
-<grammar xmlns:db="http://docbook.org/ns/docbook" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:db="http://docbook.org/ns/docbook" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <db:info>
     <db:releaseinfo>$Id: kiwi.rnc 2957 2008-01-11 12:53:39Z thomas-schraitle $</db:releaseinfo>
     <db:releaseinfo>RNC Schema Version 6.2</db:releaseinfo>
@@ -2262,6 +2262,15 @@ To be remove from here by the end of 2014</a:documentation>
         </choice>
       </attribute>
     </define>
+    <define name="k.type.formatoptions.attribute">
+      <attribute name="formatoptions">
+        <a:documentation>Specifies additional format options passed on to qemu-img
+formatoptions is a comma separated list of format specific
+options in a name=value format like qemu-img expects it.
+kiwi will take the information and pass it as parameter to
+the -o option in the qemu-img call</a:documentation>
+      </attribute>
+    </define>
     <define name="k.type.fsnocheck.attribute">
       <attribute name="fsnocheck">
         <a:documentation>Turn off periodic filesystem checks on ext2/3/4.</a:documentation>
@@ -2501,6 +2510,9 @@ into the master block. There is space for 32 characters.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.format.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.formatoptions.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.fsnocheck.attribute"/>

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -3888,6 +3888,7 @@ sub __genTypeHash {
         'firmware',
         'flags',
         'format',
+        'formatoptions',
         'fsmountoptions',
         'zfsoptions',
         'fsnocheck',

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -71,6 +71,7 @@ sub new {
     #     firmware               = ''
     #     flags                  = ''
     #     format                 = ''
+    #     formatoptions          = ''
     #     fsmountoptions         = ''
     #     zfsoptions             = ''
     #     fsnocheck              = ''
@@ -136,6 +137,7 @@ sub new {
         firmware
         flags
         format
+        formatoptions
         fsmountoptions
         zfsoptions
         fsnocheck
@@ -204,6 +206,7 @@ sub new {
     $this->{firmware}               = $init->{firmware};
     $this->{flags}                  = $init->{flags};
     $this->{format}                 = $init->{format};
+    $this->{formatoptions}          = $init->{formatoptions};
     $this->{fsmountoptions}         = $init->{fsmountoptions};
     $this->{zfsoptions}             = $init->{zfsoptions};
     $this->{fsreadonly}             = $init->{fsreadonly};
@@ -448,6 +451,17 @@ sub getFormat {
     # ---
     my $this = shift;
     return $this->{format};
+}
+
+#==========================================
+# getFormatOptions
+#------------------------------------------
+sub getFormatOptions {
+    # ...
+    # Return the format options for the virtual image format
+    # ---
+    my $this = shift;
+    return $this->{formatoptions};
 }
 
 #==========================================
@@ -901,6 +915,10 @@ sub getXMLElement {
     if ($format) {
         $element -> setAttribute('format', $format);
     }
+    my $formatoptions = $this -> getFormatOptions();
+    if ($formatoptions) {
+        $element -> setAttribute('formatoptions', $formatoptions);
+    }
     my $fsOpts = $this -> getFSMountOptions();
     if ($fsOpts) {
         $element -> setAttribute('fsmountoptions', $fsOpts);
@@ -1328,6 +1346,19 @@ sub setFormat {
         return;
     }
     $this->{format} = $format;
+    return $this;
+}
+
+#==========================================
+# setFormatOptions
+#------------------------------------------
+sub setFormatOptions {
+    # ...
+    # Set format options for the virtual image format
+    # ---
+    my $this   = shift;
+    my $options= shift;
+    $this->{formatoptions} = $options;
     return $this;
 }
 

--- a/tests/unit/lib/Test/kiwiXMLTypeData.pm
+++ b/tests/unit/lib/Test/kiwiXMLTypeData.pm
@@ -1201,6 +1201,27 @@ sub test_getFormat {
 }
 
 #==========================================
+# test_getFormatOptions
+#------------------------------------------
+sub test_getFormatOptions {
+    # ...
+    # Test the getFormatOptions method
+    # ---
+    my $this = shift;
+    my $kiwi = $this -> {kiwi};
+    my $typeDataObj = $this -> __getTypeObj();
+    my $format = $typeDataObj -> getFormatOptions();
+    my $msg = $kiwi -> getMessage();
+    $this -> assert_str_equals('No messages set', $msg);
+    my $msgT = $kiwi -> getMessageType();
+    $this -> assert_str_equals('none', $msgT);
+    my $state = $kiwi -> getState();
+    $this -> assert_str_equals('No state set', $state);
+    $this -> assert_str_equals('compat=bob,name=xxx', $format);
+    return;
+}
+
+#==========================================
 # test_getFSMountOptions
 #------------------------------------------
 sub test_getFSMountOptions {
@@ -1816,6 +1837,7 @@ sub test_getXMLElement{
         . 'firmware="efi" '
         . 'flags="compressed" '
         . 'format="qcow2" '
+        . 'formatoptions="compat=bob,name=xxx" '
         . 'fsmountoptions="barrier" '
         . 'fsnocheck="true" '
         . 'fsreadonly="ext3" '
@@ -5112,6 +5134,7 @@ sub __getTypeObj {
                 firmware               => 'efi',
                 flags                  => 'compressed',
                 format                 => 'qcow2',
+                formatoptions          => 'compat=bob,name=xxx',
                 fsmountoptions         => 'barrier',
                 fsnocheck              => 'true',
                 fsreadonly             => 'ext3',


### PR DESCRIPTION
Added support for custom qemu-img format options

When kiwi calls qemu-img to convert the image into the format the user has specified in the XML description it might be required to pass on additional format options like the compat mode for the qcow2 format. This can now be done like the following example shows:

```
<type ... formatoptions="compat=0.10"/>
```
