### PR TITLE
Run dracut as background process for vmx images

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -1595,10 +1595,19 @@ function setupInitrd {
             # 1. dracut
             Echo "Creating dracut based initrd"
             params=" -f /boot/initrd-$kernel_version $kernel_version"
-            if ! $dracutExec -H $params;then
-                Echo "Can't create initrd with dracut"
-                systemIntegrity=unknown
-                bootLoaderOK=0
+            if [[ $kiwi_iname =~ vmxboot ]];then
+                # run dracut in the background to speed up the boot.
+                # We loose the status check of the call and reboot is
+                # only safe after the call has finished. Therefore this
+                # is only done for simple vmx type images which are
+                # mostly used in cloud frameworks
+                $dracutExec -H $params &>/dev/null </dev/null &
+            else
+                if ! $dracutExec -H $params;then
+                    Echo "Can't create initrd with dracut"
+                    systemIntegrity=unknown
+                    bootLoaderOK=0
+                fi
             fi
         elif [ -x "$mkinitrdExec" ]; then
             # 2. mkinitrd


### PR DESCRIPTION
The dracut process takes quite some time and blocks the boot
process. In cloud frameworks instance boot time matters and
with this patch the dracut process runs in parallel with the
rest of the boot process.