### PR TITLE
Assemble mdraid

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -10525,6 +10525,15 @@ function pxeRaidAssemble {
         fi
         IFS=$IFS_ORIG
         mdadm --assemble --run /dev/md$mdcount $devices
+        if ! waitForStorageDevice /dev/md$mdcount; then
+            # start any array that has been partially assembled
+            mdadm -IRs
+            if ! waitForStorageDevice /dev/md$mdcount; then
+                systemException \
+                    "Failed to assemble raid array, too many devices missing" \
+                "reboot"
+            fi
+        fi
         mdadm -Db /dev/md$mdcount >> $conf
         mdcount=$((mdcount + 1))
     done

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -6125,7 +6125,7 @@ function partitionSize {
     local psizeBytes
     local psizeKBytes
     if [ -z "$diskDevice" ] || [ ! -e "$diskDevice" ];then
-        echo 1 ; return 1
+        echo 0 ; return 1
     fi
     psizeBytes=$(blockdev --getsize64 $diskDevice)
     psizeKBytes=$((psizeBytes / 1024))
@@ -7400,26 +7400,26 @@ function killShell {
 #--------------------------------------
 function waitForStorageDevice {
     # /.../
-    # function to check access on a storage device
-    # which could be a whole disk or a partition.
-    # the function will wait until the size of the
-    # storage device could be obtained or the timeout
-    # is reached. Default timeout is 60 seconds, however
-    # it can be set to different value by setting the
-    # DEVICE_TIMEOUT variable in the kernel command
-    # line.
+    # function to check access on a storage device which could be
+    # a whole disk or a partition. The function will wait until
+    # the size of the storage device could be obtained and is
+    # greater than zero or the timeout is reached. Default timeout
+    # is set to 60 seconds, however it can be set to different
+    # value by setting the DEVICE_TIMEOUT variable on the kernel
+    # command line.
     # ----
     local IFS=$IFS_ORIG
     local device=$1
     local check=0
     local limit=30
+    local storage_size=0
     if [[ $DEVICE_TIMEOUT =~ ^[0-9]+$ ]]; then
-	limit=$(((DEVICE_TIMEOUT + 1)/ 2))
+        limit=$(((DEVICE_TIMEOUT + 1)/ 2))
     fi
     udevPending
     while true;do
-        partitionSize $device &>/dev/null
-        if [ $? = 0 ]; then
+        storage_size=$(partitionSize $device &>/dev/null)
+        if [ $storage_size -gt 0 ]; then
             sleep 1; return 0
         fi
         if [ $check -eq $limit ]; then


### PR DESCRIPTION
Fixup assembling of mdraid array
    
when udev discovers an mdraid array it partially starts the array.
That is interfering with the mdadm --assemble call by kiwi which
leads to a busy state and an array in inactive state. Therefore
the method should wait until the raid array really exists no
matter if the assembling is started by udev or kiwi's mdadm call.
    
In addition if the array got assembled but is incomplete because
devices are missing or the timout is fired, an additional call to
start any array that has been partially assembled is required.
    
pxeRaidAssemble will throw an exception if after this call no
md device with a size > 0 will show up after a timeout. This
Fixes bnc#1000742