### PR TITLE
Remove genisoimage and cdrkit-cdrtools-compat dependency (third try)

### DIFF
--- a/doc/devdoc/devDocs/KIWIIsoLinux.html
+++ b/doc/devdoc/devDocs/KIWIIsoLinux.html
@@ -193,7 +193,7 @@ Called in
 <a name="new"><h2>new</h2></a>
 <p>
      Create a new KIWIIsoLinux object which is used to wrap
-     around the major genisoimage/mkisofs call. This code requires a
+     around the major mkisofs call. This code requires a
      specific source directory structure which is:
 <p>
 Defined on line: 46
@@ -215,7 +215,7 @@ Called in
 <li><a href="KIWIIsoLinux.html">KIWIIsoLinux</a> : 1174</li><li><a href="KIWIIsoLinux.html">KIWIIsoLinux</a> : 1357</li></ul>
 <a name="relocateCatalog"><h2>relocateCatalog</h2></a>
 <p>
-     mkisofs/genisoimage leave one sector empty (or fill it with
+     mkisofs leave one sector empty (or fill it with
      version info if the ISODEBUG environment variable is set) before
      starting the path table. We use this space to move the boot
      catalog there. It's important that the boot catalog is at the

--- a/doc/examples/extras/suse-13.1/suse-vagrant-box/config.xml
+++ b/doc/examples/extras/suse-13.1/suse-vagrant-box/config.xml
@@ -66,7 +66,7 @@
         <package name="kiwi-desc-vmxboot"/>
         <package name="kiwi-templates"/>
         <package name="btrfsprogs"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="squashfs"/>
     </packages>
     <packages type="bootstrap">

--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -9,7 +9,7 @@
 # BELONGS TO    : Operating System images
 #               :
 # DESCRIPTION   : This module is used to create an ISO
-#               : filesystem based on genisoimage/mkisofs
+#               : filesystem based on mkisofs
 #               :
 #               :
 # STATUS        : Development
@@ -46,7 +46,7 @@ my @EXPORT_OK = qw ();
 sub new {
     # ...
     # Create a new KIWIIsoLinux object which is used to wrap
-    # around the major genisoimage/mkisofs call. This code requires a
+    # around the major mkisofs call. This code requires a
     # specific source directory structure which is:
     # ---
     # $source/boot/<arch>/loader
@@ -67,7 +67,7 @@ sub new {
     #------------------------------------------
     my $source       = shift;  # location of source tree
     my $dest         = shift;  # destination for the iso file
-    my $params       = shift;  # global genisoimage/mkisofs parameters
+    my $params       = shift;  # global mkisofs parameters
     my $mediacheck   = shift;  # run tagmedia with --check y/n
     my $cmdL         = shift;  # commandline params: optional
     my $xml          = shift;  # system image XML: optional
@@ -99,7 +99,7 @@ sub new {
     # Find iso tool to use on this system
     #------------------------------------------
     my $locator = KIWILocator -> instance();
-    my $genTool = $locator -> getExecPath('genisoimage');
+    my $genTool = $locator -> getExecPath('mkisofs');
     my $mkTool = $locator -> getExecPath('mkisofs');
     if ($genTool && -x $genTool) {
         $tool = $genTool;
@@ -1165,7 +1165,7 @@ sub createHybrid {
 #------------------------------------------
 sub relocateCatalog {
     # ...
-    # mkisofs/genisoimage leave one sector empty (or fill it with
+    # mkisofs leave one sector empty (or fill it with
     # version info if the ISODEBUG environment variable is set) before
     # starting the path table. We use this space to move the boot
     # catalog there. It's important that the boot catalog is at the

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -4267,7 +4267,7 @@ function searchImageISODevice {
     if [ ! -x $isoinfo ]; then
        isoinfo=/usr/lib/genisoimage/isoinfo
     fi
-    if [ ! -e $isoinfo ];then
+    if [ ! -x $isoinfo ];then
         systemException \
             "Can't find isoinfo tool in initrd" \
         "reboot"

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -4267,7 +4267,7 @@ function searchImageISODevice {
     if [ ! -x $isoinfo ]; then
        isoinfo=/usr/lib/genisoimage/isoinfo
     fi
-    if [ ! -x $isoinfo ];then
+    if [ ! -e $isoinfo ];then
         systemException \
             "Can't find isoinfo tool in initrd" \
         "reboot"

--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -624,7 +624,7 @@ sub __checkFilesystemTool {
             $toolError = 1;
         }
     } elsif ($typeName eq 'iso') {
-        my $genTool = $this -> {locator} -> getExecPath('genisoimage');
+        my $genTool = $this -> {locator} -> getExecPath('mkisofs');
         my $mkTool = $this -> {locator} -> getExecPath('mkisofs');
         if ((! $genTool) && (! $mkTool)) {
             $checkedFS = 'iso';
@@ -1846,7 +1846,7 @@ sub __hasBootLoaderTools {
     my $bootloader = $bldType -> getBootLoader();
     my $loader_check;
     if ($imgType eq 'iso') {
-        $loader_check = 'genisoimage';
+        $loader_check = 'mkisofs';
     } elsif ((! $bootloader) || ($bootloader eq 'grub')) {
         $loader_check = 'grub-install';
     } elsif (($bootloader eq 'grub2') && ($firmware eq 'bios')) {

--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -67,7 +67,14 @@ BuildRequires:  syslinux
 %endif
 %if 0%{?suse_version} > 1140
 BuildRequires:  btrfsprogs
+
+%if 0%{?suse_version} <= 1315
+BuildRequires:  cdrkit-cdrtools-compat
+BuildRequires:  genisoimage
+%else
 BuildRequires:  mkisofs
+%endif
+
 BuildRequires:  squashfs
 BuildRequires:  zypper
 %endif
@@ -241,7 +248,14 @@ Requires:       createrepo
 Requires:       inst-source-utils
 Requires:       kiwi-instsource-plugin
 Requires:       kiwi = %{version}
-Requires:       mkisofs
+
+%if 0%{?suse_version} <= 1315
+BuildRequires:  cdrkit-cdrtools-compat
+BuildRequires:  genisoimage
+%else
+BuildRequires:  mkisofs
+%endif
+
 %ifarch %ix86 x86_64
 Requires:       syslinux
 %endif
@@ -334,9 +348,16 @@ Requires:       kiwi = %{version}
 Requires:       syslinux
 %endif
 Requires:       dosfstools
+
 %if 0%{?suse_version}
-Requires:       mkisofs
+%if 0%{?suse_version} <= 1315
+BuildRequires:  cdrkit-cdrtools-compat
+BuildRequires:  genisoimage
+%else
+BuildRequires:  mkisofs
 %endif
+%endif
+
 License:        GPL-2.0+
 Group:          System/Management
 
@@ -351,9 +372,16 @@ Authors:
 %package -n kiwi-desc-isoboot-requires
 Provides:       kiwi-image:iso
 Provides:       kiwi-boot:isoboot
+
 %if 0%{?suse_version}
-Requires:       mkisofs
+%if 0%{?suse_version} <= 1315
+BuildRequires:  cdrkit-cdrtools-compat
+BuildRequires:  genisoimage
+%else
+BuildRequires:  mkisofs
 %endif
+%endif
+
 Requires:       kiwi-desc-isoboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} isoboot %{myarch} %{mysystems}`)
 %ifarch ppc ppc64 ppc64le
@@ -422,9 +450,16 @@ Authors:
 Summary:        KIWI - buildservice package requirements for vmxboot
 Provides:       kiwi-image:vmx
 Provides:       kiwi-boot:vmxboot
+
 %if 0%{?suse_version}
-Requires:       mkisofs
+%if 0%{?suse_version} <= 1315
+BuildRequires:  cdrkit-cdrtools-compat
+BuildRequires:  genisoimage
+%else
+BuildRequires:  mkisofs
 %endif
+%endif
+
 Requires:       kiwi-desc-vmxboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} vmxboot %{myarch} %{mysystems}`)
 %ifarch ppc ppc64 ppc64le
@@ -502,7 +537,14 @@ Requires:       e2fsprogs
 Requires:       kiwi = %{version}
 Requires:       parted
 %if 0%{?suse_version}
-Requires:       mkisofs
+
+%if 0%{?suse_version} <= 1315
+BuildRequires:  cdrkit-cdrtools-compat
+BuildRequires:  genisoimage
+%else
+BuildRequires:  mkisofs
+%endif
+
 Requires:       multipath-tools
 Requires:       mtools
 Requires:       squashfs
@@ -537,9 +579,16 @@ Authors:
 Provides:       kiwi-image:oem
 Provides:       kiwi-boot:oemboot
 Provides:       kiwi-boot:tbz
+
 %if 0%{?suse_version}
-Requires:       mkisofs
+%if 0%{?suse_version} <= 1315
+BuildRequires:  cdrkit-cdrtools-compat
+BuildRequires:  genisoimage
+%else
+BuildRequires:  mkisofs
 %endif
+%endif
+
 Requires:       kiwi-desc-oemboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} oemboot %{myarch} %{mysystems}`)
 %ifarch ppc ppc64 ppc64le

--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -67,8 +67,7 @@ BuildRequires:  syslinux
 %endif
 %if 0%{?suse_version} > 1140
 BuildRequires:  btrfsprogs
-BuildRequires:  cdrkit-cdrtools-compat
-BuildRequires:  genisoimage
+BuildRequires:  mkisofs
 BuildRequires:  squashfs
 BuildRequires:  zypper
 %endif
@@ -242,8 +241,7 @@ Requires:       createrepo
 Requires:       inst-source-utils
 Requires:       kiwi-instsource-plugin
 Requires:       kiwi = %{version}
-Requires:       cdrkit-cdrtools-compat
-Requires:       genisoimage
+Requires:       mkisofs
 %ifarch %ix86 x86_64
 Requires:       syslinux
 %endif
@@ -337,8 +335,7 @@ Requires:       syslinux
 %endif
 Requires:       dosfstools
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 License:        GPL-2.0+
 Group:          System/Management
@@ -355,8 +352,7 @@ Authors:
 Provides:       kiwi-image:iso
 Provides:       kiwi-boot:isoboot
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 Requires:       kiwi-desc-isoboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} isoboot %{myarch} %{mysystems}`)
@@ -427,8 +423,7 @@ Summary:        KIWI - buildservice package requirements for vmxboot
 Provides:       kiwi-image:vmx
 Provides:       kiwi-boot:vmxboot
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 Requires:       kiwi-desc-vmxboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} vmxboot %{myarch} %{mysystems}`)
@@ -507,8 +502,7 @@ Requires:       e2fsprogs
 Requires:       kiwi = %{version}
 Requires:       parted
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 Requires:       multipath-tools
 Requires:       mtools
 Requires:       squashfs
@@ -544,8 +538,7 @@ Provides:       kiwi-image:oem
 Provides:       kiwi-boot:oemboot
 Provides:       kiwi-boot:tbz
 %if 0%{?suse_version}
-Requires:       genisoimage
-Requires:       cdrkit-cdrtools-compat
+Requires:       mkisofs
 %endif
 Requires:       kiwi-desc-oemboot = %{version}
 Requires:       %(echo `bash %{S:4} %{S:0} oemboot %{myarch} %{mysystems}`)

--- a/system/boot/armv7l/oemboot/suse-SLES12/config.xml
+++ b/system/boot/armv7l/oemboot/suse-SLES12/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>

--- a/system/boot/armv7l/oemboot/suse-leap42.1/config.xml
+++ b/system/boot/armv7l/oemboot/suse-leap42.1/config.xml
@@ -102,7 +102,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>

--- a/system/boot/armv7l/oemboot/suse-tumbleweed/config.xml
+++ b/system/boot/armv7l/oemboot/suse-tumbleweed/config.xml
@@ -102,7 +102,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>

--- a/system/boot/ix86/isoboot/rhel-06.0/config.xml
+++ b/system/boot/ix86/isoboot/rhel-06.0/config.xml
@@ -83,7 +83,7 @@
         <package name="e2fsprogs"/>
         <package name="file"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="hdparm"/>
         <package name="hwinfo"/>
         <package name="initscripts"/>

--- a/system/boot/ix86/isoboot/rhel-07.0/config.xml
+++ b/system/boot/ix86/isoboot/rhel-07.0/config.xml
@@ -90,7 +90,7 @@
         <package name="e2fsprogs"/>
         <package name="file"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="hdparm"/>
         <package name="hwinfo"/>
         <package name="initscripts"/>

--- a/system/boot/ix86/isoboot/suse-13.1/config.xml
+++ b/system/boot/ix86/isoboot/suse-13.1/config.xml
@@ -107,7 +107,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="clicfs"/>
         <package name="cryptsetup"/>
         <package name="dhcpcd"/>
@@ -117,7 +116,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-13.2/config.xml
+++ b/system/boot/ix86/isoboot/suse-13.2/config.xml
@@ -106,7 +106,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="cryptsetup"/>
         <package name="nfs-client"/>
         <package name="dialog"/>
@@ -114,7 +113,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/isoboot/suse-SLES11/config.xml
@@ -97,7 +97,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/isoboot/suse-SLES12/config.xml
@@ -100,7 +100,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="cryptsetup"/>
         <package name="nfs-client"/>
         <package name="dialog"/>
@@ -108,7 +107,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-leap42.1/config.xml
+++ b/system/boot/ix86/isoboot/suse-leap42.1/config.xml
@@ -114,7 +114,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/isoboot/suse-tumbleweed/config.xml
+++ b/system/boot/ix86/isoboot/suse-tumbleweed/config.xml
@@ -106,7 +106,6 @@
         <package name="bind-libs"/>
         <package name="bind-utils"/>
         <package name="checkmedia"/>
-        <package name="cdrkit-cdrtools-compat"/>
         <package name="cryptsetup"/>
         <package name="nfs-client"/>
         <package name="dialog"/>
@@ -114,7 +113,7 @@
         <package name="filesystem"/>
         <package name="fribidi"/>
         <package name="gawk"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gfxboot"/>
         <package name="glibc"/>
         <package name="glibc-locale"/>

--- a/system/boot/ix86/oemboot/rhel-06.0/config.xml
+++ b/system/boot/ix86/oemboot/rhel-06.0/config.xml
@@ -102,7 +102,7 @@
         <package name="bc"/>
         <package name="e2fsprogs"/>
         <package name="gettext"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="syslinux"/>
         <package name="sysvinit-tools"/>
     </packages>

--- a/system/boot/ix86/oemboot/rhel-07.0/config.xml
+++ b/system/boot/ix86/oemboot/rhel-07.0/config.xml
@@ -114,7 +114,7 @@
         <package name="bc"/>
         <package name="e2fsprogs"/>
         <package name="gettext"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="syslinux"/>
         <package name="sysvinit-tools"/>
     </packages>

--- a/system/boot/ix86/oemboot/suse-13.1/config.xml
+++ b/system/boot/ix86/oemboot/suse-13.1/config.xml
@@ -132,7 +132,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ix86/oemboot/suse-13.2/config.xml
+++ b/system/boot/ix86/oemboot/suse-13.2/config.xml
@@ -133,7 +133,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ix86/oemboot/suse-SLES11/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLES11/config.xml
@@ -121,7 +121,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub"/>
         <package name="hwinfo"/>

--- a/system/boot/ix86/oemboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/oemboot/suse-SLES12/config.xml
@@ -127,7 +127,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ix86/oemboot/suse-leap42.1/config.xml
+++ b/system/boot/ix86/oemboot/suse-leap42.1/config.xml
@@ -133,7 +133,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ix86/oemboot/suse-tumbleweed/config.xml
+++ b/system/boot/ix86/oemboot/suse-tumbleweed/config.xml
@@ -133,7 +133,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/system/boot/ppc/oemboot/suse-SLES11/config.xml
+++ b/system/boot/ppc/oemboot/suse-SLES11/config.xml
@@ -86,7 +86,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/ppc/oemboot/suse-SLES12/config.xml
+++ b/system/boot/ppc/oemboot/suse-SLES12/config.xml
@@ -102,7 +102,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/ppc/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/ppc/vmxboot/suse-SLES12/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/s390/oemboot/suse-SLES11/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES11/config.xml
@@ -75,7 +75,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/s390/oemboot/suse-SLES12/config.xml
+++ b/system/boot/s390/oemboot/suse-SLES12/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/s390/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/s390/vmxboot/suse-SLES12/config.xml
@@ -103,7 +103,7 @@
         <package name="fbiterm"/>
         <package name="file"/>
         <package name="fribidi"/>
-        <package name="genisoimage"/>
+        <package name="mkisofs"/>
         <package name="gettext-runtime"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/tests/jenkins/prepare.sh
+++ b/tests/jenkins/prepare.sh
@@ -34,7 +34,7 @@ fi
 
 # install required packages
 spec=/home/jenkins/kiwi/kiwi/rpm/kiwi.spec
-packages="grub grub2 genisoimage cdrkit-cdrtools-compat squashfs osc yum trang dosfstools"
+packages="grub grub2 mkisofs squashfs osc yum trang dosfstools"
 if ! zypper -n install --no-recommends $packages;then
     exit 1
 fi


### PR DESCRIPTION
Follow-up to #484.
The kiwi rpm is built [here](https://build.opensuse.org/package/show/home:jkeil:terminate_wodim/kiwi). The submit request for zisofs-tools, which resolves the Factory issue can be found [here](https://build.opensuse.org/request/show/341666).