### PR TITLE
Initialize the systemd machine ID on first boot

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -8101,6 +8101,21 @@ function setupConfigFiles {
     rm -rf /config
 }
 #======================================
+# setupMachineID
+#--------------------------------------
+function setupMachineID {
+    # /.../
+    # systemd-machine-id-setup. Initialize the machine ID
+    # in /etc/machine-id. The machine ID is defined to be a
+    # unique information. Thus it is required to initialize
+    # it on first boot of the image. In addition the same
+    # machine-id is configured to be used by dbus
+    # ----
+    systemd-machine-id-setup
+    rm -f /var/lib/dbus/machine-id && \
+        ln -s /etc/machine-id /var/lib/dbus/machine-id
+}
+#======================================
 # activateImage
 #--------------------------------------
 function activateImage {

--- a/system/boot/armv7l/oemboot/suse-preinit
+++ b/system/boot/armv7l/oemboot/suse-preinit
@@ -141,12 +141,17 @@ fi
 setupConsole
 
 #======================================
-# 10) Run user script
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 11) kill udev
+# 12) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/system/boot/armv7l/vmxboot/suse-preinit
+++ b/system/boot/armv7l/vmxboot/suse-preinit
@@ -76,12 +76,17 @@ fi
 setupConsole
 
 #======================================
-# 9) Run user script
+# 9) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 10) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 10) kill udev
+# 11) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/system/boot/ix86/isoboot/suse-preinit
+++ b/system/boot/ix86/isoboot/suse-preinit
@@ -36,11 +36,16 @@ updateMTAB
 setupConsole
 
 #======================================
-# 4) create framebuffer devices
+# 4) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 5) create framebuffer devices
 #--------------------------------------
 createFramebufferDevices
 
 #======================================
-# 5) clean mount
+# 6) clean mount
 #--------------------------------------
 umountSystemFilesystems

--- a/system/boot/ix86/netboot/suse-preinit
+++ b/system/boot/ix86/netboot/suse-preinit
@@ -117,6 +117,7 @@ fi
 #--------------------------------------
 if [ "$systemIntegrity" = "clean" ];then
     setupConsole
+    setupMachineID
 fi
 
 #======================================

--- a/system/boot/ix86/oemboot/suse-preinit
+++ b/system/boot/ix86/oemboot/suse-preinit
@@ -141,12 +141,17 @@ fi
 setupConsole
 
 #======================================
-# 10) Run user script
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 11) kill udev
+# 12) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/system/boot/ix86/vmxboot/suse-preinit
+++ b/system/boot/ix86/vmxboot/suse-preinit
@@ -76,12 +76,17 @@ fi
 setupConsole
 
 #======================================
-# 9) Run user script
+# 9) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 10) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 10) kill udev
+# 11) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/system/boot/ppc/netboot/suse-preinit
+++ b/system/boot/ppc/netboot/suse-preinit
@@ -117,6 +117,7 @@ fi
 #--------------------------------------
 if [ "$systemIntegrity" = "clean" ];then
     setupConsole
+    setupMachineID
 fi
 
 #======================================

--- a/system/boot/ppc/oemboot/suse-preinit
+++ b/system/boot/ppc/oemboot/suse-preinit
@@ -141,12 +141,17 @@ fi
 setupConsole
 
 #======================================
-# 10) Run user script
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 11) kill udev
+# 12) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/system/boot/ppc/vmxboot/suse-preinit
+++ b/system/boot/ppc/vmxboot/suse-preinit
@@ -76,12 +76,17 @@ fi
 setupConsole
 
 #======================================
-# 9) Run user script
+# 9) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 10) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 10) kill udev
+# 11) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/system/boot/s390/netboot/suse-preinit
+++ b/system/boot/s390/netboot/suse-preinit
@@ -123,6 +123,7 @@ fi
 #--------------------------------------
 if [ "$systemIntegrity" = "clean" ];then
     setupConsole
+    setupMachineID
 fi
 
 #======================================

--- a/system/boot/s390/oemboot/suse-preinit
+++ b/system/boot/s390/oemboot/suse-preinit
@@ -154,11 +154,16 @@ fi
 setupConsole
 
 #======================================
-# 11) load network module
+# 11) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 12) load network module
 #--------------------------------------
 if loadNetworkCardS390 "0.0.0191";then
     #======================================
-    # 11.2) Setup network interface and DNS
+    # 12.2) Setup network interface and DNS
     #--------------------------------------
     setupNetworkInterfaceS390
     udevPending
@@ -167,12 +172,12 @@ if loadNetworkCardS390 "0.0.0191";then
 fi
 
 #======================================
-# 12) Run user script
+# 13) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 13) kill udev
+# 14) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/system/boot/s390/vmxboot/suse-preinit
+++ b/system/boot/s390/vmxboot/suse-preinit
@@ -89,11 +89,16 @@ fi
 setupConsole
 
 #======================================
-# 10) load network module
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) load network module
 #--------------------------------------
 if loadNetworkCardS390 "0.0.0191";then
     #======================================
-    # 10.2) Setup network interface and DNS
+    # 11.2) Setup network interface and DNS
     #--------------------------------------
     setupNetworkInterfaceS390
     udevPending
@@ -102,12 +107,12 @@ if loadNetworkCardS390 "0.0.0191";then
 fi
 
 #======================================
-# 11) Run user script
+# 12) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 12) kill udev
+# 13) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems


### PR DESCRIPTION
The systemd machine id is considered to be a unique information
Thus it is required to initialize it on first boot of the image.
If the image uses the kiwi boot code (initrd) this action is
performed and and Fixes #624