### PR TITLE
UpdateOtherDeviceFstab method was not keeping the first argument

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -3732,7 +3732,6 @@ function updateOtherDeviceFstab {
     # ----
     local IFS=$IFS_ORIG
     local prefix=$1
-    local prefix=$2
     local nfstab=$prefix/etc/fstab
     local index=0
     local field=0


### PR DESCRIPTION
This PR fixes bnc#1007765

updateOtherDeviceFstab is method responsible to include the fstab
lines needed to mount additional partitions (apart from swap and
root) defined in the description file. This method had an error
overwriting the variable $1 with the value of $2, which is always
empty, as the method it is never used with more than a single
parameter.