### PR TITLE
Centos grub mkimage fix

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -3894,6 +3894,7 @@ sub setupBootLoaderStages {
             my $core= "$tmpdir/EFI/BOOT/$fo_bin";
             my $core_opts;
             $core_opts = "-O $fo -o $core -c $earlyboot ";
+            $core_opts.= "-p /boot/grub2 ";
             $core_opts.= "-d $tmpdir/$stages{efi}{stageSRC}";
             $status = KIWIQX::qxx (
                 "$grub2_mkimage $core_opts @modules 2>&1"
@@ -3997,6 +3998,7 @@ sub setupBootLoaderStages {
             my $core     = "$tmpdir/boot/grub2/$format/core.elf";
             my $core_opts;
             $core_opts = "-O $format -o $core -c $earlyboot ";
+            $core_opts.= "-p /boot/grub2 ";
             $core_opts.= "-d $tmpdir/$stages{ofw}{stageSRC}";
             my $status = KIWIQX::qxx (
                 "$grub2_mkimage $core_opts @modules 2>&1"
@@ -4028,6 +4030,7 @@ sub setupBootLoaderStages {
             my $cdcore   = "$tmpdir/boot/grub2/$format/cdboot.img";
             my $core_opts;
             $core_opts = "-O $format -o $core -c $earlyboot ";
+            $core_opts.= "-p /boot/grub2 ";
             $core_opts.= "-d $tmpdir/$stages{bios}{stageSRC}";
             my $status = KIWIQX::qxx (
                 "$grub2_mkimage $core_opts @modules 2>&1"


### PR DESCRIPTION
grub2-mkimage on CentOS/RHEL7 *needs* the "-p <prefix>" option or it
will abort with an error.
On openSUSE's grub2-mkimage, prefix defaults to "/boot/grub2".
Add "-p /boot/grub2" to all grub2-mkimage calls, so that they can work
with CentOS, too. This *should* not break things on SUSE base ;-)

So this should be harmless... but might be good to test with more different SUSE configurations.
I only tested a OEM ISO built with this config:

    <type checkprebuilt='false' boot='oemboot/suse-SLES12'
          fsnocheck='true' filesystem='ext3' bootloader='grub2'
          installiso='true' installpxe='true' installboot='install'
          installstick='true'
          kernelcmdline='net.ifnames=0 video=800x600'
          fsmountoptions='acl'
          firmware='uefi'
          image='oem'>

...and this booted / installed fine in a Virtualbox VM. But that's about it... ;-)