### PR TITLE
Set PReP device if not defined

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -1324,8 +1324,9 @@ EOF
     # install grub2 in BIOS mode
     #--------------------------------------
     if [ ! -z "$kiwi_OfwGrub" ];then
+        local prepdev=$(ddn $imageDiskDevice $kiwi_OfwGrub)
         # install powerpc grub2
-        $instTool $imagePrepDevice 1>&2
+        $instTool $prepdev 1>&2
         if [ ! $? = 0 ];then
             Echo "Failed to install boot loader"
             return 1

--- a/system/boot/ppc/oemboot/suse-repart
+++ b/system/boot/ppc/oemboot/suse-repart
@@ -766,7 +766,6 @@ function setupDeviceNames {
     local bootID=$4
     local iorwID=$5
     local vgroup=$6
-    local prepID=$7
     if [ -z "$vgroup" ];then
         #======================================
         # set root device name
@@ -801,10 +800,6 @@ function setupDeviceNames {
         # set boot device name
         #--------------------------------------
         export imageBootDevice=$(ddn $imageDiskDevice $bootID)
-        #======================================
-        # set PReP device name
-        #--------------------------------------
-        export imagePrepDevice=$(ddn $imageDiskDevice $prepID)
         #======================================
         # set boot partition id
         #--------------------------------------
@@ -842,10 +837,6 @@ function setupDeviceNames {
         # set LVM boot device name
         #--------------------------------------
         export imageBootDevice=$(ddn $imageDiskDevice $bootID)
-        #======================================
-        # set PReP boot device name
-        #--------------------------------------
-        export imagePrepDevice=$(ddn $imageDiskDevice $prepID)
         #======================================
         # set LVM boot partition id
         #--------------------------------------


### PR DESCRIPTION
This fixes vmxboot, where ImagePrepDevice is not defined

Signed-off-by: Dinar Valeev <dvaleev@suse.com>