### PR TITLE
- Enable pvops builds for EC2

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -303,6 +303,7 @@ sub new {
         $type{boottimeout}            = $xmltype -> getBootTimeout();
         $type{btrfs_root_is_snapshot} = $xmltype -> getBtrfsRootIsSnapshot();
         $type{cmdline}                = $xmltype -> getKernelCmdOpts();
+        $type{devicepersistency}      = $xmltype -> getDevicePersistent();
         $type{filesystem}             = $xmltype -> getFilesystem();
         $type{firmware}               = $xmltype -> getFirmwareType();
         $type{fsmountoptions}         = $xmltype -> getFSMountOptions();
@@ -4330,7 +4331,21 @@ sub setupBootLoaderConfiguration {
         $kiwi -> info (
             "Kernel root device set to $1 via custom cmdline\n"
         );
-    } elsif ($firmware eq 'ec2') {
+    } elsif ( ($this->{type}->{devicepersistency}) && ($firmware =~ /ec2/)) {
+        # /.../
+        # With the introduction of the 4.4 kernel in openSUSE and SLE
+        # the SUSE Xen patches were all upstremead and we enabled the so
+        # called "pvops kernel" as the -default kernel. With this the
+        # behavior for PV images in EC2 changes and we can now treat
+        # PV and HVM as equals. For PV image we still need to handle
+        # pv-grub and thus we just tell it to mount with the default
+        # file system label that kiwi creates anyway. This also works
+        # for HVM and one no longer has to maintain separarate image builds
+        $kiwi -> info (
+            "Kernel root device set via label 'ROOT' for firmware $firmware\n"
+        );
+        $cmdline .= ' root=LABEL=ROOT';
+    } elsif ($firmware eq 'ec2')  {
         # /.../
         # EC2 requires to specifiy the root device in the bootloader
         # configuration. EC2 extracts this information via pygrub and

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -4197,7 +4197,7 @@ function probeDevices {
     #======================================
     # Manual loading of modules
     #--------------------------------------
-    for i in rd brd edd dm-mod xennet xenblk virtio_blk loop squashfs fuse;do
+    for i in rd brd edd dm-mod xen:vif xen:vbd virtio_blk loop squashfs fuse;do
         modprobe $i &>/dev/null
     done
     udevPending
@@ -7384,7 +7384,7 @@ function waitForStorageDevice {
         if [ $check -eq 30 ];then
             return 1
         fi
-        Echo "Waiting for device $device to settle..."
+        Echo "Waiting for storage device $device to settle..."
         check=$((check + 1))
         sleep 2
     done
@@ -7429,7 +7429,7 @@ function waitForBlockDevice {
         if [ -b $device ] || [ $check -eq 4 ];then
             break
         fi
-        Echo "Waiting for device $device to settle..."
+        Echo "Waiting for block device $device to settle..."
         check=$((check + 1))
         sleep 2
     done

--- a/system/boot/ix86/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/vmxboot/suse-SLES12/config.xml
@@ -70,6 +70,11 @@
     </drivers>
     <drivers profiles="xen,ec2">
         <file name="drivers/xen/*"/>
+        <file name="drivers/block/xen-blkfront.ko"/>
+        <file name="drivers/net/xen-netfront.ko"/>
+        <file name="drivers/scsi/xen-scsifront.ko"/>
+        <file name="drivers/input/misc/xen-kbdfront.ko"/>
+        <file name="drivers/pci/xen-pcifront.ko"/>
     </drivers>
     <repository type="yast2" status="replaceable">
         <source path="obs://SUSE:SLE-12:GA/standard"/>


### PR DESCRIPTION
Additional changes to KIWILinuxRC.sh are needed, detailed in an e-mail.

The symptom is as follows:

[    1.135490] Waiting for device LABEL to settle...

This stems from the fact that we now generate "root=LABEL=ROOT" in grub.cfg and the code assumes that whatever follows "root=" is a device or partition. This assumption was added to the code way back when we sorted out how to get EC2 images to behave nicely. This has to change with the emergence of the pvops kernel. I tried:

if [ ( ! -z "$root" ) -a ( "${root#*$devIndicator}" ) ];then

line 4720 in LinuxRC.sh but that results in no root device being found, so we need something else there.

Anyway, I realize this is incomplete but it gets us part of the way there.
   