### PR TITLE
have tar preserve all xattrs

### DIFF
--- a/modules/KIWIContainerBuilder.pm
+++ b/modules/KIWIContainerBuilder.pm
@@ -367,7 +367,7 @@ sub __createContainerBundle {
         return;
     }
     my $data = KIWIQX::qxx (
-        "$tar --xattrs -C $origin -cJf $baseBuildDir/$imgFlName @dirlist 2>&1"
+        "$tar --xattrs --xattrs-include=* -C $origin -cJf $baseBuildDir/$imgFlName @dirlist 2>&1"
     );
     my $code = $? >> 8;
     if ($code != 0) {


### PR DESCRIPTION
By default tar will only preserve a subset of the capabilities with --xattrs.
Adding --xattrs-include=* should preserve all capabilities (e.g. user.*,
security.capability etc.).

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>