### PR TITLE
Added support for mkisofs in addition to genisoimage

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -925,7 +925,7 @@ sub setupInstallCD {
     my $attr = "-R -J -f -pad -joliet-long";
     if (-s $system >= 4294967296) {
         # install image is bigger than 4g, needs extra iso options
-        $attr .= " -allow-limited-size -udf -hfs -iso-level 3";
+        $attr .= " -udf -hfs -iso-level 3";
     }
     $attr .= " -V \"$volid\"";
     $attr .= " -A \"$this->{mbrid}\"";

--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -2263,10 +2263,13 @@ sub createImageLiveCD {
     if (! defined $gzip) {
         $attr = "-R -J -pad -joliet-long";
     }
-    if (($flags) && ($flags =~ /clic_udf|seed|overlay/)) {
-        $attr .= " -allow-limited-size -udf";
-    }
-    if (! defined $gzip) {
+    if ((($flags) && ($flags =~ /clic_udf|seed|overlay/)) &&
+	(defined $gzip)) {
+        $attr .= " -iso-level 3 -udf";
+    } elsif ((($flags) && ($flags =~ /clic_udf|seed|overlay/)) &&
+	(! defined $gzip)) {
+        $attr .= " -iso-level 4 -udf";
+    } elsif (! defined $gzip) {
         $attr .= " -iso-level 4";
     }
     if ($volid) {

--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -1007,7 +1007,7 @@ sub isols {
             $dir = $1;
             next;
         }
-        if(/^(.).*\s\[\s*(\d+)(\s+\d+)?\]\s+(.*?)\s*$/) {
+        if(/.*(-)[-rxw]{9}.*\s\[\s*(\d+)(\s+\d+)?\]\s+(.*?)\s*$/) {
             my $type = $1;
             $type = ' ' if $type eq '-';
             if($4 ne '.' && $4 ne '..') {
@@ -1412,7 +1412,7 @@ sub fixCatalog {
     my $t = (unpack "C", $entry2)[0];
     if ($t == 0x90 || $t == 0x91) {
         close $ISO;
-        return;
+        return $this;
     }
     substr($entry2, 12, 20) = pack "Ca19", 1, "UEFI (elilo)";
     if((unpack "C", $entry2)[0] == 0x88) {


### PR DESCRIPTION
Support for live iso images using mkisofs or genisoimage. Kiwi v7 always looks for a genisoimage executable in PATH, however now genisoimage can be a symlink to mkisofs. 

This PR is related to the issue bnc#997443.