### PR TITLE
Added __checkMountDependencies runtime check

### DIFF
--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -1486,30 +1486,56 @@ sub __checkMountDependencies {
     if ($ENV{KIWI_IGNORE_OLD_MOUNTS}) {
         return 1;
     }
-    my $kiwi_mount_references = KIWIQX::qxx (
-        "grep -il kiwi /proc/[1-9]*/task/*/mounts|cut -d/ -f3|sort -u 2>&1"
-    );
-    if (! $kiwi_mount_references) {
+    my %proc_result;
+    foreach my $pid ($this->__read_pids('/proc')) {
+        foreach my $task_pid ($this->__read_pids("/proc/$pid/task")) {
+            my $TASK_MOUNTS = FileHandle->new();
+            if ($TASK_MOUNTS->open("/proc/$pid/task/$task_pid/mounts")) {
+                while (my $line = <$TASK_MOUNTS>) {
+                    # The search expression to indicate this mount belongs to
+                    # some kiwi process is not 100% reliable, but so far the
+                    # only solution I could come up with
+                    if ($line =~ /kiwi/) {
+                        $proc_result{$task_pid} = 1;
+                    }
+                }
+                $TASK_MOUNTS->close();
+            }
+        }
+    }
+    my @kiwi_mount_references = sort keys %proc_result;
+    if (! @kiwi_mount_references) {
         return 1;
     }
-    my @kiwi_mount_references = split(/\n/, $kiwi_mount_references);
-    my $details = KIWIQX::qxx ("ps -o pid,cmd @kiwi_mount_references");
-    $msg = "It appears there are processes which are holding onto\n";
-    $msg.= "mounts created by a previous run:\n";
-    $msg.= "\n";
-    $msg.= $details;
-    $msg.= "\n";
-    $msg.= "This could cause kiwi to fail, or even worse, if you are\n";
-    $msg.= "building on tmpfs, it could totally freeze or crash your\n";
-    $msg.= "machine.\n";
-    $msg.= "\n";
-    $msg.= "Please first clean up these old mounts, or export:\n";
-    $msg.= "\n";
-    $msg.= "KIWI_IGNORE_OLD_MOUNTS=yes\n";
-    $msg.= "\n";
-    $msg.= "and re-run.\n";
-    $kiwi->error($msg);
-    $kiwi->failed();
+
+    $msg = <<'    END_MESSAGE';
+    It appears there are processes which are holding onto
+    mounts created by a previous run
+    END_MESSAGE
+    $kiwi->error($this->__here_format($msg));
+
+    my $PS = FileHandle->new();
+    if ($PS->open("pstree -p|")) {
+        while (my $line = <$PS>) {
+            foreach my $ref_pid (@kiwi_mount_references) {
+                if ($line =~ /\($ref_pid\)/) {
+                    $kiwi->note($line);
+                    last;
+                }
+            }
+        }
+        $PS -> close();
+    }
+    $kiwi->note("\n");
+
+    $msg = <<'    END_MESSAGE';
+    This could cause kiwi to fail, or even worse, if you are
+    building on tmpfs, it could totally freeze or crash your
+    machine. Please first clean up these old mounts, or export
+    'KIWI_IGNORE_OLD_MOUNTS=yes' and re-run
+    END_MESSAGE
+    $kiwi->error($this->__here_format($msg));
+
     return;
 }
 
@@ -1671,6 +1697,41 @@ sub __checkCorrectRootFSPermissons {
         }
     }
     return 1;
+}
+
+#==========================================
+# __read_pids
+#------------------------------------------
+sub __read_pids {
+    # ...
+    # proc data help method, to read process ID entries
+    # ---
+    my $this = shift;
+    my $path = shift;
+    my @pids;
+    if (opendir (my $FD, $path)) {
+        foreach my $pid (readdir $FD) {
+            next if $pid !~ /^\d+$/;
+            push @pids, $pid;
+        }
+        closedir $FD;
+    }
+    return @pids;
+}
+
+#==========================================
+# __here_format
+#------------------------------------------
+sub __here_format {
+    # ...
+    # message text formatter for result of here documents
+    # ---
+    my $this = shift;
+    my $message = shift;
+    $message =~ s/\n/ /g;
+    $message =~ s/ {4}+//g;
+    $message.= "\n";
+    return $message;
 }
 
 1;


### PR DESCRIPTION
The check looks for processes which holds onto mounts created by a previos kiwi run. In such a condition kiwi is not able to release its own mount table and shows information about the processes which keeps these mount points busy. We still don't understand why there could be non kiwi related processes holding onto mounts kiwi has created during its run but kiwi should provide a way to tell this information to the user and stop if the environment is still tainted by such processes

https://bugzilla.suse.com/show_bug.cgi?id=895204

