### PR TITLE
Allow xfs as hybrid RW file system

### DIFF
--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -1783,7 +1783,7 @@ div {
         ## hybrid ISO is used as disk on e.g a USB Stick. By default
         ## the btrfs filesystem is used
         attribute hybridpersistent_filesystem {
-            "btrfs" | "fat" | "ext4"
+            "btrfs" | "fat" | "ext4" | "xfs"
         }
     k.type.image.attribute =
         ## Specifies the image type

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -2404,6 +2404,7 @@ the btrfs filesystem is used</a:documentation>
           <value>btrfs</value>
           <value>fat</value>
           <value>ext4</value>
+          <value>xfs</value>
         </choice>
       </attribute>
     </define>


### PR DESCRIPTION
btrfs is still not fully ready [eg. it reliably breaks with overlay fs on Leap 42.1].  xfs is used by current openSuSE for data partitions [instead of ext3/4].