### PR TITLE
Fixed expansion of msdos disks

### DIFF
--- a/system/boot/armv7l/oemboot/suse-repart
+++ b/system/boot/armv7l/oemboot/suse-repart
@@ -934,7 +934,16 @@ function getFreeDiskBytes {
     if [ ! -b "$disk" ];then
         echo 0 ; return
     fi
+    local pt_table_type=$(blkid -s PTTYPE -o value $disk)
     local disk_Bytes=$(blockdev --getsize64 $disk)
+    # max msdos table geometry is at 2TB - 512
+    # max sector count taken from parted
+    local max_dos_disk=$((4294967295 * 512))
+    if [ "$pt_table_type" = "dos" ] && [ "$disk_Bytes" -gt $max_dos_disk ];then
+        Echo "Warning: msdos table allows a max disk size of 2TB"
+        Echo "Warning: disk expansion will be truncated to 2TB"
+        disk_Bytes=$max_dos_disk
+    fi
     local rest_Bytes=$disk_Bytes
     local part_Bytes=0
     for i in 1 2 3 4;do

--- a/system/boot/ix86/oemboot/rhel-repart
+++ b/system/boot/ix86/oemboot/rhel-repart
@@ -931,7 +931,16 @@ function getFreeDiskBytes {
     if [ ! -b "$disk" ];then
         echo 0 ; return
     fi
+    local pt_table_type=$(blkid -s PTTYPE -o value $disk)
     local disk_Bytes=$(blockdev --getsize64 $disk)
+    # max msdos table geometry is at 2TB - 512
+    # max sector count taken from parted
+    local max_dos_disk=$((4294967295 * 512))
+    if [ "$pt_table_type" = "dos" ] && [ "$disk_Bytes" -gt $max_dos_disk ];then
+        Echo "Warning: msdos table allows a max disk size of 2TB"
+        Echo "Warning: disk expansion will be truncated to 2TB"
+        disk_Bytes=$max_dos_disk
+    fi
     local rest_Bytes=$disk_Bytes
     local part_Bytes=0
     for i in 1 2 3 4;do

--- a/system/boot/ix86/oemboot/suse-repart
+++ b/system/boot/ix86/oemboot/suse-repart
@@ -931,7 +931,16 @@ function getFreeDiskBytes {
     if [ ! -b "$disk" ];then
         echo 0 ; return
     fi
+    local pt_table_type=$(blkid -s PTTYPE -o value $disk)
     local disk_Bytes=$(blockdev --getsize64 $disk)
+    # max msdos table geometry is at 2TB - 512
+    # max sector count taken from parted
+    local max_dos_disk=$((4294967295 * 512))
+    if [ "$pt_table_type" = "dos" ] && [ "$disk_Bytes" -gt $max_dos_disk ];then
+        Echo "Warning: msdos table allows a max disk size of 2TB"
+        Echo "Warning: disk expansion will be truncated to 2TB"
+        disk_Bytes=$max_dos_disk
+    fi
     local rest_Bytes=$disk_Bytes
     local part_Bytes=0
     for i in 1 2 3 4;do

--- a/system/boot/ppc/oemboot/suse-repart
+++ b/system/boot/ppc/oemboot/suse-repart
@@ -930,7 +930,16 @@ function getFreeDiskBytes {
     if [ ! -b "$disk" ];then
         echo 0 ; return
     fi
+    local pt_table_type=$(blkid -s PTTYPE -o value $disk)
     local disk_Bytes=$(blockdev --getsize64 $disk)
+    # max msdos table geometry is at 2TB - 512
+    # max sector count taken from parted
+    local max_dos_disk=$((4294967295 * 512))
+    if [ "$pt_table_type" = "dos" ] && [ "$disk_Bytes" -gt $max_dos_disk ];then
+        Echo "Warning: msdos table allows a max disk size of 2TB"
+        Echo "Warning: disk expansion will be truncated to 2TB"
+        disk_Bytes=$max_dos_disk
+    fi
     local rest_Bytes=$disk_Bytes
     local part_Bytes=0
     for i in 1 2 3 4;do

--- a/system/boot/s390/oemboot/suse-repart
+++ b/system/boot/s390/oemboot/suse-repart
@@ -957,7 +957,16 @@ function getFreeDiskBytes {
     if [ ! -b "$disk" ];then
         echo 0 ; return
     fi
+    local pt_table_type=$(blkid -s PTTYPE -o value $disk)
     local disk_Bytes=$(blockdev --getsize64 $disk)
+    # max msdos table geometry is at 2TB - 512
+    # max sector count taken from parted
+    local max_dos_disk=$((4294967295 * 512))
+    if [ "$pt_table_type" = "dos" ] && [ "$disk_Bytes" -gt $max_dos_disk ];then
+        Echo "Warning: msdos table allows a max disk size of 2TB"
+        Echo "Warning: disk expansion will be truncated to 2TB"
+        disk_Bytes=$max_dos_disk
+    fi
     local rest_Bytes=$disk_Bytes
     local part_Bytes=0
     for i in 1 2 3 4;do


### PR DESCRIPTION
If the target disk size is beyond 2TB it can't be expanded to
the full size if the msdos partition table layout is in use.
Because of this the disk expansion will be limited to the
allowed maximum for the msdos partition table type which is
at 2TB. This fixes bnc#1010966