### PR TITLE
insserv is not a chkconfig

### DIFF
--- a/modules/KIWIContainerBuilder.pm
+++ b/modules/KIWIContainerBuilder.pm
@@ -707,7 +707,7 @@ sub __disableServices {
     my $locator = $this->{locator};
     $kiwi -> info("Disable unwanted services\n");
     my $sysctl = $locator -> getExecPath('systemctl', $targetDir);
-    my $ins = $locator -> getExecPath('chkconfig', $targetDir);
+    my $ins = $locator -> getExecPath('insserv', $targetDir);
     my $croot = $locator -> getExecPath('chroot');
     if (defined $sysctl) {
         my @srvs = qw (


### PR DESCRIPTION
Without this PR applied, docker type fails the following way:

```
Jul-13 09:45:26 <1> : Reading contents of bootincluded packages/archives
Jul-13 09:45:26 <2> : --> package redhat-logos not installed
Jul-13 09:45:26 <1> : Checking for tools in bootincluded contents to keep
Jul-13 09:45:26 <1> : --> no tools to keep
Jul-13 09:45:26 <1> : Creating rootfs target directory                                                                                        done
Jul-13 09:45:26 <1> : Copy unpacked image tree                                                                                                done
Jul-13 09:45:43 <1> : Clean up kiwi image build artifacts                                                                                     done
Jul-13 09:45:43 <1> : Setup container configuration                                                                                           done
Jul-13 09:45:43 <1> : Create container inittab                                                                                                done
Jul-13 09:45:43 <1> : Disable unwanted services
-f: unknown option
Jul-13 09:45:43 <3> : --> Could not disable service: boot.clock                                                                               failed
Jul-13 09:45:43 <3> : Unsupported type: docker                                                                                                failed
Jul-13 09:45:43 <1> : Closing session with ecode: 1
Jul-13 09:45:45 <3> : KIWI exited with error(s)
Jul-13 09:45:45 <1> : Complete logfile at: /out/build/image-root.log
Jul-13 09:45:46 <1> : Removing yum repo(s) in: /var/cache/kiwi/yum                                                                            done
```
