### PR TITLE
Remove grub2 from the armv6/v7 initrd

### DIFF
--- a/system/boot/armv7l/oemboot/suse-SLES12/config.xml
+++ b/system/boot/armv7l/oemboot/suse-SLES12/config.xml
@@ -105,7 +105,6 @@
         <package name="fribidi"/>
         <package name="genisoimage"/>
         <package name="gettext-runtime"/>
-        <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/armv7l/oemboot/suse-leap42.1/config.xml
+++ b/system/boot/armv7l/oemboot/suse-leap42.1/config.xml
@@ -104,7 +104,6 @@
         <package name="fribidi"/>
         <package name="genisoimage"/>
         <package name="gettext-runtime"/>
-        <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="hwinfo"/>
         <package name="iputils"/>

--- a/system/boot/armv7l/oemboot/suse-tumbleweed/config.xml
+++ b/system/boot/armv7l/oemboot/suse-tumbleweed/config.xml
@@ -104,7 +104,6 @@
         <package name="fribidi"/>
         <package name="genisoimage"/>
         <package name="gettext-runtime"/>
-        <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="hwinfo"/>
         <package name="iputils"/>


### PR DESCRIPTION
Grub2 adds 35MB to the initrd for no reason on armv6/v7, as
those images use u-boot scripts for booting.