### PR TITLE
Handle /boot/vc files for Raspberry Pi

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -5591,6 +5591,11 @@ sub copyBootCode {
         KIWIQX::qxx ("mv $dest/boot/*.img $target &>/dev/null");
         KIWIQX::qxx ("mv $dest/boot/*.imx $target &>/dev/null");
         KIWIQX::qxx ("mv $dest/boot/*.elf $target &>/dev/null");
+        if (-d "$dest/boot/vc") {
+            # Raspberry Pi VideoCore files
+            KIWIQX::qxx ("mv $dest/boot/vc/* $target &>/dev/null");
+            KIWIQX::qxx ("mv $dest/boot/vc $dest &>/dev/null");
+        }
     }
     #==========================================
     # YaBoot

--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -1200,6 +1200,9 @@ function suseGFXBoot {
         if [ -f /boot/MLO ];then
             mv /boot/MLO /image/loader
         fi
+        if [ -d /boot/vc ];then
+            mv /boot/vc /image/loader
+        fi
         mv /boot/*.dat /image/loader &>/dev/null
         mv /boot/*.bin /image/loader &>/dev/null
         mv /boot/*.img /image/loader &>/dev/null


### PR DESCRIPTION
openSUSE Tumbleweed raspberrypi-firmware[-branding-openSUSE] packages
have been updated to install files to /boot/vc rather than /boot.

Ensure that all files in /boot/vc find their way into the vboot partition
and on the boot partition prepare vc as potential mount point.

Signed-off-by: Andreas Färber <afaerber@suse.de>