### PR TITLE
Fix bashisms in image.sh shell scripts

### DIFF
--- a/system/boot/ix86/netboot/suse-12.3/images.sh
+++ b/system/boot/ix86/netboot/suse-12.3/images.sh
@@ -22,6 +22,6 @@ suseStripInitrd
 #==========================================
 # umount
 #------------------------------------------
-umount /proc &>/dev/null
+umount /proc >/dev/null 2>&1
 
 exit 0

--- a/system/boot/ix86/netboot/suse-13.1/images.sh
+++ b/system/boot/ix86/netboot/suse-13.1/images.sh
@@ -22,6 +22,6 @@ suseStripInitrd
 #==========================================
 # umount
 #------------------------------------------
-umount /proc &>/dev/null
+umount /proc >/dev/null 2>&1
 
 exit 0

--- a/system/boot/ix86/netboot/suse-13.2/images.sh
+++ b/system/boot/ix86/netboot/suse-13.2/images.sh
@@ -22,6 +22,6 @@ suseStripInitrd
 #==========================================
 # umount
 #------------------------------------------
-umount /proc &>/dev/null
+umount /proc >/dev/null 2>&1
 
 exit 0

--- a/system/boot/ix86/netboot/suse-SLED12/images.sh
+++ b/system/boot/ix86/netboot/suse-SLED12/images.sh
@@ -22,6 +22,6 @@ suseStripInitrd
 #==========================================
 # umount
 #------------------------------------------
-umount /proc &>/dev/null
+umount /proc >/dev/null 2>&1
 
 exit 0

--- a/system/boot/ix86/netboot/suse-SLES12/images.sh
+++ b/system/boot/ix86/netboot/suse-SLES12/images.sh
@@ -22,6 +22,6 @@ suseStripInitrd
 #==========================================
 # umount
 #------------------------------------------
-umount /proc &>/dev/null
+umount /proc >/dev/null 2>&1
 
 exit 0

--- a/system/boot/ppc/netboot/suse-SLES12/images.sh
+++ b/system/boot/ppc/netboot/suse-SLES12/images.sh
@@ -22,6 +22,6 @@ suseStripInitrd
 #==========================================
 # umount
 #------------------------------------------
-umount /proc &>/dev/null
+umount /proc >/dev/null 2>&1
 
 exit 0

--- a/system/boot/s390/netboot/suse-SLES12/images.sh
+++ b/system/boot/s390/netboot/suse-SLES12/images.sh
@@ -22,6 +22,6 @@ suseStripInitrd
 #==========================================
 # umount
 #------------------------------------------
-umount /proc &>/dev/null
+umount /proc >/dev/null 2>&1
 
 exit 0


### PR DESCRIPTION
Replace '&>/dev/null' output redirections to '>/dev/null 2>&1'.
