### PR TITLE
Activate new swap after repartitioning

### DIFF
--- a/system/boot/armv7l/oemboot/suse-repart
+++ b/system/boot/armv7l/oemboot/suse-repart
@@ -650,6 +650,10 @@ function OEMRepart {
             if ! mkswap $imageSwapDevice 1>&2;then
                 systemException "Failed to create swap signature" "reboot"
             fi
+            Echo "Activating swap space on $imageSwapDevice"
+            if ! swapon $imageSwapDevice 1>&2;then
+                Echo "Warning: Could not activate swap on $imageSwapDevice" 
+            fi
         fi
     fi
     #======================================


### PR DESCRIPTION
Activate newly created swap partition for low-memory devices. For my phytech pcm051 board this avoids OMM killer appearance on first boot.

```
[1416700816.865796] Creating swap space on /dev/mmcblk0p3
[1416700817.053569] Activating swap space on /dev/mmcblk0p3
[   35.432725] Adding 505856k swap on /dev/mmcblk0p3.  Priority:-1 extents:1 across:505856k SSFS
```

AFAIU original commit has accidentally been dropped by 
88664701c5814c603109feea7656887147069137