### PR TITLE
Add aarch64_ilp32 support

### DIFF
--- a/modules/KIWIXML.pm
+++ b/modules/KIWIXML.pm
@@ -258,6 +258,7 @@ sub new {
     my $arch = KIWIGlobals -> instance() -> getArch();
     my %supported = map { ($_ => 1) } qw(
         aarch64
+        aarch64_ilp32
         armv5el
         armv5tel
         armv6l

--- a/modules/KIWIXMLDataBase.pm
+++ b/modules/KIWIXMLDataBase.pm
@@ -55,6 +55,7 @@ sub new {
     my $kiwi = $this->{kiwi};
     my %archesSup = map { ($_ => 1) } qw(
         aarch64
+        aarch64_ilp32
         armv5el
         armv5tel
         armv6l


### PR DESCRIPTION
This is the -32bit variant of aarch64. Right now only needed for
install medias.