### PR TITLE
run exec >/dev/null after screen clears in quiet mode

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -628,11 +628,11 @@ function errorLogStart {
         #======================================
         # Redirect/Clean stdout if quiet is set
         #--------------------------------------
-        exec >/dev/null
         if [ -x /usr/bin/setterm ];then
             setterm -clear all
             setterm -background black
         fi
+        exec >/dev/null
     else
         #======================================
         # Redirect stdout to console

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -643,7 +643,7 @@ function errorLogStart {
     # Clean proc
     #--------------------------------------
     if [ $umountProc -eq 1 ];then
-        umount /proc
+        umount /proc 2>/dev/null
     fi
     #======================================
     # Enable shell debugging


### PR DESCRIPTION
If exec >/dev/null is run before setterm clears the screen, then "Failed to find cpu0 device node" is displayed even if quiet is set. This commit fixes that.