### PR TITLE
Remove flush before resize filesystem

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -9871,17 +9871,17 @@ function resizeFilesystem {
     if [ "$FSTYPE" = "reiserfs" ];then
         resize_fs="resize_reiserfs -q $deviceResize"
     elif [ "$FSTYPE" = "ext2" ];then
-        resize_fs="resize2fs -f -F -p $deviceResize"
+        resize_fs="resize2fs -f -p $deviceResize"
         if [ $ramdisk -eq 1 ];then
             resize_fs="resize2fs -f $deviceResize"
         fi
     elif [ "$FSTYPE" = "ext3" ];then
-        resize_fs="resize2fs -f -F -p $deviceResize"
+        resize_fs="resize2fs -f -p $deviceResize"
         if [ $ramdisk -eq 1 ];then
             resize_fs="resize2fs -f $deviceResize"
         fi
     elif [ "$FSTYPE" = "ext4" ];then
-        resize_fs="resize2fs -f -F -p $deviceResize"
+        resize_fs="resize2fs -f -p $deviceResize"
         if [ $ramdisk -eq 1 ];then
             resize_fs="resize2fs -f $deviceResize"
         fi


### PR DESCRIPTION
According to the manpage, -F is flushing the fileystem buffer
caches. which is only really useful for doing resize2fs time trials.

With current Tumbleweed installed on MMC, -F triggers a Inappropriate ioctl for device
while trying to flush error, and then fails to resize.