### PR TITLE
Fix kernel name in extractLinux on s390x arch

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -4129,6 +4129,12 @@ sub extractLinux {
     if (-f "$imageTree/boot/vmlinux") {
         $kernname = "vmlinux";
     }
+    #
+    # on s390x arch, kernel has /boot/image name
+    # 
+    if (-f "$imageTree/boot/image") {
+        $kernname = "image";
+    }
     if ($vconf) {
         $xendomain = $vconf -> getDomain();
     }


### PR DESCRIPTION
I have problem with extracting kernel on s390x architecture. As I have found problem is that on s390x link to kernel file is called `/boot/image`. 

This patch fix this issue