### PR TITLE
Fixup setupMachineID

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -8105,19 +8105,11 @@ function setupConfigFiles {
 #--------------------------------------
 function setupMachineID {
     # /.../
-    # systemd-machine-id-setup initializes the machine ID
-    # in /etc/machine-id. The machine ID is defined to be a
-    # unique information. Thus it is required to initialize
-    # it on first boot of the image. In addition the same
-    # machine-id is configured to be used by dbus. In order
-    # to achieve this kiwi cleans up all existing machine
-    # id files which triggers the creation of a new set of
-    # machine ids by systemd on startup
+    # This method can be used to handle the machine ID
+    # in /etc/machine-id and/or /var/lib/dbus/machine-id
+    # It is actually implemented as a custom hook script
     # ----
-    rm -f /etc/machine-id
-    if [ ! -L /var/lib/dbus/machine-id ];then
-        rm -f /var/lib/dbus/machine-id
-    fi
+    runHook handleMachineID "$@"
 }
 #======================================
 # activateImage


### PR DESCRIPTION
Cleaning up existing machine id files by deleting them
causes an interactive session to be started by systemd
This is something we don't want. As the consequences
of touching the machine id files seems to be too critical
the method has been turned into a hook caller. This
allows the user to make use of it on their own purpose
and by default doesn't mess with the machine id files
This Fixes #628