### PR TITLE
remove plymouth packages from s390x boot image

### DIFF
--- a/system/boot/s390/netboot/suse-SLES12/config.xml
+++ b/system/boot/s390/netboot/suse-SLES12/config.xml
@@ -101,8 +101,6 @@
         <package name="netcfg"/>
         <package name="nfs-client"/>
         <package name="parted"/>
-        <package name="plymouth"/>
-        <package name="plymouth-scripts"/>
         <package name="tar"/>
         <package name="xfsprogs"/>
         <package name="s390-tools"/>

--- a/system/boot/s390/oemboot/suse-SLES12/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES12/config.xml
@@ -120,8 +120,6 @@
         <package name="netcfg"/>
         <package name="parted"/>
         <package name="pciutils"/>
-        <package name="plymouth"/>
-        <package name="plymouth-scripts"/>
         <package name="squashfs"/>
         <package name="sysconfig"/>
         <package name="sysfsutils"/>

--- a/system/boot/s390/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/s390/vmxboot/suse-SLES12/config.xml
@@ -120,8 +120,6 @@
         <package name="netcfg"/>
         <package name="parted"/>
         <package name="pciutils"/>
-        <package name="plymouth"/>
-        <package name="plymouth-scripts"/>
         <package name="squashfs"/>
         <package name="sysconfig"/>
         <package name="sysfsutils"/>


### PR DESCRIPTION
We don't need graphical boot on s390x.