### PR TITLE
Use more reliable tool to detect link status, fall back to ip if it is not available

### DIFF
--- a/metadata/KIWIConfig.xml
+++ b/metadata/KIWIConfig.xml
@@ -131,6 +131,7 @@
         <file name="init"/>
         <file name="insmod"/>
         <file name="id"/>
+        <file name="ifplugstatus"/>
         <file name="iucv_configure"/>
         <file name="kexec"/>
         <file name="kill"/>

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -7434,10 +7434,10 @@ function waitForLinkUp {
     local check=0
     if [ -x /usr/sbin/ifplugstatus ]; then
         linkstatus=ifplugstatus
-	linkgrep="link beat detected"
+        linkgrep="link beat detected"
     else
         linkstatus="ip link ls" 
-	linkgrep="state UP"
+        linkgrep="state UP"
     fi
     while true;do
         $linkstatus $dev | grep -qi "$linkgrep"

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -7432,8 +7432,15 @@ function waitForLinkUp {
     local IFS=$IFS_ORIG
     local dev=$1
     local check=0
+    if [ -x /usr/sbin/ifplugstatus ]; then
+        linkstatus=ifplugstatus
+	linkgrep="link beat detected"
+    else
+        linkstatus="ip link ls" 
+	linkgrep="state UP"
+    fi
     while true;do
-        ip link ls $dev | grep -qi "state UP"
+        $linkstatus $dev | grep -qi "$linkgrep"
         if [ $? = 0 ];then
             sleep 1; return 0
         fi

--- a/system/boot/ix86/netboot/suse-tumbleweed/config.xml
+++ b/system/boot/ix86/netboot/suse-tumbleweed/config.xml
@@ -196,6 +196,7 @@
         <package name="psmisc"/>
         <package name="sysvinit-tools"/>
         <package name="e2fsprogs"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete" profiles="default,diskless,xen">
         <package name="cracklib-dict-full"/>


### PR DESCRIPTION
On some clients 'ip link ls' shows 'state UNKNOWN' using ifplugstatus seems to be more reliable so prefer that if it is available, ifplugd which provides ifplugstatus command is only added to tumbleweed config.xml at the moment, may be it should be added to other distrbiutions  netboot config.xml as well.

This is proper version of https://github.com/openSUSE/kiwi/pull/595
boot.kiwi log broken client: https://github.com/openSUSE/kiwi/files/478114/boot.txt
boot.kiwi log with this fix applied:
[boot.txt](https://github.com/openSUSE/kiwi/files/478640/boot.txt)
