### PR TITLE
modules: KIWIContainerBuilder: preserve xattrs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -y xsltproc
     - sudo apt-get install -y syslinux
+    - echo "deb http://archive.ubuntu.com/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
+    - sudo apt-get update
+    - sudo apt-get install -y -t trusty tar
 
 install:
     - cpanm -f -n $(cat .perlmodules | tr "\n" " ")

--- a/modules/KIWIContainerBuilder.pm
+++ b/modules/KIWIContainerBuilder.pm
@@ -367,7 +367,7 @@ sub __createContainerBundle {
         return;
     }
     my $data = KIWIQX::qxx (
-        "$tar -C $origin -cJf $baseBuildDir/$imgFlName @dirlist 2>&1"
+        "$tar --xattrs -C $origin -cJf $baseBuildDir/$imgFlName @dirlist 2>&1"
     );
     my $code = $? >> 8;
     if ($code != 0) {

--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -90,7 +90,7 @@ Requires:       perl-XML-SAX
 Requires:       perl-libwww-perl
 Requires:       rsync
 Requires:       screen
-Requires:       tar
+Requires:       tar >= 1.2.7
 Requires:       psmisc
 Requires:       util-linux
 %if 0%{?suse_version} == 1110


### PR DESCRIPTION
tar doesn't preserve extended attributes by default, causing Docker
images to not have any correct set-capabilities bits set on binaries
such as ping. Fix this by adding the --xattrs flag to the tar command
run to generate the root filesystem image.

Fixes #555.

Signed-off-by: Aleksa Sarai <asarai@suse.com>