### PR TITLE
Switch to using appstream-builder instead of XML parsing

### DIFF
--- a/distribution/kiwi-instsource-plugins-openSUSE-13-2/KIWIDescrPlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-13-2/KIWIDescrPlugin.pm
@@ -233,23 +233,18 @@ sub executeDir {
         );
         return 1;
     }
-    if ((-x "/usr/bin/extract-appdata-icons") &&
-        (-s "$targetdir/appdata.xml")
-    ) {
-        $cmd = "/usr/bin/extract-appdata-icons "
-            . "$targetdir/appdata.xml $targetdir";
-        $call = $this -> callCmd($cmd);
-        $status = $call->[0];
-        if($status) {
+    if (-x "/usr/bin/openSUSE-appstream-process") {
+        foreach my $p (@{$paths}) {
+            $cmd = "/usr/bin/openSUSE-appstream-process";
+            $cmd .= " $p";
+            $cmd .= " $targetdir";
+            $call = $this -> callCmd($cmd);
+            $status = $call->[0];
             my $out = join("\n",@{$call->[1]});
-            $this->logMsg("E",
+            $this->logMsg("I",
                 "Called <$cmd> exit status: <$status> output: $out"
             );
-            return 1;
-        }
-        if($this->{m_compress} =~ m{yes}i) {
-            system("gzip", "--rsyncable", "$targetdir/appdata.xml");
-        }
+        };
     }
     if($this->{m_compress} =~ m{yes}i) {
         foreach my $pfile(glob("$targetdir/packages*")) {
@@ -306,44 +301,18 @@ sub createRepositoryMetadata {
             );
             return 0;
         }
-        my $newtargetdir = "$p/$datadir/repodata";
-        if ((-x "/usr/bin/extract-appdata-icons") && 
-            (-s "$newtargetdir/appdata.xml")
-        ) {
-            $cmd = "/usr/bin/extract-appdata-icons "
-                . "$newtargetdir/appdata.xml $newtargetdir";
+        if (-x "/usr/bin/openSUSE-appstream-process")
+        {
+            $cmd = "/usr/bin/openSUSE-appstream-process";
+            $cmd .= " $p/$datadir";
+            $cmd .= " $p/$datadir/repodata";
+
             $call = $this -> callCmd($cmd);
             $status = $call->[0];
-            if($status) {
-                my $out = join("\n",@{$call->[1]});
-                $this->logMsg("E",
-                    "Called $cmd exit status: <$status> output: $out"
-                );
-                return 1;
-            }
-            if($this->{m_compress} =~ m{yes}i) {
-                system("gzip", "--rsyncable", "$newtargetdir/appdata.xml");
-            }
-        }
-        if ((-x "/usr/bin/extract-appdata-icons") &&
-            (-s "$targetdir/appdata.xml")
-        ) {
-            $newtargetdir = "$p/$datadir/repodata";
-            system("cp $targetdir/appdata.xml $newtargetdir/appdata.xml");
-            $cmd = "/usr/bin/extract-appdata-icons "
-                . "$newtargetdir/appdata.xml $newtargetdir";
-            $call = $this -> callCmd($cmd);
-            $status = $call->[0];
-            if($status) {
-                my $out = join("\n",@{$call->[1]});
-                $this->logMsg("E",
-                    "Called $cmd exit status: <$status> output: $out"
-                );
-                return 1;
-            }
-            if($this->{m_compress} =~ m{yes}i) {
-                system("gzip", "--rsyncable", "$newtargetdir/appdata.xml");
-            }
+            my $out = join("\n",@{$call->[1]});
+            $this->logMsg("I",
+                "Called $cmd exit status: <$status> output: $out"
+            );
         }
         if ( -f "/usr/bin/add_product_susedata" ) {
             my $kwdfile = abs_path(


### PR DESCRIPTION
I would like to get a review on this work so far.

I managed to build the non-oss tree using this switch and get a good set of valid appstream metadata out of this.
The advantage over extracting .appdata during build is that this version can 'redo' the entire extraciton over all existing RPMs in case of issues, without having to rebuild the packages (think: extractor problem producing invalid data.. before: fix extractor, rebuild all packages, rebuild ftp tree; new: fix extractor (appstream-builder), rebuild ftp-tree

The variant for rpm-md is not yet working, as I did not (yet) prepare a test setup for it... If prefered, I can leave the existing extractor in place, only with a FIXME, and only switch the yast style repository creation.