### PR TITLE
Make sure the disk symlink is removed before moving ovf folder

### DIFF
--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -1302,6 +1302,9 @@ sub createOVFConfiguration {
     }
     KIWIQX::qxx ("mv $ovfdir $ovfdir.tmp");
     KIWIQX::qxx ("mkdir -p $destdir");
+    if (-l "$ovfdir.tmp/$vmdk"){
+        unlink "$ovfdir.tmp/$vmdk";
+    }
     KIWIQX::qxx ("mv -f $ovfdir.tmp/* $destdir");
     KIWIQX::qxx ("rmdir $ovfdir.tmp");
     return $ovf;


### PR DESCRIPTION
This commit deletes a relative symlink of the vmx disk before
moving ovf files from a temporary folder to the destination folder.

Fixes #633