### PR TITLE
/run should not be mounted in firstboot initrd for distros not using systemd

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -453,7 +453,7 @@ function createInitialDevices {
     #--------------------------------------
     mkdir -p -m 0755 /run
     mkdir -p -m 0755 /var/run
-    if [[ ! $kiwi_iname =~ SLE.11 ]];then
+    if [[ ! $kiwi_iname =~ SLE.11 ]] && [[ ! $kiwi_iname =~ "rhel-06" ]] ; then
         mount -t tmpfs -o mode=0755,nodev,nosuid tmpfs /run
         mount --bind /run /var/run
     fi


### PR DESCRIPTION
CentOS, RHEL 6.0' or similiar should be handled like SLE 11 not using a tmpfs on /run in the initial initrd created by KIWI.