### PR TITLE
Introduce initial support for App Container Image (aci)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -14,6 +14,8 @@ my $result = GetOptions(
 
 # The known Perl modules
 my @kiwiModules = qw (
+    kiwiACIConfigWriter.pm
+    KIWIACIConfigWriter.pm
     KIWIAnalyseReport.pm
     KIWIAnalyseSoftware.pm
     KIWIAnalyseSystem.pm
@@ -157,6 +159,7 @@ my @kiwiModules = qw (
     KIWIXMLValidator.pm
     kiwiXMLVMachineData.pm
     KIWIXMLVMachineData.pm
+    KTACIConfigWriter.t
     KTCommandLine.t
     KTConfigWriterFactory.t
     KTContainerBuilder.t
@@ -210,6 +213,8 @@ my @kiwiModules = qw (
 
 # List of modules not clean to level 1 (brutal) of perlcritic
 my @notClean1 = qw (
+    kiwiACIConfigWriter.pm
+    KIWIACIConfigWriter.pm
     KIWIResult.pm
     KIWIArchList.pm
     KIWIArch.pm
@@ -305,6 +310,7 @@ my @notClean1 = qw (
     KIWIXMLUserData.pm
     KIWIXMLVMachineData.pm
     KIWIXMLValidator.pm
+    KTACIConfigWriter.t
     KTCommandLine.t
     KTConfigWriterFactory.t
     KTContainerBuilder.t
@@ -406,6 +412,8 @@ my @notClean1 = qw (
 
 # List of modules not clean to level 2 (cruel) of perlcritic
 my @notClean2 = qw (
+    kiwiACIConfigWriter.pm
+    KIWIACIConfigWriter.pm
     KIWIResult.pm
     KIWIArchList.pm
     KIWIArch.pm
@@ -479,6 +487,8 @@ my @notClean2 = qw (
 
 # List of modules not clean to level 3 (harsh) of perlcritic
 my @notClean3 = qw (
+    kiwiACIConfigWriter.pm
+    KIWIACIConfigWriter.pm
     KIWIResult.pm
     KIWIArchList.pm
     KIWIBoot.pm

--- a/doc/examples/extras/suse-13.1/suse-aci-container/config.sh
+++ b/doc/examples/extras/suse-13.1/suse-aci-container/config.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2013 SUSE LLC
+#               :
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for SUSE based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# SuSEconfig
+#--------------------------------------
+suseConfig
+
+#======================================
+# Activate services
+#--------------------------------------
+suseActivateDefaultServices
+
+#======================================
+# Umount kernel filesystems
+#--------------------------------------
+baseCleanMount
+
+exit 0

--- a/doc/examples/extras/suse-13.1/suse-aci-container/config.xml
+++ b/doc/examples/extras/suse-13.1/suse-aci-container/config.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.2" name="suse-13.1-aci-guest">
+    <description type="system">
+        <author>Matwey V. Kornilov</author>
+        <contact>matwey.kornilov@gmail.com</contact>
+        <specification>openSUSE 13.1 ACI container</specification>
+    </description>
+    <preferences>
+        <type image="aci" container="os131">
+        </type>
+        <version>1.0.0</version>
+        <packagemanager>zypper</packagemanager>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <rpm-force>true</rpm-force>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <hwclock>utc</hwclock>
+        <timezone>US/Eastern</timezone>
+    </preferences>
+    <users group="root">
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository type="yast2" imageinclude="true">
+        <source path="opensuse://13.1/repo/oss/"/>
+    </repository>
+    <repository type="rpm-md" imageinclude="true">
+        <source path="http://download.opensuse.org/update/13.1/"/>
+    </repository>
+    <packages type="image">
+        <package name="coreutils"/>
+        <package name="iputils"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="module-init-tools"/>
+    </packages>
+</image>

--- a/doc/examples/suse-13.1/suse-aci-container.readme
+++ b/doc/examples/suse-13.1/suse-aci-container.readme
@@ -1,0 +1,25 @@
+KIWI Image Description Example
+==============================
+* A ACI[1] is a tarball containing the root file system of the container and manifest.
+
+How to build this Example
+==============================
+
+    kiwi -p /usr/share/doc/packages/kiwi/examples/suse-13.1/suse-aci-container \
+         --root /tmp/mycontainer
+
+    kiwi --create /tmp/mycontainer --type aci -d /tmp/mycontainer-result
+
+How to sign the container
+=======================================
+
+    gpg --no-default-keyring --armor \
+        --secret-keyring ./rkt.sec --keyring ./rkt.pub \
+        --output suse-13.1-aci-guest-1.0.0-linux-x86_64.aci.asc \
+        --detach-sig suse-13.1-aci-guest-1.0.0-linux-x86_64.aci
+
+Login Details
+==============================
+* Though you are not going to need it, the user root password is 'linux'.
+
+[1] https://github.com/appc/spec/blob/master/SPEC.md

--- a/modules/KIWIACIConfigWriter.pm
+++ b/modules/KIWIACIConfigWriter.pm
@@ -1,0 +1,111 @@
+#================
+# FILE          : KIWIACIConfigWriter.pm
+#----------------
+# PROJECT       : openSUSE Build-Service
+# COPYRIGHT     : (c) 2015 Matwey V. Kornilov
+#               :
+# AUTHOR        : Matwey V. Kornilov <matwey.kornilov@gmail.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : Write a manifest file for a ACI
+#               :
+# STATUS        : Development
+#----------------
+package KIWIACIConfigWriter;
+#==========================================
+# Modules
+#------------------------------------------
+use strict;
+use warnings;
+use JSON;
+
+#==========================================
+# Base class
+#------------------------------------------
+use base qw /Exporter/;
+use base qw /KIWIConfigWriter/;
+
+#==========================================
+# KIWI Modules
+#------------------------------------------
+use KIWIXML;
+use KIWIXMLVMachineData;
+
+#==========================================
+# Exports
+#------------------------------------------
+our @EXPORT_OK = qw ();
+
+#==========================================
+# Constructor
+#------------------------------------------
+sub new {
+    # ...
+    # Create the KIWIACIConfigWriter object
+    # ---
+    my $class = shift;
+    my $this  = $class->SUPER::new(@_);
+
+    if (! $this) {
+        return;
+    }
+    $this->{name} = 'config';
+    return $this;
+}
+
+#==========================================
+# p_writeConfigFile
+#------------------------------------------
+sub p_writeConfigFile {
+    # ...
+    # Write the container configuration file
+    # ---
+    my $this = shift;
+    my $kiwi = $this->{kiwi};
+    my $xml = $this->{xml};
+    my $loc = $this -> getConfigDir();
+    my $fileName = 'manifest';
+    my $name = $xml -> getImageName();
+    my $iver = $xml -> getPreferences() -> getVersion();
+    my $json_data = {
+    'acKind' => 'ImageManifest',
+    'acVersion' => '0.5.1',
+    'name' => $name,
+    'labels' =>
+    [{
+         'name' => 'os',
+         'value' => 'linux',
+    },
+    {
+         'name' => 'version',
+         'value' => $iver,
+    }],
+    };
+    my $json_text = JSON->new->utf8->encode($json_data);
+
+    $kiwi -> info("Write container manifest file\n");
+    $kiwi -> info("--> $loc/$fileName");
+    my $status = open (my $CONF, '>', "$loc/$fileName");
+    if (! $status) {
+         $kiwi -> failed();
+         my $msg = 'Could not write container manifest file'."$loc/$fileName";
+         $kiwi -> error($msg);
+         $kiwi -> failed();
+         return;
+    }
+    binmode $CONF;
+    print $CONF $json_text;
+    $status = close $CONF;
+    if (! $status) {
+         $kiwi -> oops();
+         my $msg = 'Unable to close manifest file'."$loc/$fileName";
+         $kiwi -> warning($msg);
+         $kiwi -> skipped();
+    }
+    $kiwi -> done();
+
+    return 1;
+}
+
+1;

--- a/modules/KIWIConfigWriterFactory.pm
+++ b/modules/KIWIConfigWriterFactory.pm
@@ -28,6 +28,7 @@ use base qw /Exporter/;
 #==========================================
 # KIWIModules
 #------------------------------------------
+use KIWIACIConfigWriter;
 use KIWIContainerConfigWriter;
 use KIWILog;
 use KIWIXML;
@@ -98,6 +99,10 @@ sub getConfigWriter {
             if (($writer) && ($typeName eq 'docker')) {
                 $writer -> setConfigFileName('default.conf');
             }
+            return $writer;
+        };
+        /^aci/smx && do {
+            my $writer = KIWIACIConfigWriter -> new($xml, $confDir);
             return $writer;
         };
         /^vmx/smx && do {

--- a/modules/KIWIContainerBuilder.pm
+++ b/modules/KIWIContainerBuilder.pm
@@ -327,6 +327,8 @@ sub __createContainerBundle {
     $kiwi -> info('Creating container tarball...');
     if ($imageType eq 'docker') {
         $extension = '-docker';
+    } elsif ($imageType eq 'aci') {
+        $extension = '';
     }
     my $baseBuildDir = $this -> getBaseBuildDirectory();
     my $origin = $baseBuildDir
@@ -336,7 +338,11 @@ sub __createContainerBundle {
     my $imgFlName = $globals -> generateBuildImageName(
         $xml, '-', $extension
     );
-    $imgFlName .= '.tar.xz';
+    if ($imageType eq 'aci') {
+        $imgFlName .= '.aci';
+    } else {
+        $imgFlName .= '.tar.xz';
+    }
     my $tar = $locator -> getExecPath('tar');
     if (! $tar) {
         $kiwi -> failed();
@@ -404,6 +410,8 @@ sub __createContainerConfigDir {
             return;
         }
         $dirPath .= '/'.$containerName;
+    } elsif ($imageType eq 'aci') {
+        $dirPath = './';
     }
     my $path = $this -> __createWorkingDir($dirPath);
     $kiwi -> info ("--> $dirPath");
@@ -640,6 +648,8 @@ sub __createTargetRootTree {
             return;
         }
         $dirPath .= $containerName . '/rootfs';
+    } elsif ($imageType eq 'aci') {
+        $dirPath = 'rootfs';
     }
     my $path = $this -> __createWorkingDir($dirPath);
     if (! $path) {

--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -620,7 +620,6 @@ sub generateBuildImageName {
     return if ! $uname_exec;
     my $arch = KIWIQX::qxx ("$uname_exec -m");
     chomp ( $arch );
-    $arch = ".$arch";
     if (! defined $separator) {
         $separator = "-";
     }
@@ -628,11 +627,15 @@ sub generateBuildImageName {
     my $iver = $xml -> getPreferences() -> getVersion();
     my $type = $xml -> getImageType();
     my $imageType = $type -> getTypeName();
-    if ($imageType eq 'docker') {
+    if ($imageType eq 'aci') {
+        $name = $name.'-'.$iver.'-linux-'.$arch;
+        return $name
+    } elsif ($imageType eq 'docker') {
         $extension = '-docker';
     } elsif ($imageType eq 'lxc') {
         $extension = '-lxc';
     }
+    $arch = ".$arch";
     if (defined $extension) {
         $name = $name.$extension.$arch.$separator.$iver;
     } else {

--- a/modules/KIWIImageBuildFactory.pm
+++ b/modules/KIWIImageBuildFactory.pm
@@ -113,7 +113,7 @@ sub getImageBuilder {
             my $builder = KIWIExt4Builder -> new($xml, $cmdL, $unPImg);
             return $builder;
         };
-        /^lxc|^docker/smx && do {
+        /^lxc|^docker|^aci/smx && do {
             my $builder = KIWIContainerBuilder -> new($xml, $cmdL, $unPImg);
             return $builder;
         };

--- a/modules/KIWIResult.pm
+++ b/modules/KIWIResult.pm
@@ -141,6 +141,9 @@ sub buildRelease {
     if ($type eq 'product') {
         $kiwi -> info ("--> Calling product bundler\n");
         $result = $this -> __bundleProduct();
+    } elsif ($type eq 'aci') {
+        $kiwi -> info ("--> Calling aci bundler\n");
+        $result = $this -> __bundleACI();
     } elsif ($type eq 'docker') {
         $kiwi -> info ("--> Calling docker bundler\n");
         $result = $this -> __bundleDocker();
@@ -340,6 +343,14 @@ sub __bundleProduct {
         return $this -> __sign_with_sha256sum();
     }
     return;
+}
+
+#==========================================
+# __bundleACI
+#------------------------------------------
+sub __bundleACI {
+    my $this = shift;
+    return $this -> __bundleExtension ('aci');
 }
 
 #==========================================

--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -1302,7 +1302,7 @@ sub __hasContainerName {
         return 1;
     }
     my $imgType = $bldType -> getTypeName();
-    if (($imgType ne 'docker') && ($imgType ne 'lxc')) {
+    if (($imgType ne 'docker') && ($imgType ne 'lxc') && ($imgType ne 'aci')) {
         # Nothing to check
         return 1;
     }
@@ -1334,6 +1334,7 @@ sub __haveValidTypeString {
     my $cmdL = $this->{cmdArgs};
     my $type = $cmdL -> getBuildType();
     my @allowedTypes = qw (
+        aci
         btrfs
         clicfs
         cpio

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -1750,7 +1750,7 @@ div {
     k.type.image.attribute =
         ## Specifies the image type
         attribute image {
-            "btrfs" | "clicfs" | "cpio" | "docker" | "ext2" | "ext3" |
+            "aci" | "btrfs" | "clicfs" | "cpio" | "docker" | "ext2" | "ext3" |
             "ext4" | "iso" | "lxc" | "oem" | "product" | "pxe" | "reiserfs" |
             "split" | "squashfs" | "tbz" | "vmx" | "xfs" | "zfs"
         }
@@ -2709,7 +2709,7 @@ div {
 #
 div {
     k.packages.type.attribute = attribute type {
-        "bootstrap" | "delete" | "docker" | "image" | "iso" |
+        "aci" | "bootstrap" | "delete" | "docker" | "image" | "iso" |
         "lxc" | "oem" | "pxe" | "split" | "testsuite" | "vmx"
     }
     k.packages.profiles.attribute = k.profiles.attribute

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -2364,6 +2364,7 @@ to keep data persistent over a reboot</a:documentation>
       <attribute name="image">
         <a:documentation>Specifies the image type</a:documentation>
         <choice>
+          <value>aci</value>
           <value>btrfs</value>
           <value>clicfs</value>
           <value>cpio</value>
@@ -3899,6 +3900,7 @@ virtual machine when running the image.</db:para>
     <define name="k.packages.type.attribute">
       <attribute name="type">
         <choice>
+          <value>aci</value>
           <value>bootstrap</value>
           <value>delete</value>
           <value>docker</value>

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -2356,6 +2356,7 @@ sub __isValidImage {
         return;
     }
     my %supported = map { ($_ => 1) } qw(
+        aci
         btrfs
         clicfs
         cpio

--- a/modules/KIWIXMLValidator.pm
+++ b/modules/KIWIXMLValidator.pm
@@ -1224,7 +1224,7 @@ sub __checkTypeConfigConsist {
     # relevant inside the initrd
     # ----
     my %typeChildDeps = (
-        'machine'       => 'image:cpio,lxc,docker,oem,vmx,split',
+        'machine'       => 'image:cpio,aci,lxc,docker,oem,vmx,split',
         'oemconfig'     => 'image:cpio,oem,split',
         'vagrantconfig' => 'image:vmx',
         'pxedeploy'     => 'image:cpio,pxe',

--- a/tests/unit/KTACIConfigWriter.t
+++ b/tests/unit/KTACIConfigWriter.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+#================
+# FILE          : KTACIConfigWriter.t
+#----------------
+# PROJECT       : openSUSE Build-Service
+# COPYRIGHT     : (c) 2013 SUSE LLC
+#               :
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : Unit test driver for the KIWIContainerConfigWriter module.
+#               :
+# STATUS        : Development
+#----------------
+package KTACIConfigWriter;
+use strict;
+use warnings;
+use FindBin;
+use Test::Unit::Lite;
+
+# Location of test cases according to program path
+use lib "$FindBin::Bin/lib";
+
+# Location of Kiwi modules relative to test
+use lib "$FindBin::Bin/../../modules";
+
+my $runner = Test::Unit::HarnessUnit->new();
+$runner->start( 'Test::kiwiACIConfigWriter' );
+
+1;

--- a/tests/unit/data/kiwiACIConfWriter/config.xml
+++ b/tests/unit/data/kiwiACIConfWriter/config.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.2" name="suse-13.1-aci-guest">
+    <description type="system">
+        <author>Matwey V. Kornilov</author>
+        <contact>matwey.kornilov@gmail.com</contact>
+        <specification>openSUSE 13.1 ACI container</specification>
+    </description>
+    <preferences>
+        <type image="aci" container="os131">
+        </type>
+        <version>1.0.0</version>
+        <packagemanager>zypper</packagemanager>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <rpm-force>true</rpm-force>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <hwclock>utc</hwclock>
+        <timezone>US/Eastern</timezone>
+    </preferences>
+    <users group="root">
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository type="yast2" imageinclude="true">
+        <source path="opensuse://13.1/repo/oss/"/>
+    </repository>
+    <repository type="rpm-md" imageinclude="true">
+        <source path="http://download.opensuse.org/update/13.1/"/>
+    </repository>
+    <packages type="image">
+        <package name="coreutils"/>
+        <package name="iputils"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="module-init-tools"/>
+    </packages>
+</image>

--- a/tests/unit/lib/Test/kiwiACIConfigWriter.pm
+++ b/tests/unit/lib/Test/kiwiACIConfigWriter.pm
@@ -1,0 +1,229 @@
+#================
+# FILE          : kiwiACIConfigWriter.pm
+#----------------
+# PROJECT       : openSUSE Build-Service
+# COPYRIGHT     : (c) 2013 SUSE LLC
+#               :
+# AUTHOR        : Robert Schweikert <rjschwei@suse.com>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : Unit test implementation for the KIWIACIConfigWriter
+#               : module.
+#               :
+# STATUS        : Development
+#----------------
+package Test::kiwiACIConfigWriter;
+
+use strict;
+use warnings;
+use JSON;
+
+use Common::ktLog;
+use Common::ktTestCase;
+use base qw /Common::ktTestCase/;
+
+use File::Slurp;
+
+use KIWICommandLine;
+use KIWIACIConfigWriter;
+use KIWILog;
+use KIWIXML;
+
+#==========================================
+# Constructor
+#------------------------------------------
+sub new {
+    # ...
+    # Construct new test case
+    # ---
+    my $this = shift -> SUPER::new(@_);
+    $this->{dataDir} = $this -> getDataDir() . '/kiwiACIConfWriter';
+    $this -> removeTestTmpDir();
+    return $this;
+}
+
+#==========================================
+# test_ctor
+#------------------------------------------
+sub test_ctor {
+    # ...
+    # Test the KIWIACIConfigWriter
+    # ---
+    my $this = shift;
+    my $kiwi = $this -> {kiwi};
+    my $confDir = $this -> {dataDir};
+    my $xml = $this -> __getXMLObj($confDir);
+    my $writer = KIWIACIConfigWriter -> new($xml, '/tmp');
+    my $msg = $kiwi -> getMessage();
+    $this -> assert_str_equals('No messages set', $msg);
+    my $msgT = $kiwi -> getMessageType();
+    $this -> assert_str_equals('none', $msgT);
+    my $state = $kiwi -> getState();
+    $this -> assert_str_equals('No state set', $state);
+    # Test this condition last to get potential error messages
+    $this -> assert_not_null($writer);
+    return;
+}
+
+#==========================================
+# test_ctor_dirNoExist
+#------------------------------------------
+sub test_ctor_dirNoExist {
+    # ...
+    # Test the KIWIACIConfigWriter with directory argument of
+    # non existing directory
+    # ---
+    my $this = shift;
+    my $kiwi = $this -> {kiwi};
+    my $confDir = $this -> {dataDir};
+    my $xml = $this -> __getXMLObj($confDir);
+    my $writer = KIWIACIConfigWriter -> new($xml, '/foo');
+    my $msg = $kiwi -> getMessage();
+    my $expected = 'KIWIACIConfigWriter: configuration target directory '
+        . 'does not exist.';
+    $this -> assert_str_equals($expected, $msg);
+    my $msgT = $kiwi -> getMessageType();
+    $this -> assert_str_equals('error', $msgT);
+    my $state = $kiwi -> getState();
+    $this -> assert_str_equals('failed', $state);
+    # Test this condition last to get potential error messages
+    $this -> assert_null($writer);
+    return;
+}
+
+#==========================================
+# test_ctor_invalidArg1
+#------------------------------------------
+sub test_ctor_invalidArg1 {
+    # ...
+    # Test the KIWIACIConfigWriter with invalid first argument
+    # ---
+    my $this = shift;
+    my $kiwi = $this -> {kiwi};
+    my $writer = KIWIACIConfigWriter -> new('foo');
+    my $msg = $kiwi -> getMessage();
+    my $expected = 'KIWIACIConfigWriter: expecting KIWIXML object as '
+        . 'first argument.';
+    $this -> assert_str_equals($expected, $msg);
+    my $msgT = $kiwi -> getMessageType();
+    $this -> assert_str_equals('error', $msgT);
+    my $state = $kiwi -> getState();
+    $this -> assert_str_equals('failed', $state);
+    # Test this condition last to get potential error messages
+    $this -> assert_null($writer);
+    return;
+}
+
+#==========================================
+# test_ctor_noArg1
+#------------------------------------------
+sub test_ctor_noArg1 {
+    # ...
+    # Test the KIWIACIConfigWriter with no argument
+    # ---
+    my $this = shift;
+    my $kiwi = $this -> {kiwi};
+    my $writer = KIWIACIConfigWriter -> new();
+    my $msg = $kiwi -> getMessage();
+    my $expected = 'KIWIACIConfigWriter: expecting KIWIXML object as '
+        . 'first argument.';
+    $this -> assert_str_equals($expected, $msg);
+    my $msgT = $kiwi -> getMessageType();
+    $this -> assert_str_equals('error', $msgT);
+    my $state = $kiwi -> getState();
+    $this -> assert_str_equals('failed', $state);
+    # Test this condition last to get potential error messages
+    $this -> assert_null($writer);
+    return;
+}
+
+#==========================================
+# test_ctor_noArg2
+#------------------------------------------
+sub test_ctor_noArg2 {
+    # ...
+    # Test the KIWIACIConfigWriter with no second argument
+    # ---
+    my $this = shift;
+    my $kiwi = $this -> {kiwi};
+    my $confDir = $this -> {dataDir};
+    my $xml = $this -> __getXMLObj($confDir);
+    my $writer = KIWIACIConfigWriter -> new($xml);
+    my $msg = $kiwi -> getMessage();
+    my $expected = 'KIWIACIConfigWriter: expecting configuration target '
+        . 'directory as second argument.';
+    $this -> assert_str_equals($expected, $msg);
+    my $msgT = $kiwi -> getMessageType();
+    $this -> assert_str_equals('error', $msgT);
+    my $state = $kiwi -> getState();
+    $this -> assert_str_equals('failed', $state);
+    # Test this condition last to get potential error messages
+    $this -> assert_null($writer);
+    return;
+}
+
+#==========================================
+# test_p_writeConfigFile
+#------------------------------------------
+sub test_p_writeConfigFile {
+    # ...
+    # Test the p_writeConfigFile method
+    # ---
+    my $this = shift;
+    my $kiwi = $this -> {kiwi};
+    my $confDir = $this -> {dataDir};
+    my $xml = $this -> __getXMLObj($confDir);
+    my $cDir = $this -> createTestTmpDir();
+    my $writer = KIWIACIConfigWriter -> new($xml, $cDir);
+    my $res = $writer -> p_writeConfigFile();
+    my $msg = $kiwi -> getInfoMessage();
+    my $expected = "Write container manifest file\n"
+        . "--> /tmp/kiwiDevTests/manifest";
+    $this -> assert_str_equals($expected, $msg);
+    my $msgT = $kiwi -> getMessageType();
+    $this -> assert_str_equals('info', $msgT);
+    my $state = $kiwi -> getState();
+    $this -> assert_str_equals('completed', $state);
+    # Test this condition last to get potential error messages
+    $this -> assert_not_null($res);
+    $this -> assert_file_exists($cDir . '/manifest');
+    my $manifest = JSON->new->utf8->decode(read_file($cDir . '/manifest'));
+    $this -> assert_str_equals($manifest->{'acKind'}, 'ImageManifest');
+    $this -> assert_str_equals($manifest->{'acVersion'}, '0.5.1');
+    $this -> assert_str_equals($manifest->{'name'}, $xml -> getImageName());
+    $this -> removeTestTmpDir();
+    return;
+}
+
+#==========================================
+# Private helper methods
+#------------------------------------------
+#==========================================
+# __getXMLObj
+#------------------------------------------
+sub __getXMLObj {
+    # ...
+    # Create an XML object with the given config dir
+    # ---
+    my $this      = shift;
+    my $configDir = shift;
+    my $kiwi = $this->{kiwi};
+    # TODO
+    # Fix the creation of the XML object once the ctor arguments change
+    my $cmdL = KIWICommandLine -> new();
+    my $xml = KIWIXML -> new(
+        $configDir, undef, undef, $cmdL
+    );
+    if (! $xml) {
+        my $errMsg = $kiwi -> getMessage();
+        print "XML create msg: $errMsg\n";
+        my $msg = 'Failed to create XML obj, most likely improper config '
+        . 'path: '
+        . $configDir;
+        $this -> assert_equals(1, $msg);
+    }
+    return $xml;
+}
+
+1;


### PR DESCRIPTION
Here is initial implementation of App Container Image (aci) format.
This commit is able to build .aci images conforming to SPEC.

[1] https://github.com/appc/spec/blob/master/SPEC.md#app-container-image

This commit writes all required fields to manifest, but not support (yet) optional fields, like app. So, there is not way (yet) to specify which application to start. However, further requests should follow.