### PR TITLE
aarch64: Load full EFI emulation size

### DIFF
--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -402,7 +402,7 @@ sub aarch64_efi {
     my $boot  = $base{$arch}{boot};
     my $loader= $base{$arch}{efi};
     $para.= " -no-emul-boot";
-    $para.= " -boot-load-size 1";
+    # do not add -boot-load-size 1 here
     $para.= " -b $loader";
     $para.= " -c $boot/boot.catalog";
     $para.= " -hide $boot/boot.catalog -hide-joliet $boot/boot.catalog";


### PR DESCRIPTION
-boot-load-size 1 is not a recommended option. First of all
a loader size that is not divideable by 4 is rejected by
most EFI firmwares. In addition we need to load all of the
EFI code into memory. When the option is not set, genisoimage
uses the full length by default, which is what we want.