### PR TITLE
Fix baseSystemdCall method, fixes bsc#1041815

### DIFF
--- a/modules/KIWIConfig.sh
+++ b/modules/KIWIConfig.sh
@@ -66,7 +66,7 @@ function baseSystemdCall {
     local service_name=$1; shift
     local service=$(baseSystemdServiceInstalled "$service_name")
     if [ ! -z "$service" ];then
-        systemctl "$@" "$service"
+        systemctl "$@" "$service_name"
     fi
 }
 


### PR DESCRIPTION
This commit fixes the parameters passed to the systemd calls, with
the patch `baseService nfs-server off` can be executed without issues.