### PR TITLE
dhclient has no option for timeout

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -4979,7 +4979,7 @@ function setupNetworkDHCLIENT {
     # assign DHCP IP address by using the dhclient tool
     # ----
     local IFS=$IFS_ORIG
-    local dhclient_opts=" -4 -1 -q -timeout 20"
+    local dhclient_opts=" -4 -1 -q"
     mkdir -p /var/lib/dhclient
     mkdir -p /var/run
     for try_iface in ${dev_list[*]}; do


### PR DESCRIPTION
The dhclient in openSUSE 13.2 has no parameter for timeout, but it
is specified in the setupNetworkDHCLIENT function. The timeout is
taken from the configuration file as mentioned in the manpage.