### PR TITLE
Fix oem partition install

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -6044,7 +6044,8 @@ function partedGetPartitionID {
         local name=$(parted -m -s $1 print | grep ^$2: | cut -f6 -d:)
         if lookup sgdisk &>/dev/null;then
             # map to short gdisk code
-            echo $(sgdisk -p $1 | grep -E "^   $2") | cut -f6 -d ' '
+            echo $(sgdisk -p $1 | grep -E "^   $2") | cut -f6 -d ' ' |\
+                cut -c-2
         elif [ "$name" = "lxroot" ];then
             # map lxroot to MBR type 83 (linux)
             echo 83

--- a/system/boot/armv7l/oemboot/suse-dump
+++ b/system/boot/armv7l/oemboot/suse-dump
@@ -351,7 +351,7 @@ function OEMInstall {
         #--------------------------------------
         info=/tmp/partinfo
         wmrc=/wmrc
-        loop=$(loop_setup -f --show $imageName)
+        loop=$(loop_setup $imageName)
         loop=$(echo $loop | sed -e s@^/dev/@@)
         if ! kpartx -sa /dev/$loop;then
             systemException \

--- a/system/boot/ix86/oemboot/rhel-dump
+++ b/system/boot/ix86/oemboot/rhel-dump
@@ -351,7 +351,7 @@ function OEMInstall {
         #--------------------------------------
         info=/tmp/partinfo
         wmrc=/wmrc
-        loop=$(loop_setup -f --show $imageName)
+        loop=$(loop_setup $imageName)
         loop=$(echo $loop | sed -e s@^/dev/@@)
         if ! kpartx -sa /dev/$loop;then
             systemException \

--- a/system/boot/ix86/oemboot/suse-dump
+++ b/system/boot/ix86/oemboot/suse-dump
@@ -351,7 +351,7 @@ function OEMInstall {
         #--------------------------------------
         info=/tmp/partinfo
         wmrc=/wmrc
-        loop=$(loop_setup -f --show $imageName)
+        loop=$(loop_setup $imageName)
         loop=$(echo $loop | sed -e s@^/dev/@@)
         if ! kpartx -sa /dev/$loop;then
             systemException \

--- a/system/boot/ppc/oemboot/suse-dump
+++ b/system/boot/ppc/oemboot/suse-dump
@@ -351,7 +351,7 @@ function OEMInstall {
         #--------------------------------------
         info=/tmp/partinfo
         wmrc=/wmrc
-        loop=$(loop_setup -f --show $imageName)
+        loop=$(loop_setup $imageName)
         loop=$(echo $loop | sed -e s@^/dev/@@)
         if ! kpartx -sa /dev/$loop;then
             systemException \

--- a/system/boot/s390/oemboot/suse-dump
+++ b/system/boot/s390/oemboot/suse-dump
@@ -351,7 +351,7 @@ function OEMInstall {
         #--------------------------------------
         info=/tmp/partinfo
         wmrc=/wmrc
-        loop=$(loop_setup -f --show $imageName)
+        loop=$(loop_setup $imageName)
         loop=$(echo $loop | sed -e s@^/dev/@@)
         if ! kpartx -sa /dev/$loop;then
             systemException \


### PR DESCRIPTION
This PR includes a couple of commits related to bnc#1039469:

* One fixes the `dump` script of the oem boot code in order to use the
appropriate arguments in `loop_setup` method.
* The other one modifies the partitionID output when using GPT partitions,
with the change the partition ID codes are two hexa digits as in MBR.