### PR TITLE
fix message of missing command

### DIFF
--- a/metadata/KIWIConfig.xml
+++ b/metadata/KIWIConfig.xml
@@ -240,6 +240,7 @@
         <file name="stat"/>
         <file name="swapoff"/>
         <file name="swapon"/>
+        <file name="systemd-detect-virt"/>
         <file name="tac"/>
         <file name="rev"/>
         <file name="tail"/>


### PR DESCRIPTION
Live iso created on recent distributions gives out this error message when booting that it is missing systemd-detect-virt command.

Try one from here for example: http://download.opensuse.org/repositories/Education/images/iso/

This commit fixes the error.