### PR TITLE
Prevent quoted domain name

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -5117,8 +5117,8 @@ function dhclientImportInfo {
         awk '{print $3}' |tr -d ';'
     )
     export DOMAIN=$(
-        cat $lease | grep 'domain-name' | grep -v 'domain-name-server' |\
-        awk '{print $3}'| tr -d ';'
+        cat $lease | grep -w 'domain-name '|\
+        awk -F \" '{print $2}'
     )
     export DNSSERVERS=$(
         cat $lease | grep 'domain-name-servers'|\


### PR DESCRIPTION
We're getting domain name by parsion a lease file. Unfortunately in
lease file domain name is quoted, which breaks linux resolver.

This commit gets domainname unquoted

Signed-off-by: Dinar Valeev <k0da@opensuse.org>