### PR TITLE
bootImage: don't copy initial ram disk content to /run/initramfs

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -8377,18 +8377,6 @@ function bootImage {
     #--------------------------------------
     umount proc &>/dev/null && \
     umount proc &>/dev/null
-    #======================================
-    # copy initrd to /run/initramfs
-    #--------------------------------------
-    mkdir -p $prefix/run/initramfs
-    match='mnt|lost\+found|dev|boot|tmp|run|proc|sys|read-only|read-write'
-    for dir in /*;do
-        if [[ $dir =~ $match ]]; then
-            mkdir -p $prefix/run/initramfs/$dir
-            continue
-        fi
-        cp -a $dir $prefix/run/initramfs
-    done
     if [ "$FSTYPE" = "zfs" ];then
         #======================================
         # setup shutdown script


### PR DESCRIPTION
We should avoid copying the initial ram disk content to a tmpfs filesystem,
especially on low memory systems.

Signed-off-by: Roberto Sassu <rsassu@suse.de>