### PR TITLE
Instsource tumbleweed

### DIFF
--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/COPYING
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/COPYING
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIBasePlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIBasePlugin.pm
@@ -1,0 +1,246 @@
+################################################################
+# Copyright (c) 2014 SUSE
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file LICENSE); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+package KIWIBasePlugin;
+
+use strict;
+use warnings;
+use IO::Select;
+use IPC::Open3;
+use Symbol;
+
+sub new {
+    my $class = shift;
+    my $this  = {
+        m_handler     => undef,
+        m_name        => "KIWIBasePlugin",
+        m_order       => undef,
+        m_requireddirs=> [],
+        m_descr       => [],
+        m_requires    => [],
+        m_ready       => 0,
+        m_collect     => 0
+    };
+    bless ($this, $class);
+    $this->{m_handler} = shift;
+    if (! ref($this->{m_handler})) {
+        return;
+    }
+    $this->{m_collect} = $this->{m_handler}->collect();
+    return $this;
+}
+
+sub name {
+    my $this = shift;
+    my $name = shift;
+    if (! ref($this)) {
+        return;
+    }
+    my $oldname = $this->{m_name};
+    if($name) {
+        $this->{m_name} = $name;
+    }
+    return $oldname;
+}
+
+sub order {
+    my $this  = shift;
+    my $order = shift;
+    if (! ref($this)) {
+        return;
+    }
+    my $oldorder = $this->{m_order};
+    if($order) {
+        $this->{m_order} = $order;
+    }
+    return $oldorder;
+}
+
+sub ready {
+    my $this  = shift;
+    my $ready = shift;
+    if (! ref($this)) {
+        return;
+    }
+    my $oldready = $this->{m_ready};
+    if($ready) {
+        $this->{m_ready} = $ready;
+    }
+    return $oldready;
+}
+
+sub requiredDirs {
+    my @params = @_;
+    my $this = shift @params;
+    my @dirs = @params;
+    if (! ref($this)) {
+        return;
+    }
+    my @oldrd = @{$this->{m_requireddirs}};
+    foreach my $entry(@params) {
+        push @{$this->{m_requireddirs}}, $entry;
+    }
+    return @oldrd;
+}
+
+sub description {
+    my @params = @_;
+    my $this = shift @params;
+    my @descr= @params;
+    if (! ref($this)) {
+        return;
+    }
+    my @olddesc = $this->{m_descr};
+    foreach my $entry(@descr) {
+        push @{$this->{m_descr}}, $entry;
+    }
+    return @olddesc;
+}
+
+sub requires {
+    my @params = @_;
+    my $this = shift;
+    my @reqs = @params;
+    if (! ref($this)) {
+        return;
+    }
+    my @oldreq = $this->{m_requires};
+    foreach my $entry(@reqs) {
+        push @{$this->{m_requires}}, $entry;
+    }
+    return @oldreq;
+}
+
+sub handler {
+    my $this = shift;
+    if (! ref($this)) {
+        return;
+    }
+    return $this->{m_handler};
+}
+
+sub collect {
+    my $this = shift;
+    if (! ref($this)) {
+        return;
+    }
+    return $this->{m_collect};
+}
+
+sub logMsg {
+    my $this = shift;
+    if (! ref($this)) {
+        return;
+    }
+    my $type = shift;
+    my $msg = shift;
+    if ((! defined($type)) || (! defined($msg))) {
+        return;
+    }
+    $this->{m_collect}->logMsg($type, $msg);
+    return $this;
+}
+
+sub callCmd {
+    my $this = shift;
+    my $cmd  = shift;
+    my $BUFSIZE = 1024;
+    my @result;
+    my @errors;
+    my $result_buf;
+    my $errors_buf;
+    my ($CHILDWRITE, $CHILDSTDOUT, $CHILDSTDERR) = map { gensym } 1..3;
+    my $pid = open3 (
+        $CHILDWRITE, $CHILDSTDOUT, $CHILDSTDERR, "$cmd"
+    );
+    my $sel = IO::Select->new();
+    $sel->add($CHILDSTDOUT);
+    $sel->add($CHILDSTDERR);
+    while($sel->count()) {
+        foreach my $handle ($sel->can_read()) {
+            my $bytes_read = '';
+            my $chunk_result = sysread($handle, $bytes_read, $BUFSIZE);
+            if ($handle == $CHILDSTDOUT) {
+                $result_buf .= $bytes_read;
+            } else {
+                $errors_buf .= $bytes_read;
+            }
+            if ($chunk_result == 0) {
+                $sel->remove($handle);
+                next;
+            }
+        }
+    }
+    if ($result_buf) {
+        @result = split (/\n/x,$result_buf);
+        chomp @result;
+    }
+    if ($errors_buf) {
+        @errors = split (/\n/x,$errors_buf);
+        chomp @errors;
+    }
+    waitpid( $pid, 0 );
+    my $status = $? >> 8;
+    return [$status,\@result,\@errors];
+}
+
+sub getSubdirLists {
+    # ...
+    # method to distinguish debugmedia and ftp media subdirectories.
+    # ---
+    my $this = shift;
+    if (! ref($this)) {
+        return;
+    }
+    my @ret = ();
+    my $coll = $this->{m_collect};
+    my $dbm = $coll->productData()->getOpt("DEBUGMEDIUM");
+    my $flavor = $coll->productData()->getVar("FLAVOR");
+    my $basesubdirs = $coll->basesubdirs();
+    my @paths = values(%{$basesubdirs});
+    @paths = grep { $_ =~ /[^0]$/x } @paths; # remove Media0
+    my %path = map { $_ => 1 } @paths;
+    if($flavor =~ m{ftp}i) {
+        # 1: FTP tree, all subdirs get a separate call.
+        my @d = sort(keys(%path));
+        foreach(@d) {
+            my @tmp;
+            push @tmp, $_;
+            push @ret, \@tmp;
+        }
+    } elsif($dbm >= 2) {
+        # 2: non-ftp tree, may have separate DEBUGMEDIUM specified
+        my @deb;
+        my @rest;
+        foreach my $d(keys(%path)) {
+            if ($d =~ m{.*$dbm$}x) {
+                push @deb, $d;
+            } else {
+                push @rest, $d;
+            }
+        }
+        push @ret, \@deb;
+        push @ret, \@rest;
+    } else {
+        my @d = keys(%path);
+        push @ret, \@d;
+    }
+    return @ret;
+}
+
+1;

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIContentPlugin.ini
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIContentPlugin.ini
@@ -1,0 +1,19 @@
+# INI file for KIWIContentPlugin.pm
+# Written by Jan-Christoph Bornschlegel <jcborn@suse.de>
+# Provides configuration for the plugin:
+# - required binaries
+# - required directories
+# - target file name
+# - unique order number
+# - package name providing the required binaries, if packaged
+
+[base]
+name = KIWIContentPlugin
+order = 4
+defaultenable = 1
+
+[target]
+targetfile = content
+targetdir = $PRODUCT_DIR
+media = all
+

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIContentPlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIContentPlugin.pm
@@ -1,0 +1,178 @@
+################################################################
+# Copyright (c) 2008 Jan-Christoph Bornschlegel, SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file LICENSE); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+package KIWIContentPlugin;
+
+use strict;
+use warnings;
+
+use base "KIWIBasePlugin";
+use FileHandle;
+use Data::Dumper;
+use Config::IniFiles;
+
+sub new {
+    # ...
+    # Create a new KIWIContentPlugin object
+    # ---
+    my $class   = shift;
+    my $handler = shift;
+    my $config  = shift;
+    my $configpath;
+    my $configfile;
+    my $this = KIWIBasePlugin -> new ($handler);
+    bless ($this, $class);
+    if ($config =~ m{(.*)/([^/]+)$}x) {
+        $configpath = $1;
+        $configfile = $2;
+    }
+    if(not defined($configpath) or not defined($configfile)) {
+        $this->logMsg("E", "wrong parameters in plugin initialisation\n");
+        return;
+    }
+    ## Gather all necessary information from the inifile:
+    #===
+    # Issue: why duplicate code here? Why not put it into the base class?
+    # Answer: Each plugin may have different options. Some only need a
+    # target filename, whilst some others may need much more. I don't want
+    # to specify a complicated framework for the plugin, it shall just be
+    # a simple straightforward way to get information into the plugin.
+    # The idea is that the people who decide on the metadata write
+    # the plugin, and therefore damn well know what it needs and what not.
+    # I'm definitely not bothering PMs with Yet Another File Specification
+    #---
+    ## plugin content:
+    #-----------------
+    #[base]
+    # name = KIWIEulaPlugin
+    # order = 3
+    # defaultenable = 1
+    #
+    #[target]
+    # targetfile = content
+    # targetdir = $PRODUCT_DIR
+    # media = (list of numbers XOR "all")
+    #
+    my $ini = Config::IniFiles -> new(
+        -file => "$configpath/$configfile"
+    );
+    my $name      = $ini->val('base', 'name'); # scalar value
+    my $order     = $ini->val('base', 'order'); # scalar value
+    my $enable    = $ini->val('base', 'defaultenable'); # scalar value
+    my $target    = $ini->val('target', 'targetfile');
+    my $targetdir = $ini->val('target', 'targetdir');
+    my @media     = $ini->val('target', 'media');
+    # if any of those isn't set, complain!
+    if(not defined($name)
+        or not defined($order)
+        or not defined($enable)
+        or not defined($target)
+        or not defined($targetdir)
+        or not @media
+    ) {
+        $this->logMsg("E", "Plugin ini file <$config> seems broken!");
+        return;
+    }
+    $this->name($name);
+    $this->order($order);
+    $targetdir = $this->collect()->productData()->_substitute("$targetdir");
+    if($enable != 0) {
+        $this->ready(1);
+    }
+    $this->requiredDirs($targetdir);
+    $this->{m_target} = $target;
+    $this->{m_targetdir} = $targetdir;
+    @{$this->{m_media}} = @media;
+    return $this;
+}
+
+sub execute {
+    my $this = shift;
+    if(not ref($this)) {
+        return;
+    }
+    my $retval = 0;
+    if($this->{m_ready} == 0) {
+        return $retval;
+    }
+    my $descrdir = $this->collect()->productData()->getInfo("DESCRDIR");
+    if ((! $descrdir) || ($descrdir eq "/")) {
+        $this->logMsg("I",
+            "Empty or (/) descrdir, skipping content file creation"
+        );
+        return $retval;
+    }
+    my @targetmedia = $this->collect()->getMediaNumbers();
+    my %targets;
+    if($this->{m_media}->[0] =~ m{all}i) {
+        %targets = map { $_ => 1 } @targetmedia;
+    } else {
+        foreach my $cd(@{$this->{m_media}}) {
+            if(grep { $cd } @targetmedia) {
+                $targets{$cd} = 1;
+            }
+        }
+    }
+    my $info = $this->collect()->productData()->getSet("prodinfo");
+    if(!$info) {
+        $this->logMsg("E", "data set named <prodinfo> seems to be broken:");
+        $this->logMsg("E", Dumper($info));
+        return $retval;
+    }
+    foreach my $cd(keys(%targets)) {
+        $this->logMsg("I", "Creating content file on medium <$cd>:");
+        my $dir = $this->collect()->basesubdirs()->{$cd};
+        my $contentfile = "$dir/$this->{m_target}";
+        my $CONT = FileHandle -> new();
+        if (! $CONT -> open(">$contentfile")) {
+            $this->logMsg("E", "Cannot create <$contentfile> on medium <$cd>");
+            next;
+        }
+        # compute maxlen:
+        my $len = 0;
+        foreach(keys(%{$info})) {
+            my $l = length($info->{$_}->[0]);
+            $len = ($l>$len)?$l:$len;
+        }
+        $len++;
+        # ftp media special mode ?
+        my $coll = $this->{m_collect};
+        my $flavor = $coll->productData()->getVar("FLAVOR");
+        my $ftpmode = ($flavor =~ m{ftp}i);
+
+        my %ftpcontentkeys = map {$_ => 1} qw{
+            CONTENTSTYLE REPOID DESCRDIR DATADIR VENDOR
+        };
+        foreach my $i(sort { $a <=> $b } keys(%{$info})) {
+        # ftp medias beside first one should get provide the product
+            if ( !$ftpmode || $cd eq "1" || $ftpcontentkeys{$info->{$i}->[0]}) {
+                print $CONT sprintf(
+                    '%-*s %s', $len, $info->{$i}->[0], $info->{$i}->[1]
+                )."\n";
+            }
+        }
+        $CONT -> close();
+        $this->logMsg(
+            "I", "Wrote file <$contentfile> for medium <$cd> successfully."
+        );
+        $retval++;
+    }
+    return $retval;
+}
+
+1;

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIDescrPlugin.ini
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIDescrPlugin.ini
@@ -1,0 +1,40 @@
+# INI file for KIWIDescrPlugin.pm
+# Written by Jan-Christoph Bornschlegel <jcborn@suse.de>
+# Provides configuration for the plugin:
+# - required binaries
+# - required directories
+# - target file name
+# - unique order number
+# - package name providing the required binaries, if packaged
+
+[base]
+name = KIWIDescrPlugin
+order = 2
+tool = create_package_descr
+tooldir = /usr/bin
+toolpack = inst-source-utils
+defaultenable = 1
+createrepo = createrepo
+rezip = rezip_repo_rsyncable
+
+[options]
+pdbfiles = -p /usr/share/pdb/11.1
+parameter = -P
+parameter = -Z
+parameter = -C
+parameter = -K
+parameter = -M 3
+parameter = -V
+parameter = -F
+parameter = -B
+#parameter = -T /usr/share/supportstatus/$DISTNAME-$PRODUCT_VERSION
+language = -l german
+language = -l english
+language = -l french
+language = -l czech
+language = -l spanish
+language = -l hungarian
+
+[target]
+compress = yes
+

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIDescrPlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIDescrPlugin.pm
@@ -1,0 +1,344 @@
+################################################################
+# Copyright (c) 2014 SUSE
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file LICENSE); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+package KIWIDescrPlugin;
+
+use strict;
+use warnings;
+
+use File::Basename;
+use base "KIWIBasePlugin";
+use Config::IniFiles;
+use Data::Dumper;
+use Cwd 'abs_path';
+
+sub new {
+    # ...
+    # Create a new KIWIDescrPlugin object
+    # creates patterns file
+    # ---
+    my $class   = shift;
+    my $handler = shift;
+    my $config  = shift;
+    my $configpath;
+    my $configfile;
+    my $this = KIWIBasePlugin -> new($handler);
+    bless ($this, $class);
+    if ($config =~ m{(.*)/([^/]+)$}x) {
+        $configpath = $1;
+        $configfile = $2;
+    }
+    if((! $configpath) || (! $configfile)) {
+        $this->logMsg("E",
+            "wrong parameters in plugin initialisation"
+        );
+        return;
+    }
+    my $ini = Config::IniFiles -> new( -file => "$configpath/$configfile" );
+    my $name       = $ini->val('base', 'name');
+    my $order      = $ini->val('base', 'order');
+    my $tool       = $ini->val('base', 'tool');
+    my $createrepo = $ini->val('base', 'createrepo');
+    my $rezip      = $ini->val('base', 'rezip');
+    my $tdir       = $ini->val('base', 'tooldir');
+    my $tpack      = $ini->val('base', 'toolpack');
+    my $enable     = $ini->val('base', 'defaultenable');
+    my @params     = $ini->val('options', 'parameter');
+    my $gzip       = $ini->val('target', 'compress');
+    # if any of those isn't set, complain!
+    if(not defined($name)
+        or not defined($order)
+        or not defined($tool)
+        or not defined($createrepo)
+        or not defined($rezip)
+        or not defined($tdir)
+        or not defined($tpack)
+        or not defined($enable)
+        or not defined($gzip)
+        or not (@params)
+    ) {
+        $this->logMsg("E",
+            "Plugin ini file <$config> seems broken!"
+        );
+        return;
+    }
+    # sanity check for tools' existence:
+    if(not( -f "$tdir/$tool" and -x "$tdir/$tool")) {
+        $this->logMsg("E",
+            "Plugin <$name>: tool <$tdir/$tool> is not executable!"
+        );
+        $this->logMsg("I",
+            "Check if package <$tpack> is installed."
+        );
+        return;
+    }
+    my $params = "";
+    foreach my $p(@params) {
+        $p = $this->collect()->productData()->_substitute("$p");
+        $params .= "$p ";
+    }
+    # add local kwd files as argument
+    my $extrafile = abs_path($this->collect()->{m_xml}->{xmlOrigFile});
+    $extrafile =~ s/.kiwi$/.kwd/x;
+    if (-f $extrafile) {
+        $this->logMsg("W", "Found extra tags file $extrafile.");
+        $params .= "-T $extrafile ";
+    }
+    $this->name($name);
+    $this->order($order);
+    $this->{m_tool} = $tool;
+    $this->{m_tooldir} = $tdir;
+    $this->{m_toolpack} = $tpack;
+    $this->{m_createrepo} = $createrepo;
+    $this->{m_rezip} = $rezip;
+    $this->{m_params} = $params;
+    $this->{m_compress} = $gzip;
+    if($enable != 0) {
+        $this->ready(1);
+    }
+    return $this;
+}
+
+sub execute {
+    my $this = shift;
+    if(not ref($this)) {
+        return;
+    }
+    if($this->{m_ready} == 0) {
+        return 0
+    }
+    my $coll = $this->{m_collect};
+    my $basesubdirs = $coll->basesubdirs();
+    if(not defined($basesubdirs)) {
+        ## prevent crash when dereferencing
+        $this->logMsg("E",
+            "<basesubdirs> is undefined! Skipping <$this->name()>"
+        );
+        return 0;
+    }
+    foreach my $dirlist($this->getSubdirLists()) {
+        my ($s,$m) = $this->executeDir(sort @{$dirlist});
+    }
+    return 0;
+}
+
+sub executeDir {
+    my @params = @_;
+    my $this     = shift @params;
+    my @paths    = @params;
+    my $call;
+    my $status;
+    my $cmd;
+    if(!@paths) {
+        $this->logMsg("W", "Empty path list!");
+        return 0;
+    }
+    my $coll  = $this->{m_collect};
+    my $datadir  = $coll->productData()->getInfo("DATADIR");
+    my $descrdir = $coll->productData()->getInfo("DESCRDIR");
+    my $cpeid = $coll->productData()->getInfo("CPEID");
+    my $repoid = $coll->productData()->getInfo("REPOID");
+    my $createrepomd = $coll->productData()->getVar("CREATE_REPOMD");
+    my $metadataonly = $coll->productData()->getVar("RPMHDRS_ONLY");
+    my $targetdir;
+    my $newtargetdir;
+    my $params = "$this->{m_params} -H" ? $metadataonly eq "true" : "$this->{m_params}";
+    ## this ugly bit creates a parameter string from a list of directories:
+    # param = -d <dir1> -d <dir2> ...
+    # the order is important. Idea: use map to make hash <dir> => -d for
+    # all subdirs not ending with "0" (those are for metafile unpacking
+    # only). The result is evaluated in list context be reverse, so
+    # there's a list looking like "<dir_N> -d ... <dir1> -d" which is
+    # reversed again, making the result '-d', '<dir1>', ..., '-d', '<dir_N>'",
+    # after the join as string.
+    # ---
+    if ($descrdir && $descrdir ne "/") {
+        my $pathlist = "-d ".join(' -d ', map{$_."/".$datadir}(@paths));
+        $this->logMsg("I",
+            "Calling ".$this->name()." for directories <@paths>:"
+        );
+        $targetdir = $paths[0]."/".$descrdir;
+        $cmd = "$this->{m_tooldir}/$this->{m_tool} "
+            . "$pathlist $params -o "
+            . $paths[0]
+            . "/"
+            . $descrdir;
+        $this->logMsg("I", "Executing command <$cmd>");
+        $call = $this -> callCmd($cmd);
+        $status = $call->[0];
+        if($status) {
+            my $out = join("\n",@{$call->[1]});
+            $this->logMsg("E",
+                "Called <$cmd> exit status <$status> output: $out"
+            );
+            return 0;
+        }
+    }
+    if ( $createrepomd && $createrepomd eq "true" ) {
+        my $distroname = $coll->productData()->getInfo("DISTRIBUTION")."."
+                . $coll->productData()->getInfo("VERSION");
+        my $result = $this -> createRepositoryMetadata(
+            \@paths, $repoid, $distroname, $cpeid, $datadir, $targetdir
+        );
+        # return values 0 || 1 indicates an error
+        if ($result != 2) {
+            return $result;
+        }
+    }
+    return 1 unless $descrdir;
+    return 1 unless $targetdir;
+    # insert translation files
+    my $trans_dir  = '/usr/share/locale/en_US/LC_MESSAGES';
+    my $trans_glob = 'package-translations-*.mo';
+    foreach my $trans (glob($trans_dir.'/'.$trans_glob)) {
+        $trans = basename($trans, ".mo");
+        $trans =~ s,.*-,,x;
+        $cmd = "/usr/bin/translate_packages.pl $trans "
+            . "< $targetdir/packages.en "
+            . "> $targetdir/packages.$trans";
+        $call = $this -> callCmd($cmd);
+        $status = $call->[0];
+        if($status) {
+            my $out = join("\n",@{$call->[1]});
+            $this->logMsg("E",
+                "Called <$cmd> exit status: <$status> output: $out"
+            );
+            return 1;
+        }
+    }
+    # one more time for english to insert possible EULAs
+    $cmd = "/usr/bin/translate_packages.pl en "
+        . "< $targetdir/packages.en "
+        . "> $targetdir/packages.en.new && "
+        . "mv $targetdir/packages.en.new $targetdir/packages.en";
+    $call = $this -> callCmd($cmd);
+    $status = $call->[0];
+    if ($status) {
+        my $out = join("\n",@{$call->[1]});
+        $this->logMsg("E",
+            "Called <$cmd> exit status: <$status> output: $out"
+        );
+        return 1;
+    }
+    if (-x "/usr/bin/openSUSE-appstream-process") {
+        foreach my $p (@paths) {
+            $cmd = "/usr/bin/openSUSE-appstream-process";
+            $cmd .= " $p";
+            $cmd .= " $p/$descrdir";
+            $call = $this -> callCmd($cmd);
+            $status = $call->[0];
+            my $out = join("\n",@{$call->[1]});
+            $this->logMsg("I",
+                "Called <$cmd> exit status: <$status> output: $out"
+            );
+        };
+    }
+    if($this->{m_compress} =~ m{yes}i) {
+        foreach my $pfile(glob("$targetdir/packages*")) {
+            if(system("gzip", "--rsyncable", "$pfile") == 0) {
+                unlink "$targetdir/$pfile";
+            } else {
+                $this->logMsg("W",
+                    "Can't compress file <$targetdir/$pfile>!"
+                );
+            }
+        }
+    }
+    return 1;
+}
+
+sub createRepositoryMetadata {
+    my @params = @_;
+    my $this       = $params[0];
+    my $paths      = $params[1];
+    my $repoid     = $params[2];
+    my $distroname = $params[3];
+    my $cpeid      = $params[4];
+    my $datadir    = $params[5];
+    my $targetdir  = $params[6];
+    my $cmd;
+    my $call;
+    my $status;
+    foreach my $p (@{$paths}) {
+        $cmd = "$this->{m_createrepo}";
+        $cmd .= " --unique-md-filenames";
+        $cmd .= " --checksum=sha256";
+        $cmd .= " --no-database";
+        $cmd .= " --repo=\"$repoid\"" if $repoid;
+        $cmd .= " --distro=\"$cpeid,$distroname\"" if $cpeid && $distroname;
+        $cmd .= " $p/$datadir";
+        $this->logMsg("I", "Executing command <$cmd>");
+        $call = $this -> callCmd($cmd);
+        $status = $call->[0];
+        if($status) {
+            my $out = join("\n",@{$call->[1]});
+            $this->logMsg("E",
+                "Called <$cmd> exit status: <$status> output: $out"
+            );
+            return 0;
+        }
+        $cmd = "$this->{m_rezip} $p/$datadir ";
+        $this->logMsg("I", "Executing command <$cmd>");
+        $call = $this -> callCmd($cmd);
+        $status = $call->[0];
+        if($status) {
+            my $out = join("\n",@{$call->[1]});
+            $this->logMsg("E",
+                "Called <$cmd> exit status: <$status> output: $out"
+            );
+            return 0;
+        }
+        if (-x "/usr/bin/openSUSE-appstream-process")
+        {
+            $cmd = "/usr/bin/openSUSE-appstream-process";
+            $cmd .= " $p/$datadir";
+            $cmd .= " $p/$datadir/repodata";
+
+            $call = $this -> callCmd($cmd);
+            $status = $call->[0];
+            my $out = join("\n",@{$call->[1]});
+            $this->logMsg("I",
+                "Called $cmd exit status: <$status> output: $out"
+            );
+        }
+        if ( -f "/usr/bin/add_product_susedata" ) {
+            my $kwdfile = abs_path(
+                $this->collect()->{m_xml}->{xmlOrigFile}
+            );
+            $kwdfile =~ s/.kiwi$/.kwd/x;
+            $cmd = "/usr/bin/add_product_susedata";
+            $cmd .= " -u"; # unique filenames
+            $cmd .= " -k $kwdfile";
+            $cmd .= " -e /usr/share/doc/packages/eulas";
+            $cmd .= " -d $p/$datadir";
+            $this->logMsg("I", "Executing command <$cmd>");
+            $call = $this -> callCmd($cmd);
+            $status = $call->[0];
+            if($status) {
+                my $out = join("\n",@{$call->[1]});
+                $this->logMsg("E",
+                    "Called <$cmd> exit status: <$status> output: $out"
+                );
+                return 0;
+            }
+        }
+    }
+    return 2;
+}
+
+1;

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIEulaPlugin.ini
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIEulaPlugin.ini
@@ -1,0 +1,28 @@
+# INI file for KIWIEulaPlugin.pm
+# Written by Jan-Christoph Bornschlegel <jcborn@suse.de>
+# Provides configuration for the plugin:
+# - required binaries
+# - required directories
+# - target file name
+# - unique order number
+# - package name providing the required binaries, if packaged
+
+[base]
+name = KIWIEulaPlugin
+order = 3
+tool = packages2eula.pl
+tooldir = /usr/bin
+toolpack = inst-source-utils
+defaultenable = 1
+sourcefile = packages.en.gz
+sourcedir = $DESCRDIR
+
+[option]
+in = -i
+out = -o
+packfile = -p
+
+[target]
+targetfile = EULA.txt
+targetdir = $PRODUCT_DIR
+

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIEulaPlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIEulaPlugin.pm
@@ -1,0 +1,171 @@
+################################################################
+# Copyright (c) 2014 SUSE
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file LICENSE); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+package KIWIEulaPlugin;
+
+use strict;
+use warnings;
+
+use base "KIWIBasePlugin";
+use Config::IniFiles;
+use FileHandle;
+
+sub new {
+    # ...
+    # Create a new KIWIEulaPlugin object
+    # creates patterns file
+    # ---
+    my $class   = shift;
+    my $handler = shift;
+    my $config  = shift;
+    my $configpath;
+    my $configfile;
+    my $this = KIWIBasePlugin -> new($handler);
+    bless ($this, $class);
+    if ($config =~ m{(.*)/([^/]+)$}x) {
+        $configpath = $1;
+        $configfile = $2;
+    }
+    if ((! $configpath) || (! $configfile)) {
+        $this->logMsg("E",
+            "wrong parameters in plugin initialisation\n"
+        );
+        return;
+    }
+    ## plugin content:
+    #-----------------
+    #[base]
+    # name = KIWIEulaPlugin
+    # order = 3
+    # src = packages.en[.gz]
+    # srcdir = $DESCRDIR
+    # tool = packages2eula.pl
+    # tooldir = /usr/bin
+    # toolpack = inst-source-utils
+    # defaultenable = 1
+    #
+    #[target]
+    # targetfile = EULA.txt
+    # targetdir = $PRODUCT_DIR
+    #
+    my $ini = Config::IniFiles -> new(
+        -file => "$configpath/$configfile"
+    );
+    my $name     = $ini->val('base', 'name');
+    my $order    = $ini->val('base', 'order');
+    my $tool     = $ini->val('base', 'tool');
+    my $tooldir  = $ini->val('base', 'tooldir');
+    my $toolpack = $ini->val('base', 'toolpack');
+    my $enable   = $ini->val('base', 'defaultenable');
+    my $src      = $ini->val('base', 'sourcefile');
+    my $srcdir   = $ini->val('base', 'sourcedir');
+    my $iopt     = $ini->val('option', 'in');
+    my $oopt     = $ini->val('option', 'out');
+    my $popt     = $ini->val('option', 'packfile');
+    my $target   = $ini->val('target', 'targetfile');
+    my $targetdir= $ini->val('target', 'targetdir');
+    # if any of those isn't set, complain!
+    if(not defined($name)
+        or not defined($order)
+        or not defined($tool)
+        or not defined($tooldir)
+        or not defined($toolpack)
+        or not defined($enable)
+        or not defined($target)
+        or not defined($targetdir)
+        or not defined($iopt)
+        or not defined($oopt)
+        or not defined($popt)
+    ) {
+        $this->logMsg("E",
+            "Plugin ini file <$config> seems broken!\n"
+        );
+        return;
+    }
+    $this->name($name);
+    $this->order($order);
+    $targetdir = $this->collect()
+        ->productData()->_substitute("$targetdir");
+    $srcdir = $this->collect()
+        ->productData()->_substitute("$srcdir");
+    $this->{m_target} = $target;
+    if($enable != 0) {
+        $this->ready(1);
+    }
+    $this->{m_source} = $src;
+    $this->{m_srcdir} = $srcdir;
+    $this->{m_tool} = $tool;
+    $this->{m_toolpath} = $this->collect()
+        ->productData()->_substitute("$tooldir");
+    $this->{m_toolpack} = $toolpack;
+    $this->{m_iopt} = $iopt;
+    $this->{m_oopt} = $oopt;
+    $this->{m_popt} = $popt;
+    $this->requiredDirs($srcdir, $targetdir);
+    return $this;
+}
+
+sub execute {
+    my $this = shift;
+    if(not ref($this)) {
+        return;
+    }
+    my $retval = 0;
+    if($this->{m_ready} == 0) {
+        return $retval;
+    }
+    my @dirlist = $this->getSubdirLists();
+    return unless @dirlist && $dirlist[0] &&
+        ref ($dirlist[0] eq "ARRAY") && $dirlist[0]->[0];
+    my $dirname = $dirlist[0]->[0];
+    my $srcdir = $dirname."/".$this->{m_requireddirs}->[0];
+    my $targetdir = $dirname."/".$this->{m_requireddirs}->[1];
+    my $SRCFILE = FileHandle -> new();
+    if (! $SRCFILE -> open ("<$srcdir/$this->{m_source}")) {
+        $this->logMsg("E",
+            "PatternsPlugin: cannot read <$srcdir/".$this->{m_source}.">"
+        );
+        $this->logMsg("I", "Skipping plugin <".$this->name().">");
+        return $retval;
+    }
+    $SRCFILE -> close();
+    my $cmd = "$this->{m_toolpath}/$this->{m_tool} "
+        . "$this->{m_iopt} $targetdir/$this->{m_target} "
+        . "$this->{m_popt} $srcdir/$this->{m_source} "
+        . "$this->{m_oopt} $targetdir/$this->{m_target}.new";
+    my $call = $this -> callCmd($cmd);
+    my $status = $call->[0];
+    my @data = @{$call->[1]};
+    $this->logMsg("I", "output of command $this->{m_tool}:\n");
+    foreach my $l(@data) {
+        $this->logMsg("I", "\t$l\n");
+    }
+    if($status) {
+        $this->logMsg("I",
+            "command $this->{m_tool} exited with <$status>\n"
+        );
+    } else {
+        $this->logMsg("I",
+            "command $this->{m_tool} exited successfully.\n"
+        );
+        $retval = 1;
+    }
+    return $retval;
+}
+
+1;

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIMiniIsoPlugin.ini
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIMiniIsoPlugin.ini
@@ -1,0 +1,14 @@
+# INI file for KIWIMiniIsoPlugin.pm
+# Written by Jan-Christoph Bornschlegel <jcborn@suse.de>
+# Provides configuration for the plugin:
+# - required binaries
+# - required directories
+# - target file name
+# - unique order number
+# - package name providing the required binaries, if packaged
+
+[base]
+name = KIWIMiniIsoPlugin
+order = 5
+defaultenable = 1
+

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIMiniIsoPlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIMiniIsoPlugin.pm
@@ -142,7 +142,8 @@ sub execute {
         $this->removeMediaCheck($isolxfiles[0]);
     }
 
-    $this -> updateInitRDNET($repoloc);
+    $this -> updateInitRDNET("./etc/linuxrc.d/10_repo", "defaultrepo=$repoloc\n");
+    $this -> updateInitRDNET("./etc/linuxrc.d/15_kexec", "kexec=1\n");
 
     my @gfxbootfiles;
     find(
@@ -320,7 +321,7 @@ sub _makecpiohead {
 # download.opensuse.org
 # https://bugzilla.opensuse.org/show_bug.cgi?id=916175
 sub updateInitRDNET {
-    my ($this, $repoloc) = @_;
+    my ($this, $file, $content) = @_;
 
     $this -> logMsg("I", "prepare initrd for NET iso");
 
@@ -331,10 +332,8 @@ sub updateInitRDNET {
     # hardcode for now
     $zipper = "xz --check=crc32";
 
-    my $linuxrc = "defaultrepo=$repoloc\n";
-
-    my ($cpio, $pad) = _makecpiohead('./etc/linuxrc.d/10_repo', [0, 0, oct(644), 1, 0, 0, 0, length($linuxrc), 0, 0, 0]);
-    $cpio .= $linuxrc;
+    my ($cpio, $pad) = _makecpiohead($file, [0, 0, oct(644), 1, 0, 0, 0, length($content), 0, 0, 0]);
+    $cpio .= $content;
     $cpio .= $pad if $pad;
     $cpio .= _makecpiohead();
 

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIMiniIsoPlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIMiniIsoPlugin.pm
@@ -1,0 +1,377 @@
+################################################################
+# Copyright (c) 2014, 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file LICENSE); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+package KIWIMiniIsoPlugin;
+
+use strict;
+use warnings;
+
+use base "KIWIBasePlugin";
+use Data::Dumper;
+use Config::IniFiles;
+use File::Find;
+use FileHandle;
+use Carp;
+use File::Basename qw /dirname/;
+
+sub new {
+    # ...
+    # Create a new KIWIMiniIsoPlugin object
+    # ---
+    my $class   = shift;
+    my $handler = shift;
+    my $config  = shift;
+    my $configpath;
+    my $configfile;
+    my $this = KIWIBasePlugin -> new($handler);
+    bless ($this, $class);
+    if ($config =~ m{(.*)/([^/]+)$}x) {
+        $configpath = $1;
+        $configfile = $2;
+    }
+    if ((! $configpath) || (! $configfile)) {
+        $this->logMsg("E",
+            "wrong parameters in plugin initialisation\n"
+        );
+        return;
+    }
+    ## plugin content:
+    #-----------------
+    #[base]
+    # name = KIWIEulaPlugin
+    # order = 3
+    # defaultenable = 1
+    #
+    #[target]
+    # targetfile = content
+    # targetdir = $PRODUCT_DIR
+    # media = (list of numbers XOR "all")
+    #
+    my $ini = Config::IniFiles -> new (
+        -file => "$configpath/$configfile"
+    );
+    my $name   = $ini->val('base', 'name');
+    my $order  = $ini->val('base', 'order');
+    my $enable = $ini->val('base', 'defaultenable');
+    # if any of those isn't set, complain!
+    if (not defined($name)
+        or not defined($order)
+        or not defined($enable)
+    ) {
+        $this->logMsg("E",
+            "Plugin ini file <$config> seems broken!\n"
+        );
+        return;
+    }
+    $this->name($name);
+    $this->order($order);
+    if($enable != 0) {
+        $this->ready(1);
+    }
+    return $this;
+}
+
+sub execute {
+    my $this = shift;
+    if(not ref($this)) {
+        return;
+    }
+    my $retval = 0;
+    if($this->{m_ready} == 0) {
+        return $retval;
+    }
+    my $repoloc = $this->collect()->productData()->getOpt("REPO_LOCATION");
+    my $ismini = $this->collect()->productData()->getVar("FLAVOR");
+    if(not defined($ismini)) {
+        $this->logMsg("W", "FLAVOR not set?");
+        return $retval;
+    }
+    if ($ismini !~ m{mini}i) {
+        $this->logMsg("I",
+            "Nothing to do for media type <$ismini>"
+        );
+        return $retval;
+    }
+    my ($srv, $path);
+    if (not defined($repoloc)) {
+        $this->logMsg("I",
+            "<REPO_LOCATION> is unset, boot protocol will be set to 'slp'!"
+        );
+    } else {
+        if ($repoloc =~ m{^http://([^/]+)/(.+)}x) {
+            ($srv, $path) = ($1, $2);
+        }
+        if(not defined($srv) or not defined($path)) {
+            $this->logMsg("W",
+                "Parsing repo-location=<$repoloc> failed!"
+            );
+            return $retval;
+        }
+    }
+    
+    my @rootfiles;
+    find(
+        sub { find_cb($this, '.*/root$', \@rootfiles) },
+        $this->handler()->collect()->basedir()
+    );
+    if (@rootfiles) {
+        $this->removeInstallSystem($rootfiles[0]);
+    }
+
+    my @isolxfiles;
+    find(
+        sub { find_cb($this, '.*/isolinux.cfg$', \@isolxfiles) },
+        $this->handler()->collect()->basedir()
+    );
+    if (@isolxfiles) {
+        $this->removeMediaCheck($isolxfiles[0]);
+    }
+
+    $this -> updateInitRDNET($repoloc);
+
+    my @gfxbootfiles;
+    find(
+        sub { find_cb($this, '.*/gfxboot\.cfg$', \@gfxbootfiles) },
+        $this->handler()->collect()->basedir()
+    );
+
+    if (!@gfxbootfiles) {
+        my $msg = "No gfxboot.cfg file found! "
+            . "This _MIGHT_ be ok for S/390. "
+            . "Please verify <installation-images> package(s)";
+        $this->logMsg("W", $msg);
+        return $retval;
+    }
+    $retval = $this -> updateGraphicsBootConfig (
+        \@gfxbootfiles, $repoloc, $srv, $path
+    );
+
+    return $retval;
+}
+
+sub removeInstallSystem {
+    my $this = shift;
+    my $rootfile = shift;
+
+    print STDERR "RF $rootfile\n";
+    my $rootdir = dirname($rootfile);
+    $this->logMsg("I", "removing files from <$rootdir>");
+    foreach my $file (glob("$rootdir/*")) {
+        if (-f $file && $file !~ m,/(efi|linux|initrd)$,) {
+            $this->logMsg("I", "removing <$file>");
+	    unlink $file;
+        }
+    }
+    return $this;
+}
+
+sub removeMediaCheck {
+	my $this = shift;
+	my $cfg = shift;
+
+	$this->logMsg("I", "Processing file <$cfg>: ");
+
+    my $CFG = FileHandle -> new();
+    if (! $CFG -> open($cfg)) {
+		$this->logMsg("E", "Cant open file <$cfg>!");
+		return;
+	}
+
+    my $CFGNEW = FileHandle -> new();
+    if (! $CFGNEW -> open(">$cfg.new")) {
+		$this->logMsg("E", "Cant open file <$cfg.new>!");
+		return;
+	}
+
+	my $mediacheck = -1;
+	while ( <$CFG> ) {
+		chomp;
+
+		if (m/label mediachk/) {
+			$mediacheck = 1;
+		}
+		if ($mediacheck == 1 && m/^\s*$/) {
+			$mediacheck = -1;
+		}
+
+		if ($mediacheck == 1) {
+			print $CFGNEW "#$_\n";
+		} else {
+			print $CFGNEW "$_\n";
+		}
+	}
+
+	$CFG -> close();
+	$CFGNEW -> close();
+
+	unlink $cfg;
+	rename "$cfg.new", $cfg;
+    return $this;
+}
+
+sub updateGraphicsBootConfig {
+    my $this = shift;
+    my $gfxbootfiles = shift;
+    my $repoloc = shift;
+    my $srv = shift;
+    my $path = shift;
+    my $retval = 0;
+    foreach my $cfg(@{$gfxbootfiles}) {
+        $this->logMsg("I", "Processing file <$cfg>: ");
+        my $F = FileHandle -> new();
+        if (! $F -> open($cfg)) {
+            $this->logMsg("E", "Cant open file <$cfg>!");
+            next;
+        }
+        my @lines = <$F>;
+        $F -> close();
+        chomp(@lines);
+        my $install = -1;
+        my $ihs = -1;
+        my $ihp = -1;
+        my $i = -1;
+        foreach my $line(@lines) {
+            $i++;
+            next if $line !~ m{^install}x;
+            if($line =~ m{^install=.*}x) {
+                $install = $i;
+            }
+            if ($line =~ m{^install.http.server=+}x) {
+                $ihs = $i;
+            }
+            if($line =~ m{^install.http.path=+}x) {
+                $ihp = $i;
+            }
+        }
+        if(!$repoloc) {
+            if($install == -1) {
+                push @lines, "install=slp";
+            } else {
+                $lines[$install] =~ s{^install.*}{install=slp}x;
+            }
+        } elsif($srv) {
+            if($ihs == -1) {
+                push @lines, "install.http.server=$srv";
+            } else {
+                $lines[$ihs] =~ s{^(install.http.server).*}{$1=$srv}x;
+            }
+            if($ihp == -1) {
+                push @lines, "install.http.path=$path";
+            } else {
+                $lines[$ihp] =~ s{^(install.http.path).*}{$1=$path}x;
+            }
+            if($install == -1) {
+                push @lines, "install=http";
+            } else {
+                $lines[$install] =~ s{^install.*}{install=http}x;
+            }
+        }
+        unlink $cfg;
+        if (! $F -> open(">$cfg")) {
+            $this->logMsg("E", "Cant open file for writing <$cfg>!");
+            next;
+        }
+        foreach(@lines) {
+            print $F "$_\n";
+        }
+        $F -> close();
+        $retval++;
+    }
+    return $retval;
+}
+
+# borrowed from obs with permission from mls@suse.de to license as
+# GPLv2+
+sub _makecpiohead {
+    my ($name, $s) = @_;
+    return "07070100000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000b00000000TRAILER!!!\0\0\0\0" if !$s;
+    #        magic ino
+    my $h = "07070100000000";
+    # mode                S_IFREG
+    $h .= sprintf("%08x", oct(100000) | $s->[2]&oct(777));
+    #      uid     gid     nlink
+    $h .= "000000000000000000000001";
+    $h .= sprintf("%08x%08x", $s->[9], $s->[7]);
+    $h .= "00000000000000000000000000000000";
+    $h .= sprintf("%08x", length($name) + 1);
+    $h .= "00000000$name\0";
+    $h .= substr("\0\0\0\0", (length($h) & 3)) if length($h) & 3;
+    my $pad = '';
+    $pad = substr("\0\0\0\0", ($s->[7] & 3)) if $s->[7] & 3;
+    return ($h, $pad);
+}
+
+# append a config snippet to initrd that instructs linuxrc to use
+# download.opensuse.org
+# https://bugzilla.opensuse.org/show_bug.cgi?id=916175
+sub updateInitRDNET {
+    my ($this, $repoloc) = @_;
+
+    $this -> logMsg("I", "prepare initrd for NET iso");
+
+    my $zipper = KIWIGlobals -> instance() -> getKiwiConfig() -> {IrdZipperCommand};
+
+    # FIXME: looks like IrdZipperCommand is not configured correctly
+    # in openSUSE product files to match installation-images so
+    # hardcode for now
+    $zipper = "xz --check=crc32";
+
+    my $linuxrc = "defaultrepo=$repoloc\n";
+
+    my ($cpio, $pad) = _makecpiohead('./etc/linuxrc.d/10_repo', [0, 0, oct(644), 1, 0, 0, 0, length($linuxrc), 0, 0, 0]);
+    $cpio .= $linuxrc;
+    $cpio .= $pad if $pad;
+    $cpio .= _makecpiohead();
+
+    my @initrdfiles;
+    find(
+        sub { find_cb($this, '.*/initrd$', \@initrdfiles) },
+        $this->handler()->collect()->basedir()
+    );
+
+    $this -> logMsg("E", "no initrds found!") unless @initrdfiles;
+
+    for my $initrd (@initrdfiles) {
+        $this -> logMsg("I", "updating $initrd with $repoloc");
+        my $fh  = FileHandle -> new();
+        if (! $fh -> open("|$zipper -c >> $initrd")) {
+        #if (! $fh -> open(">$initrd.append")) {
+            croak "Cant launch $zipper for $initrd: $!";
+        }
+        print $fh $cpio;
+        $fh -> close();
+    }
+    return;
+}
+
+sub find_cb {
+    my $this = shift;
+    return if not ref($this);
+
+    my $pat = shift;
+    my $listref = shift;
+    if(not defined($listref) or not defined($pat)) {
+        return;
+    }
+    if($File::Find::name =~ m{$pat}x) {
+        push @{$listref}, $File::Find::name;
+    }
+    return $this;
+}
+
+1;

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIPromoDVDPlugin.ini
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIPromoDVDPlugin.ini
@@ -1,0 +1,5 @@
+[base]
+name = KIWIPromoDVDPlugin
+order = 7
+defaultenable = 1
+

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIPromoDVDPlugin.pm
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/KIWIPromoDVDPlugin.pm
@@ -1,0 +1,121 @@
+################################################################
+# Copyright (c) 2014 SUSE
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file LICENSE); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+package KIWIPromoDVDPlugin;
+
+use strict;
+use warnings;
+
+use base "KIWIBasePlugin";
+use Data::Dumper;
+use Config::IniFiles;
+use File::Find;
+use File::Basename;
+
+sub new {
+    # ...
+    # Create a new KIWIPromoDVDPlugin object
+    # ---
+    my $class   = shift;
+    my $handler = shift;
+    my $config  = shift;
+    my $configpath;
+    my $configfile;
+    my $this = KIWIBasePlugin -> new($handler);
+    bless ($this, $class);
+
+    if ($config =~ m{(.*)/([^/]+)$}x) {
+        $configpath = $1;
+        $configfile = $2;
+    }
+    if ((! $configpath) || (! $configfile)) {
+        $this->logMsg("E",
+            "wrong parameters in plugin initialisation\n"
+        );
+        return;
+    }
+    ## plugin content:
+    #-----------------
+    #[base]
+    # name = KIWIEulaPlugin
+    # order = 3
+    # defaultenable = 1
+    #
+    #[target]
+    # targetfile = content
+    # targetdir = $PRODUCT_DIR
+    # media = (list of numbers XOR "all")
+    #
+    my $ini = Config::IniFiles -> new(
+        -file => "$configpath/$configfile"
+    );
+    my $name   = $ini->val('base', 'name');
+    my $order  = $ini->val('base', 'order');
+    my $enable = $ini->val('base', 'defaultenable');
+    # if any of those isn't set, complain!
+    if(not defined($name)
+        or not defined($order)
+        or not defined($enable)
+    ) {
+        $this->logMsg("E",
+            "Plugin ini file <$config> seems broken!\n"
+        );
+        return;
+    }
+    $this->name($name);
+    $this->order($order);
+    if($enable != 0) {
+        $this->ready(1);
+    }
+    return $this;
+}
+
+sub execute {
+    my $this = shift;
+    if(not ref($this)) {
+        return;
+    }
+    if($this->{m_ready} == 0) {
+        return 0;
+    }
+    my $ismini = $this->collect()
+        ->productData()->getVar("FLAVOR");
+    if(not defined($ismini)) {
+        $this->logMsg("W", "FLAVOR not set?");
+        return 0;
+    }
+    if ($ismini !~ m{dvd-promo}ix) {
+        return 0;
+    }
+    my $medium = $this->collect()
+        ->productData()->getVar("MEDIUM_NAME");
+    find( sub { 
+            if (m/initrd.liv/x) { 
+                my $cd = $File::Find::name; 
+                system("mkdir -p boot; echo $medium > boot/mbrid");
+                system("echo boot/mbrid | cpio --create --format=newc --quiet | gzip -9 -f >> $cd");
+                system("rm boot/mbrid; rmdir boot");
+                $this->logMsg("I", "updated $cd");
+            }
+        },
+        $this->handler()->collect()->basedir()
+    );
+    return 0;
+}
+
+1;

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/LICENSE
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/LICENSE
@@ -1,0 +1,342 @@
+
+        GNU GENERAL PUBLIC LICENSE
+           Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                          675 Mass Ave, Cambridge, MA 02139, USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+          Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+        GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+          NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+         END OF TERMS AND CONDITIONS
+
+  Appendix: How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 19yy  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) 19yy name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.
+
+-------------------------------------------------------------------------

--- a/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/Makefile
+++ b/distribution/kiwi-instsource-plugins-openSUSE-Tumbleweed/Makefile
@@ -1,0 +1,25 @@
+# /.../
+# Copyright (c) 2006 SUSE LINUX Products GmbH. All rights reserved.
+# Author: Marcus Schaefer <ms@suse.de>, 2006
+#
+# Makefile for OpenSuSE - KIWI Image System InstSource Plugins
+# ---
+buildroot = /
+kiwi_prefix = ${buildroot}/usr/share/kiwi/
+
+#============================================
+# Variables... 
+#--------------------------------------------
+KIWIPLUGINVZ  = ${kiwi_prefix}/modules/plugins/suse-13.2
+
+install:
+	#============================================
+	# Install base directories
+	#--------------------------------------------
+	install -d -m 755 ${KIWIPLUGINVZ}
+
+	#============================================
+	# Install plugins
+	#--------------------------------------------
+	install -m 644 ./*.pm  ${KIWIPLUGINVZ}
+	install -m 644 ./*.ini ${KIWIPLUGINVZ}


### PR DESCRIPTION
This is intentionally done in two commits:

1) realy duplicate 13,2 to Tumbleweed - separating this out gives the freedom to not break other setups relying on this (kiwi-instsource-plugins-openSUSE is so far also used in Leap 42.2)
2) Update KIWIMini to add an additional file into initrd: instruct linuxrc to use kexec=1 (that is: download initrd from the network as well and respawn the installer)

note: I had close to no chance yet to test this... once we have a kiwi-instsoource-plugins=openSUSE-Tumbleweed in Tumbleweed I can adjust the _product definitions to use the new templates