### PR TITLE
Fall back to lazyly umount /dev nodes in case of failure

### DIFF
--- a/modules/KIWIRoot.pm
+++ b/modules/KIWIRoot.pm
@@ -1721,8 +1721,16 @@ sub cleanMount {
         my $data = KIWIQX::qxx ("umount \"$item\" 2>&1");
         my $code = $? >> 8;
         if (($code != 0) && ($data !~ "not mounted")) {
-            $kiwi -> warning ("Umount of $item failed: $data");
-            $kiwi -> skipped ();
+            # umount failed - for /dev we can allow to lazy umount it (null might be held open)
+            if ($item =~ "/dev") {
+                $kiwi -> loginfo ("Umounting path (lazy): $item\n");
+                my $data = KIWIQX::qxx ("umount -l \"$item\" 2>&1");
+                my $code = $? >> 8;
+            }
+            if ($code != 0) {
+                $kiwi -> warning ("Umount of $item failed: $data");
+                $kiwi -> skipped ();
+            }
         }
         if (($prefix) && ($item =~ /^$prefix/)) {
             KIWIQX::qxx ("rmdir -p \"$item\" 2>&1");


### PR DESCRIPTION
umount -l seems about the only way that gets us really going.

I only use this as fallback for /dev nodes in order to not mask other issues we might encounter.
In my tests, with the latest kiwi submitted plus this patch, I get builds going;

Any chance to get this rather fast reviewed / discussed / merged and submitted? It blocks Factory publishing
