### PR TITLE
check user_name is defined when checking file tree

### DIFF
--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -1550,7 +1550,9 @@ sub __checkCorrectRootFSPermissons {
         my $group_name = getgrgid($gid);
         if (($uid != 0) || ($gid != 0)) {
             $msg = "Image tree check for $path ";
-            $msg.= "returned owner/group name '$user_name/$group_name' ";
+            if (defined($user_name) && defined($group_name)) {
+                $msg.= "returned owner/group name '$user_name/$group_name' ";
+            }
             $msg.= "with owner/group IDs '$uid/$gid'. ";
             $msg.= "Expected 'root/root with 0/0 IDs'";
             $kiwi -> error ($msg);


### PR DESCRIPTION
It is possible to have files that should be owned by root which
are owned by a non-existing user, meaning the uid has no corresponding
username. When this happens, the check used to give the error

"Use of uninitialized value $user_name in concatenation (.) or string
at /usr/share/kiwi/modules/KIWIRuntimeChecker.pm line 1558."

Thus we need to check whether the user exists.