### PR TITLE
s390 grub2 support

### DIFF
--- a/modules/KIWIImageCreator.pm
+++ b/modules/KIWIImageCreator.pm
@@ -125,7 +125,9 @@ sub initialize {
     #==========================================
     # Cleanup buildtype from cmdL if boot image
     #------------------------------------------
-    if ($this->{configDir} =~ /(iso|oem|net|vmx)boot/) {
+    if (($this->{configDir}) &&
+        ($this->{configDir} =~ /(iso|oem|net|vmx)boot/)
+    ) {
         undef $this->{buildType};
     }
     #==========================================

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -1634,7 +1634,7 @@ div {
         ## At the moment grub, zipl and sys|extlinux are supported
         attribute bootloader {
             "extlinux" | "grub" | "grub2" | "syslinux" |
-            "zipl" | "yaboot" | "uboot" | "berryboot"
+            "zipl" | "yaboot" | "uboot" | "berryboot" | "ziplgrub"
         }
     k.type.target_blocksize =
         ## Specifies the image blocksize in bytes which has to match

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -2141,6 +2141,7 @@ At the moment grub, zipl and sys|extlinux are supported</a:documentation>
           <value>yaboot</value>
           <value>uboot</value>
           <value>berryboot</value>
+          <value>ziplgrub</value>
         </choice>
       </attribute>
     </define>

--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -5371,9 +5371,11 @@ sub __setDefaultBuildType {
         $defType = $this->{imageConfig}
             ->{kiwi_default}->{preferences}->{types}->{$defTypeName};
         my $type = $defType->{type};
-        my $prim = $type -> getPrimary();
-        if ($prim && $prim eq 'true') {
-            $primaryCount++;
+        if ($type) {
+            my $prim = $type -> getPrimary();
+            if ($prim && $prim eq 'true') {
+                $primaryCount++;
+            }
         }
     }
     # /.../

--- a/modules/KIWIXMLTypeData.pm
+++ b/modules/KIWIXMLTypeData.pm
@@ -2251,6 +2251,7 @@ sub __isValidBootloader {
         berryboot
         yaboot
         zipl
+        ziplgrub
     );
     if (! $supported{$bootL} ) {
         my $msg = "$caller: specified bootloader '$bootL' is not supported.";

--- a/system/boot/s390/oemboot/suse-SLES12/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES12/config.xml
@@ -140,6 +140,8 @@
         <package name="sysvinit-tools"/>
         <package name="multipath-tools"/>
         <package name="xz"/>
+        <package name="grub2-s390x-emu"/>
+        <package name="grub2"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/system/boot/s390/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/s390/vmxboot/suse-SLES12/config.xml
@@ -136,6 +136,8 @@
         <package name="s390-tools"/>
         <package name="psmisc"/>
         <package name="sysvinit-tools"/>
+        <package name="grub2-s390x-emu"/>
+        <package name="grub2"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/template/s390/suse-SLE12-JeOS/config.xml
+++ b/template/s390/suse-SLE12-JeOS/config.xml
@@ -17,9 +17,14 @@
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
         <hwclock>utc</hwclock>
-        <type image="vmx" filesystem="ext3" boot="vmxboot/suse-SLES12" bootloader="zipl" primary="true" target_blocksize="4096" zipl_targettype="CDL"/>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-SLES12" bootloader="zipl" target_blocksize="4096" zipl_targettype="CDL">
-            <systemdisk/>
+        <type image="vmx" filesystem="btrfs" boot="vmxboot/suse-SLES12" bootloader="ziplgrub" primary="true" target_blocksize="4096" zipl_targettype="CDL" kernelcmdline="cio_ignore=all,!ipldev,!condev">
+            <size unit="G">2</size>
+        </type>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-SLES12" bootloader="ziplgrub" target_blocksize="4096" zipl_targettype="CDL" kernelcmdline="cio_ignore=all,!ipldev,!condev">
+            <size unit="G">2</size>
+            <systemdisk>
+                <volume name="home"/>
+            </systemdisk>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
@@ -39,8 +44,26 @@
         <package name="cmsfs"/>
         <package name="kernel-default"/>
         <package name="iputils"/>
+        <package name="iproute2"/>
         <package name="vim"/>
         <package name="s390-tools"/>
+        <package name="grub2-s390x-emu"/>
+        <package name="grub2"/>
+        <package name="lvm2"/>
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="systemd"/>
+        <package name="dracut"/>
+        <package name="wicked"/>
+        <package name="openssh"/>
+        <package name="rsync"/>
+        <package name="psmisc"/>
+        <package name="sudo"/>
+        <package name="dhcp-client"/>
+        <package name="which"/>
+        <package name="btrfsprogs"/>
+        <package name="kexec-tools"/>
+        <package name="less"/>
     </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>


### PR DESCRIPTION
On SLES12 an s390 system boots in a two stage system

* first zipl loads from an ext2 partition the kernel and a grub2-install created initrd
* second the initrd from the first stage emulates a user space grub and kexec's the kernel and system initrd from the root partition

This patch implements this behaviour into the appliance building stack. In order to activate the feature one needs to configure the bootloader in the kiwi XML as follows

```
bootloader="ziplgrub"
```