### PR TITLE
Fixed detection of Xen PV guest

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -214,10 +214,6 @@ sub new {
     #------------------------------------------
     $this->{gdata} = $global -> getKiwiConfig();
     #==========================================
-    # check if Xen system is used
-    #------------------------------------------
-    ($xengz, $isxen) = $global -> isXen ($initrd);
-    #==========================================
     # create tmp dir for operations
     #------------------------------------------
     $tmpdir = KIWIQX::qxx ("mktemp -qdt kiwiboot.XXXXXX");
@@ -273,6 +269,10 @@ sub new {
             $syszip = $read_result{sysz_size};
         }
     }
+    #==========================================
+    # check if Xen system is used
+    #------------------------------------------
+    ($xengz, $isxen) = $global -> isXen ($initrd, $xml);
     #==========================================
     # read origin path of XML description
     #------------------------------------------
@@ -4682,7 +4682,7 @@ sub setupBootLoaderConfiguration {
         #==========================================
         # Standard boot
         #------------------------------------------
-        if ((! $isxen) || ($isxen && $xendomain eq "domU")) {
+        if ((! $isxen) || ($isxen && $xendomain =~ "domU")) {
             if ($iso) {
                 print $FD "\t"."echo Loading linux...\n";
                 print $FD "\t"."set gfxpayload=$gfx"."\n";
@@ -4782,7 +4782,7 @@ sub setupBootLoaderConfiguration {
             $title = $this -> quoteLabel ("Failsafe -- $title");
             print $FD 'menuentry "'.$title.'"';
             print $FD ' --class opensuse --class os {'."\n";
-            if ((! $isxen) || ($isxen && $xendomain eq "domU")) {
+            if ((! $isxen) || ($isxen && $xendomain =~ "domU")) {
                 if ($iso) {
                     print $FD "\t"."echo Loading linux...\n";
                     print $FD "\t"."set gfxpayload=$gfx"."\n";
@@ -4961,7 +4961,7 @@ sub setupBootLoaderConfiguration {
         #==========================================
         # Standard boot
         #------------------------------------------
-        if ((! $isxen) || ($isxen && $xendomain eq "domU")) {
+        if ((! $isxen) || ($isxen && $xendomain =~ "domU")) {
             if ($iso) {
                 print $FD " kernel (cd)/boot/linux vga=$vga";
                 print $FD " ramdisk_size=512000 ramdisk_blocksize=4096";
@@ -5011,7 +5011,7 @@ sub setupBootLoaderConfiguration {
         if ($failsafe) {
             $title = $this -> makeLabel ("Failsafe -- $title");
             print $FD "title $title\n";
-            if ((! $isxen) || ($isxen && $xendomain eq "domU")) {
+            if ((! $isxen) || ($isxen && $xendomain =~ "domU")) {
                 if ($iso) {
                     print $FD " kernel (cd)/boot/linux vga=$vga";
                     print $FD " ramdisk_size=512000 ramdisk_blocksize=4096";
@@ -5411,7 +5411,7 @@ sub setupBootLoaderConfiguration {
         #==========================================
         # Standard boot
         #------------------------------------------
-        if ((! $isxen) || ($isxen && $xendomain eq "domU")) {
+        if ((! $isxen) || ($isxen && $xendomain =~ "domU")) {
             if ($iso) {
                 print $FD "\t"."label = $title\n";
                 print $FD "\t"."image  = /boot/linux\n";

--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -1085,7 +1085,7 @@ sub createImageVMX {
     #==========================================
     # Create VM format/configuration
     #------------------------------------------
-    if ((defined $name->{format}) || ($xendomain eq "domU")) {
+    if ((defined $name->{format}) || ($xendomain =~ /domU/)) {
         $cmdL -> setSystemLocation (
             $idest."/".$name->{systemImage}.".raw"
         );
@@ -3131,7 +3131,7 @@ sub createImageSplit {
         #==========================================
         # Create VM format/configuration
         #------------------------------------------
-        if ((defined $name->{format}) || ($xendomain eq "domU")) {
+        if ((defined $name->{format}) || ($xendomain =~ /domU/)) {
             $cmdL -> setSystemLocation (
                 $idest."/".$name->{systemImage}.".raw"
             );

--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -257,7 +257,7 @@ sub createMachineConfiguration {
         $kiwi -> skipped ();
         return;
     }
-    if (($bootp) && ($bootp eq "xen") && ($xend eq "domU")) {
+    if (($bootp) && ($bootp eq "xen") && ($xend =~ /domU/)) {
         $kiwi -> info ("Creating $imgtype image machine configuration\n");
         return $this -> createXENConfiguration();
     } elsif ($format eq "vmdk") {

--- a/modules/KIWISchema.rnc
+++ b/modules/KIWISchema.rnc
@@ -2703,7 +2703,10 @@ div {
         attribute arch { "ix86" | "x86_64" }
     k.machine.domain.attribute =
         ## The domain setup for the VM (xen only)
-        attribute domain { "dom0" | "domU" }
+        ## dom0 is the master domain from which xen instances are started
+        ## domU indicates a HVM guest
+        ## domU-PV indicates a PV guest
+        attribute domain { "dom0" | "domU" | "domU-PV" }
     k.machine.guestOS.attribute =
         ## The virtual guestOS identification string for the VM
         ## (vmdk and ovf, note the name designation is different for the two

--- a/modules/KIWISchema.rng
+++ b/modules/KIWISchema.rng
@@ -3862,10 +3862,14 @@ If not specified the image name is used</a:documentation>
     </define>
     <define name="k.machine.domain.attribute">
       <attribute name="domain">
-        <a:documentation>The domain setup for the VM (xen only)</a:documentation>
+        <a:documentation>The domain setup for the VM (xen only)
+dom0 is the master domain from which xen instances are started
+domU indicates a HVM guest
+domU-PV indicates a PV guest</a:documentation>
         <choice>
           <value>dom0</value>
           <value>domU</value>
+          <value>domU-PV</value>
         </choice>
       </attribute>
     </define>


### PR DESCRIPTION
The method isXen was used to check if the paravirtual kernel
kernel-xen is used and if so it influences the setup of the
bootloader. In newer versions there is no kernel-xen anymore
and its capabilities were moved into the pvops kernel provided
with the standard kernel-default package. Thus one kernel can
now serve for pv, hvm and dom0 images. Because of that there is
no other way than specifying the target Xen use case as part
of the image description. The information can be provided in
the doman setup of the machine configuratin with:

- domain="dom0"
- domain="domU"
- domain="domU-PV"

The new domU-PV value allows to specify that this image is going
to be used as a xen para virtual guest. The standard domU value
will setup the bootloader in a way that it is usable as "real"
bootloader in an hvmloader Xen guest. Fixes (bsc#1036198)