### PR TITLE
do not use ramdisk for rw, using tmpfs is more efficient

### DIFF
--- a/system/boot/ix86/netboot/suse-linuxrc
+++ b/system/boot/ix86/netboot/suse-linuxrc
@@ -694,7 +694,7 @@ else
             systemException "No NBD export name specified" "reboot"
         fi
         if [ -z "$nbdwriteDevice" ];then
-            nbdwriteDevice="/dev/ram1"
+            nbdwriteDevice="tmpfs"
         fi
         waitForBlockDevice $nbdDevice
         if [ ! -b $nbdDevice ];then
@@ -775,7 +775,7 @@ else
         aoeRWDevice=`echo $AOEROOT | cut -d , -f 2`
         unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
         if [ -z "$aoeRWDevice" ] || [ "$aoeRODevice" = "$aoeRWDevice" ];then
-            aoeRWDevice=/dev/ram1
+            aoeRWDevice=tmpfs
         fi
         if ! modprobe aoe;then
             systemException "Failed to load AoE module" "reboot"

--- a/system/boot/ppc/netboot/suse-linuxrc
+++ b/system/boot/ppc/netboot/suse-linuxrc
@@ -694,7 +694,7 @@ else
             systemException "No NBD export name specified" "reboot"
         fi
         if [ -z "$nbdwriteDevice" ];then
-            nbdwriteDevice="/dev/ram1"
+            nbdwriteDevice="tmpfs"
         fi
         waitForBlockDevice $nbdDevice
         if [ ! -b $nbdDevice ];then
@@ -775,7 +775,7 @@ else
         aoeRWDevice=`echo $AOEROOT | cut -d , -f 2`
         unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
         if [ -z "$aoeRWDevice" ] || [ "$aoeRODevice" = "$aoeRWDevice" ];then
-            aoeRWDevice=/dev/ram1
+            aoeRWDevice=tmpfs
         fi
         if ! modprobe aoe;then
             systemException "Failed to load AoE module" "reboot"

--- a/system/boot/s390/netboot/suse-linuxrc
+++ b/system/boot/s390/netboot/suse-linuxrc
@@ -711,7 +711,7 @@ else
             systemException "No NBD export name specified" "reboot"
         fi
         if [ -z "$nbdwriteDevice" ];then
-            nbdwriteDevice="/dev/ram1"
+            nbdwriteDevice="tmpfs"
         fi
         waitForBlockDevice $nbdDevice
         if [ ! -b $nbdDevice ];then
@@ -792,7 +792,7 @@ else
         aoeRWDevice=`echo $AOEROOT | cut -d , -f 2`
         unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
         if [ -z "$aoeRWDevice" ] || [ "$aoeRODevice" = "$aoeRWDevice" ];then
-            aoeRWDevice=/dev/ram1
+            aoeRWDevice=tmpfs
         fi
         if ! modprobe aoe;then
             systemException "Failed to load AoE module" "reboot"


### PR DESCRIPTION
Defaulting to tmpfs has few advantages:
* RAM does not have to be reserved for ramdisk allowing applications to use RAM not use by the system.
* mkfs run is not needed on /dev/ram1