### PR TITLE
- Fix consistency check for LXC builds

### DIFF
--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -430,13 +430,13 @@ sub __checkContainerHasLXC {
         push @{$pckgs}, @{$xml -> getBootstrapPackages()};
         for my $pckg (@{$pckgs}) {
             my $pname = $pckg -> getName();
-            if ($pname =~ /^lxc/smx) {
+            if ($pname =~ /^lxc|^systemd/smx) {
                 return 1;
             }
         }
         my $kiwi = $this->{kiwi};
-        my $msg = 'Attempting to build container, but no lxc package included '
-            . 'in image.';
+        my $msg = 'Attempting to build container, neither systemd nor the '
+            . 'lxc package is included in the image.';
         $kiwi -> error ( $msg );
         $kiwi -> failed ();
         return;

--- a/tests/unit/lib/Test/kiwiRuntimeChecker.pm
+++ b/tests/unit/lib/Test/kiwiRuntimeChecker.pm
@@ -240,8 +240,8 @@ sub test_containerPackMissing {
     my $checker = KIWIRuntimeChecker -> new($cmd, $xml);
     $res = $checker -> __checkContainerHasLXC();
     my $msg = $kiwi -> getMessage();
-    my $expected = 'Attempting to build container, but no lxc package '
-        . 'included in image.';
+    my $expected = 'Attempting to build container, neither systemd nor the '
+        . 'lxc package is included in the image.';
     $this -> assert_str_equals($expected, $msg);
     my $msgT = $kiwi -> getMessageType();
     $this -> assert_str_equals('error', $msgT);


### PR DESCRIPTION
  + Prior to the emergence of systemd the lxc package provided a special
    init script, lxc-init. This was necessary as SysV-init was not container
    aware. systemd is container aware, thus including systemd as the init
    system is sufficient.