### PR TITLE
Testing isoinfo binary correctly

### DIFF
--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -999,10 +999,15 @@ sub isols {
     my $isoinfo_opts = " -R -l -i $iso 2>/dev/null |";
     my $files;
     local $_;
-    if (! $fd -> open ("/usr/bin/isoinfo" . $isoinfo_opts)) {
-        if (! $fd -> open ("/usr/lib/genisoimage/isoinfo" . $isoinfo_opts)) {
+    my $isoinfo_cmd = "/usr/bin/isoinfo";
+    if (! -x $isoinfo_cmd){
+        $isoinfo_cmd = "/usr/lib/genisoimage/isoinfo";
+        if (! -x $isoinfo_cmd){
             return;
         }
+    }
+    if (! $fd -> open ($isoinfo_cmd . $isoinfo_opts)) {
+        return;
     }
     while(<$fd>) {
         if(/^Directory listing of\s*(\/.*\/)/) {


### PR DESCRIPTION
In method 'isols()' isoinfo command line tool is used, however the
binary was opened before testing if it existed. Apparently the open
perl function was not returning an error if the file did not exist.
So in the case that isoinfo was not located in /usr/bin/isoinfo the
open command was not failing, hence never trying to open the
fallback location /usr/lib/genisoimage/isoinfo.

This commit fixes #614.