### PR TITLE
- Update copyBootCode function:

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -5562,7 +5562,7 @@ sub copyBootCode {
         my $target = $dest;
         KIWIQX::qxx ("mv $dest/boot/boot.scr $target &>/dev/null");
         KIWIQX::qxx ("mv $dest/boot/*.dtb $target &>/dev/null");
-        KIWIQX::qxx ("mv $dest/boot/dtb/  $target &>/dev/null");
+        KIWIQX::qxx ("mv $dest/boot/dtb*  $target &>/dev/null");
         if (-f "$dest/boot/MLO") {
             $status = KIWIQX::qxx ("mv $dest/boot/MLO $target");
             $result = $? >> 8;

--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -1205,7 +1205,7 @@ function suseGFXBoot {
         mv /boot/*.img /image/loader &>/dev/null
         mv /boot/*.imx /image/loader &>/dev/null
         mv /boot/*.dtb /image/loader &>/dev/null
-        mv /boot/dtb/  /image/loader &>/dev/null
+        mv /boot/dtb*  /image/loader &>/dev/null
         mv /boot/*.elf /image/loader &>/dev/null
     else
         # boot loader binaries


### PR DESCRIPTION
	Add support to check for /boot/dtb* since DTB files
	can be stored in /boot/dtb/ folder but also in
	/boot/dtb-<version>/ folder with /boot/dtb a symlink