### PR TITLE
make .checksum.md5 contents reproducible

### DIFF
--- a/kiwi.pl
+++ b/kiwi.pl
@@ -2184,7 +2184,7 @@ sub createHash {
         $kiwi -> failed ();
         kiwiExit (1);
     }
-    my $cmd  = "find -L -type f | grep -v .svn | grep -v .checksum.md5";
+    my $cmd  = "find -L -type f ! -wholename '*.svn*' ! -name .checksum.md5 | sort";
     my $status = KIWIQX::qxx (
         "cd $idesc && $cmd | xargs md5sum > .checksum.md5"
     );

--- a/system/boot/armv7l/.md5
+++ b/system/boot/armv7l/.md5
@@ -3,7 +3,7 @@
 for dir in `find -type d`;do
     if [ -f $dir/config.xml ];then
         pushd $dir &>/dev/null
-        find -L -type f | grep -v .svn | grep -v .checksum.md5 |\
+        find -L -type f ! -wholename '*.svn*' ! -name .checksum.md5 | sort |\
             xargs md5sum > .checksum.md5
         popd &>/dev/null
     fi

--- a/system/boot/ia64/.md5
+++ b/system/boot/ia64/.md5
@@ -3,7 +3,7 @@
 for dir in `find -type d`;do
     if [ -f $dir/config.xml ];then
         pushd $dir &>/dev/null
-        find -L -type f | grep -v .svn | grep -v .checksum.md5 |\
+        find -L -type f ! -wholename '*.svn*' ! -name .checksum.md5 | sort |\
             xargs md5sum > .checksum.md5
         popd &>/dev/null
     fi

--- a/system/boot/ix86/.md5
+++ b/system/boot/ix86/.md5
@@ -3,7 +3,7 @@
 for dir in `find -type d`;do
     if [ -f $dir/config.xml ];then
         pushd $dir &>/dev/null
-        find -L -type f | grep -v .svn | grep -v .checksum.md5 |\
+        find -L -type f ! -wholename '*.svn*' ! -name .checksum.md5 | sort |\
             xargs md5sum > .checksum.md5
         popd &>/dev/null
     fi

--- a/system/boot/m68k/.md5
+++ b/system/boot/m68k/.md5
@@ -3,7 +3,7 @@
 for dir in `find -type d`;do
     if [ -f $dir/config.xml ];then
         pushd $dir &>/dev/null
-        find -L -type f | grep -v .svn | grep -v .checksum.md5 |\
+        find -L -type f ! -wholename '*.svn*' ! -name .checksum.md5 | sort |\
             xargs md5sum > .checksum.md5
         popd &>/dev/null
     fi

--- a/system/boot/ppc/.md5
+++ b/system/boot/ppc/.md5
@@ -3,7 +3,7 @@
 for dir in `find -type d`;do
     if [ -f $dir/config.xml ];then
         pushd $dir &>/dev/null
-        find -L -type f | grep -v .svn | grep -v .checksum.md5 |\
+        find -L -type f ! -wholename '*.svn*' ! -name .checksum.md5 | sort |\
             xargs md5sum > .checksum.md5
         popd &>/dev/null
     fi

--- a/system/boot/s390/.md5
+++ b/system/boot/s390/.md5
@@ -3,7 +3,7 @@
 for dir in `find -type d`;do
     if [ -f $dir/config.xml ];then
         pushd $dir &>/dev/null
-        find -L -type f | grep -v .svn | grep -v .checksum.md5 |\
+        find -L -type f ! -wholename '*.svn*' ! -name .checksum.md5 | sort |\
             xargs md5sum > .checksum.md5
         popd &>/dev/null
     fi


### PR DESCRIPTION
In order to have reproducible builds in OBS with unchanged sources, sort
the file list before feeding it to "md5sum". Without, rebuilds would
differ in that file as the file list order was random.
Also, get rid of "find | grep -v ... | grep -v ..." for ignoring
filenames and just use find's options to achieve that. Saves two fork()
and a few CPU cycles :-)