### PR TITLE
- fix dependencies of s390 requires

### DIFF
--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -350,7 +350,7 @@ Requires:       yaboot
 %endif
 %endif
 %ifarch s390 s390x
-Requires:       zipl
+Requires:       s390-tools
 %endif
 %ifarch %ix86 x86_64
 %if 0%{?suse_version} < 1315
@@ -421,7 +421,7 @@ Requires:       yaboot
 %endif
 %endif
 %ifarch s390 s390x
-Requires:       zipl
+Requires:       s390-tools
 %endif
 %ifarch %ix86 x86_64
 %if 0%{?suse_version} < 1315
@@ -536,7 +536,7 @@ Requires:       yaboot
 %endif
 %endif
 %ifarch s390 s390x
-Requires:       zipl
+Requires:       s390-tools
 %endif
 %ifarch %ix86 x86_64
 %if 0%{?suse_version} < 1315

--- a/system/boot/s390/oemboot/suse-SLES12/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES12/config.xml
@@ -124,7 +124,6 @@
         <package name="squashfs"/>
         <package name="sysconfig"/>
         <package name="sysfsutils"/>
-        <package name="syslinux"/>
         <package name="tar"/>
         <package name="util-linux"/>
         <package name="xfsprogs"/>

--- a/system/boot/s390/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/s390/vmxboot/suse-SLES12/config.xml
@@ -124,7 +124,6 @@
         <package name="squashfs"/>
         <package name="sysconfig"/>
         <package name="sysfsutils"/>
-        <package name="syslinux"/>
         <package name="tar"/>
         <package name="util-linux"/>
         <package name="xfsprogs"/>


### PR DESCRIPTION
* zipl was never an own package, it is part of s390-tools
* syslinux does not exist on SLES 12 s390

(cherry picked from commit 43798988bfd41072e6c537211b7360969fe1baf4)