### PR TITLE
there is no state UP in ip link ls eth0 output

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -7433,7 +7433,7 @@ function waitForLinkUp {
     local dev=$1
     local check=0
     while true;do
-        ip link ls $dev | grep -qi "state UP"
+        ip link ls $dev | grep -qi "UP"
         if [ $? = 0 ];then
             sleep 1; return 0
         fi


### PR DESCRIPTION

Here is the output from the tumbleweed client:
ip link ls eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 08:00:27:3d:5c:c5 brd ff:ff:ff:ff:ff:ff

This results in loop going on forever as linuxrc is checking for grep -i 'state UP'
[boot.txt](https://github.com/openSUSE/kiwi/files/478114/boot.txt)

