### PR TITLE
Add warning to extractkernel  for aarch64/armv7/s390x

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -4192,6 +4192,11 @@ sub extractLinux {
         }
         KIWIQX::qxx ("rm -rf $imageTree/boot/*");
     }
+    else {
+        $kiwi -> warning  ("--> Can't find kernel for extraction: " .
+                           "did you call suseStripKernel?");
+        $kiwi -> skipped ();
+    }
     return $name;
 }
 


### PR DESCRIPTION
For those architectures, the kernel links are named differently
than on x86/ppc.