### PR TITLE
Fix filesystem check on boot

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -9909,7 +9909,7 @@ function resizeFilesystem {
     if [ -z "$callme" ];then
         if [ $ramdisk -eq 0 ]; then
             Echo "Checking $FSTYPE filesystem on ${deviceResize}..."
-            checkFilesystem $check
+            checkFilesystem $deviceResize
         fi
         Echo "Resizing $FSTYPE filesystem on ${deviceResize}..."
         eval $resize_fs


### PR DESCRIPTION
In the refactoring fc363cc06, the parameters of checkFileSystem got
changed to expect the device name, but one of the invocations didn't
pass down the device name due to a typo.