### PR TITLE
Remove genisoimage and cdrkit-cdrtools-compat dependency (second try)

### DIFF
--- a/doc/devdoc/devDocs/KIWIIsoLinux.html
+++ b/doc/devdoc/devDocs/KIWIIsoLinux.html
@@ -193,7 +193,7 @@ Called in
 <a name="new"><h2>new</h2></a>
 <p>
      Create a new KIWIIsoLinux object which is used to wrap
-     around the major genisoimage/mkisofs call. This code requires a
+     around the major mkisofs call. This code requires a
      specific source directory structure which is:
 <p>
 Defined on line: 46
@@ -215,7 +215,7 @@ Called in
 <li><a href="KIWIIsoLinux.html">KIWIIsoLinux</a> : 1174</li><li><a href="KIWIIsoLinux.html">KIWIIsoLinux</a> : 1357</li></ul>
 <a name="relocateCatalog"><h2>relocateCatalog</h2></a>
 <p>
-     mkisofs/genisoimage leave one sector empty (or fill it with
+     mkisofs leave one sector empty (or fill it with
      version info if the ISODEBUG environment variable is set) before
      starting the path table. We use this space to move the boot
      catalog there. It's important that the boot catalog is at the

--- a/doc/examples/extras/suse-13.1/suse-vagrant-box/config.xml
+++ b/doc/examples/extras/suse-13.1/suse-vagrant-box/config.xml
@@ -66,7 +66,7 @@
         <package name="kiwi-desc-vmxboot"/>
         <package name="kiwi-templates"/>
         <package name="btrfsprogs"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="squashfs"/>
     </packages>
     <packages type="bootstrap">

--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -9,7 +9,7 @@
 # BELONGS TO    : Operating System images
 #               :
 # DESCRIPTION   : This module is used to create an ISO
-#               : filesystem based on genisoimage/mkisofs
+#               : filesystem based on mkisofs
 #               :
 #               :
 # STATUS        : Development
@@ -46,7 +46,7 @@ my @EXPORT_OK = qw ();
 sub new {
     # ...
     # Create a new KIWIIsoLinux object which is used to wrap
-    # around the major genisoimage/mkisofs call. This code requires a
+    # around the major mkisofs call. This code requires a
     # specific source directory structure which is:
     # ---
     # $source/boot/<arch>/loader
@@ -67,7 +67,7 @@ sub new {
     #------------------------------------------
     my $source       = shift;  # location of source tree
     my $dest         = shift;  # destination for the iso file
-    my $params       = shift;  # global genisoimage/mkisofs parameters
+    my $params       = shift;  # global mkisofs parameters
     my $mediacheck   = shift;  # run tagmedia with --check y/n
     my $cmdL         = shift;  # commandline params: optional
     my $xml          = shift;  # system image XML: optional
@@ -99,7 +99,7 @@ sub new {
     # Find iso tool to use on this system
     #------------------------------------------
     my $locator = KIWILocator -> instance();
-    my $genTool = $locator -> getExecPath('genisoimage');
+    my $genTool = $locator -> getExecPath('mkisofs');
     my $mkTool = $locator -> getExecPath('mkisofs');
     if ($genTool && -x $genTool) {
         $tool = $genTool;
@@ -1162,7 +1162,7 @@ sub createHybrid {
 #------------------------------------------
 sub relocateCatalog {
     # ...
-    # mkisofs/genisoimage leave one sector empty (or fill it with
+    # mkisofs leave one sector empty (or fill it with
     # version info if the ISODEBUG environment variable is set) before
     # starting the path table. We use this space to move the boot
     # catalog there. It's important that the boot catalog is at the

--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -994,10 +994,13 @@ sub isols {
     my $iso  = $this -> {dest};
     my $fd   = FileHandle -> new();
     my $dir  = "/";
+    my $isoinfo_opts = " -R -l -i $iso 2>/dev/null |";
     my $files;
     local $_;
-    if (! $fd -> open ("isoinfo -R -l -i $iso 2>/dev/null |")) {
-        return;
+    if (! $fd -> open ("/usr/bin/isoinfo" . $isoinfo_opts)) {
+        if (! $fd -> open ("/usr/lib/genisoimage/isoinfo" . $isoinfo_opts)) {
+            return;
+        }
     }
     while(<$fd>) {
         if(/^Directory listing of\s*(\/.*\/)/) {

--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -1406,6 +1406,11 @@ sub fixCatalog {
     substr($entry1, 12, 20) = pack "Ca19", 1, "Legacy (isolinux)";
     substr($boot_catalog, 32 * 1, 32) = $entry1;
     my $entry2 = substr $boot_catalog, 32 * 2, 32;
+    my $t = (unpack "C", $entry2)[0];
+    if ($t == 0x90 || $t == 0x91) {
+        close $ISO;
+        return;
+    }
     substr($entry2, 12, 20) = pack "Ca19", 1, "UEFI (elilo)";
     if((unpack "C", $entry2)[0] == 0x88) {
         substr($boot_catalog, 32 * 3, 32) = $entry2;

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -4054,7 +4054,7 @@ function searchImageISODevice {
     if [ ! -x $isoinfo ]; then
        isoinfo=/usr/lib/genisoimage/isoinfo
     fi
-    if [ ! -e $isoinfo ];then
+    if [ ! -x $isoinfo ];then
         systemException \
             "Can't find isoinfo tool in initrd" \
         "reboot"

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -4052,9 +4052,6 @@ function searchImageISODevice {
     local isoinfo=/usr/bin/isoinfo
     mkdir -p /cdrom
     if [ ! -e $isoinfo ];then
-        isoinfo=/usr/lib/genisoimage/isoinfo
-    fi
-    if [ ! -e $isoinfo ];then
         systemException \
             "Can't find isoinfo tool in initrd" \
         "reboot"

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -4051,6 +4051,9 @@ function searchImageISODevice {
     local count=0
     local isoinfo=/usr/bin/isoinfo
     mkdir -p /cdrom
+    if [ ! -x $isoinfo ]; then
+       isoinfo=/usr/lib/genisoimage/isoinfo
+    fi
     if [ ! -e $isoinfo ];then
         systemException \
             "Can't find isoinfo tool in initrd" \

--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -620,7 +620,7 @@ sub __checkFilesystemTool {
             $toolError = 1;
         }
     } elsif ($typeName eq 'iso') {
-        my $genTool = $this -> {locator} -> getExecPath('genisoimage');
+        my $genTool = $this -> {locator} -> getExecPath('mkisofs');
         my $mkTool = $this -> {locator} -> getExecPath('mkisofs');
         if ((! $genTool) && (! $mkTool)) {
             $checkedFS = 'iso';
@@ -1801,7 +1801,7 @@ sub __hasBootLoaderTools {
     my $bootloader = $bldType -> getBootLoader();
     my $loader_check;
     if ($imgType eq 'iso') {
-        $loader_check = 'genisoimage';
+        $loader_check = 'mkisofs';
     } elsif ((! $bootloader) || ($bootloader eq 'grub')) {
         $loader_check = 'grub-install';
     } elsif (($bootloader eq 'grub2') && ($firmware eq 'bios')) {

--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -67,8 +67,7 @@ BuildRequires:  syslinux
 %endif
 %if 0%{?suse_version} > 1140
 BuildRequires:  btrfsprogs
-BuildRequires:  cdrkit-cdrtools-compat
-BuildRequires:  genisoimage
+BuildRequires:  mkisofs
 BuildRequires:  squashfs
 BuildRequires:  zypper
 %endif
@@ -233,8 +232,7 @@ Requires:       createrepo
 Requires:       inst-source-utils
 Requires:       kiwi-instsource-plugin
 Requires:       kiwi = %{version}
-Requires:       cdrkit-cdrtools-compat
-Requires:       genisoimage
+Requires:       mkisofs
 %ifarch %ix86 x86_64
 Requires:       syslinux
 %endif
@@ -328,8 +326,7 @@ Requires:       syslinux
 %endif
 Requires:       dosfstools
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 License:        GPL-2.0+
 Group:          System/Management
@@ -346,8 +343,7 @@ Authors:
 Provides:       kiwi-image:iso
 Provides:       kiwi-boot:isoboot
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 Requires:       kiwi-desc-isoboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} isoboot %{myarch} %{mysystems}`)
@@ -418,8 +414,7 @@ Summary:        KIWI - buildservice package requirements for vmxboot
 Provides:       kiwi-image:vmx
 Provides:       kiwi-boot:vmxboot
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 Requires:       kiwi-desc-vmxboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} vmxboot %{myarch} %{mysystems}`)
@@ -498,8 +493,7 @@ Requires:       e2fsprogs
 Requires:       kiwi = %{version}
 Requires:       parted
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 Requires:       multipath-tools
 Requires:       squashfs
 %endif
@@ -534,8 +528,7 @@ Provides:       kiwi-image:oem
 Provides:       kiwi-boot:oemboot
 Provides:       kiwi-boot:tbz
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 Requires:       kiwi-desc-oemboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} oemboot %{myarch} %{mysystems}`)

--- a/system/boot/armv7l/oemboot/suse-12.3/config.xml
+++ b/system/boot/armv7l/oemboot/suse-12.3/config.xml
@@ -100,7 +100,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/armv7l/oemboot/suse-13.1/config.xml
+++ b/system/boot/armv7l/oemboot/suse-13.1/config.xml
@@ -99,7 +99,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/armv7l/oemboot/suse-13.2/config.xml
+++ b/system/boot/armv7l/oemboot/suse-13.2/config.xml
@@ -98,7 +98,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/ix86/isoboot/rhel-06.0/config.xml
+++ b/system/boot/ix86/isoboot/rhel-06.0/config.xml
@@ -83,7 +83,7 @@
         <package name="e2fsprogs"/>
         <package name="file"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="hdparm"/>
         <package name="hwinfo"/>
         <package name="initscripts"/>

--- a/system/boot/ix86/isoboot/rhel-07.0/config.xml
+++ b/system/boot/ix86/isoboot/rhel-07.0/config.xml
@@ -90,7 +90,7 @@
         <package name="e2fsprogs"/>
         <package name="file"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="hdparm"/>
         <package name="hwinfo"/>
         <package name="initscripts"/>

--- a/system/boot/ix86/isoboot/suse-12.3/config.xml
+++ b/system/boot/ix86/isoboot/suse-12.3/config.xml
@@ -114,7 +114,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-13.1/config.xml
+++ b/system/boot/ix86/isoboot/suse-13.1/config.xml
@@ -107,7 +107,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="clicfs"/>
         <package name="cryptsetup"/>
         <package name="dhcpcd"/>
@@ -117,7 +116,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-13.2/config.xml
+++ b/system/boot/ix86/isoboot/suse-13.2/config.xml
@@ -106,7 +106,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="cryptsetup"/>
         <package name="nfs-client"/>
         <package name="dialog"/>
@@ -114,7 +113,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-SLED11/config.xml
+++ b/system/boot/ix86/isoboot/suse-SLED11/config.xml
@@ -96,7 +96,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-SLED12/config.xml
+++ b/system/boot/ix86/isoboot/suse-SLED12/config.xml
@@ -100,7 +100,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="cryptsetup"/>
         <package name="nfs-client"/>
         <package name="dialog"/>
@@ -108,7 +107,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/isoboot/suse-SLES11/config.xml
@@ -97,7 +97,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/isoboot/suse-SLES12/config.xml
@@ -100,7 +100,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="cryptsetup"/>
         <package name="nfs-client"/>
         <package name="dialog"/>
@@ -108,7 +107,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/oemboot/rhel-06.0/config.xml
+++ b/system/boot/ix86/oemboot/rhel-06.0/config.xml
@@ -102,7 +102,7 @@
         <package name="bc"/>
         <package name="e2fsprogs"/>
         <package name="gettext"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="syslinux"/>
         <package name="sysvinit-tools"/>
     </packages>

--- a/system/boot/ix86/oemboot/rhel-07.0/config.xml
+++ b/system/boot/ix86/oemboot/rhel-07.0/config.xml
@@ -114,7 +114,7 @@
         <package name="bc"/>
         <package name="e2fsprogs"/>
         <package name="gettext"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="syslinux"/>
         <package name="sysvinit-tools"/>
     </packages>

--- a/system/boot/ix86/oemboot/suse-12.3/config.xml
+++ b/system/boot/ix86/oemboot/suse-12.3/config.xml
@@ -132,7 +132,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub"/>
         <package name="grub2"/>

--- a/system/boot/ix86/oemboot/suse-13.1/config.xml
+++ b/system/boot/ix86/oemboot/suse-13.1/config.xml
@@ -132,7 +132,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ix86/oemboot/suse-13.2/config.xml
+++ b/system/boot/ix86/oemboot/suse-13.2/config.xml
@@ -133,7 +133,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ix86/oemboot/suse-SLED11/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLED11/config.xml
@@ -115,7 +115,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub"/>
         <package name="hwinfo"/>

--- a/system/boot/ix86/oemboot/suse-SLED12/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLED12/config.xml
@@ -124,7 +124,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ix86/oemboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLES11/config.xml
@@ -121,7 +121,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub"/>
         <package name="hwinfo"/>

--- a/system/boot/ix86/oemboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLES12/config.xml
@@ -127,7 +127,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ppc/oemboot/suse-SLES11/config.xml
+++ b/system/boot/ppc/oemboot/suse-SLES11/config.xml
@@ -86,7 +86,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/ppc/oemboot/suse-SLES12/config.xml
+++ b/system/boot/ppc/oemboot/suse-SLES12/config.xml
@@ -102,7 +102,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/ppc/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/ppc/vmxboot/suse-SLES12/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/s390/oemboot/suse-SLES11/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES11/config.xml
@@ -75,7 +75,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/s390/oemboot/suse-SLES12/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES12/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/s390/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/s390/vmxboot/suse-SLES12/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/tests/jenkins/prepare.sh
+++ b/tests/jenkins/prepare.sh
@@ -34,7 +34,7 @@ fi
 
 # install required packages
 spec=/home/jenkins/kiwi/kiwi/rpm/kiwi.spec
-packages="grub grub2 genisoimage cdrkit-cdrtools-compat squashfs osc yum trang dosfstools"
+packages="grub grub2 mkisofs squashfs osc yum trang dosfstools"
 if ! zypper -n install --no-recommends $packages;then
     exit 1
 fi

--- a/tools/livestick/livestick
+++ b/tools/livestick/livestick
@@ -22,6 +22,15 @@ if [ -z "$1" ] || [ -z "$2" ];then
     exit 1
 fi
 
+isoinfo=/usr/bin/isoinfo
+if [ ! -x $isoinfo ]; then
+   isoinfo=/usr/lib/genisoimage/isoinfo
+fi
+if [ ! -x $isoinfo ];then
+    echo "Can't find isoinfo in /usr/bin or /usr/lib/genisoimage"
+    exit 1
+fi
+
 #==========================================
 # Functions
 #------------------------------------------
@@ -82,7 +91,7 @@ fi
 #==========================================
 # check if file is a kiwi live iso
 #------------------------------------------
-if ! isoinfo -l -i $image 2>/dev/null | grep -q LIVEBOOT;then
+if ! $isoinfo -l -i $image 2>/dev/null | grep -q LIVEBOOT;then
     echo "Can't find live iso signature"
     echo "Make sure the given kiwi image file is of type: image=iso"
     clean
@@ -144,7 +153,7 @@ echo 'set prefix=($root)/boot/grub2'   >> $conf
 #------------------------------------------
 conf=$tmpdir/boot/grub2/grub.cfg
 arch=x86_64
-if ! isoinfo -p -i $image | grep -q X86_64;then
+if ! $isoinfo -p -i $image | grep -q X86_64;then
     arch=i386
     title=$(echo $image_base | sed -e s@\.i.86.*@@)
 else


### PR DESCRIPTION
Based on @schaefi's  last [comment](https://github.com/openSUSE/kiwi/pull/481#issuecomment-134590929) I've updated the pull request with checks to ensure whether `/usr/bin/isoinfo` or `/usr/lib/genisoimage/isoinfo` should be used.