### PR TITLE
output correct sha256 file

### DIFF
--- a/modules/KIWIResult.pm
+++ b/modules/KIWIResult.pm
@@ -21,7 +21,6 @@ use strict;
 use warnings;
 use Config::IniFiles;
 use Digest::SHA qw(sha256);
-use Cwd;
 
 #==========================================
 # KIWI Modules
@@ -492,11 +491,9 @@ sub __sign_with_sha256sum {
         $kiwi -> failed ();
         return;
     }
-    my $orig_cwd = getcwd;
-    chdir $tmpdir;
     while (my $entry = readdir ($dh)) {
         next if $entry eq "." || $entry eq "..";
-        next if ! -f $entry;
+        next if ! -f "$tmpdir/$entry";
         my $alg = 'sha256';
         my $sha = Digest::SHA->new($alg);
         if (! $sha) {
@@ -504,7 +501,7 @@ sub __sign_with_sha256sum {
             $kiwi -> failed ();
             return;
         }
-        $sha -> addfile ($entry);
+        $sha -> addfile ($tmpdir."/".$entry);
         my $digest = $sha -> hexdigest;
         my $fd = FileHandle -> new();
         if (! $fd -> open (">$tmpdir/$entry.sha256")) {
@@ -512,10 +509,9 @@ sub __sign_with_sha256sum {
             $kiwi -> failed ();
             return;
         }
-        print $fd $digest."\n";
+        print $fd "$digest  $entry\n";
         $fd -> close();
     }
-    chdir $orig_cwd;
     closedir $dh;
     return $this;
 }


### PR DESCRIPTION
whether or not the argument to $sha->addfile is absolute doesn't
actually matter as $sha->hexdigest never outputs any file name. We
have to add the file name ourselves.

Reason for the confusion is code in OBS's build script that under
certain conditions computes the sha256sum file itself. So this code here
was never used where it actually matters.

This reverts commit 97b92d0e0a58cdd237b109efbf843b6057172164.