### PR TITLE
Add btrfs to general documentation of volume setup

### DIFF
--- a/doc/docbook/xml/kiwi-doc-description.xml
+++ b/doc/docbook/xml/kiwi-doc-description.xml
@@ -712,7 +712,11 @@
           <listitem>
             <para>Using the optional systemdisk section it is possible to
               create a LVM (Logical Volume Management) based storage
-              layout. By default, the volume group is named
+              layout or a btrfs based layout using sub volumes. See chapter
+              17 for details.
+            </para>
+            <para>
+              By default, the volume group is named
               <emphasis>kiwiVG</emphasis>. It
               is possible to change the name of the group by setting the
               <sgmltag class="attribute">name</sgmltag> attribute


### PR DESCRIPTION
Kiwi supports two options for setting up storage layouts with sub volumes, LVM and btrfs. Chapter 17 explains this in detail. The overview section in the general documentation didn't reference this. This patch fixes this.