### PR TITLE
Do not include any suffix to the displayname value bsc#1029904

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -4296,11 +4296,14 @@ sub setupBootLoaderConfiguration {
     my $failsafe = 1;
     my $cmdline;
     my $title;
+    my $label_is_displayname = 0;
     #==========================================
     # set empty label if not defined
     #------------------------------------------
     if (! $label) {
         $label = "";
+    } elsif ($label eq $xml -> getImageDisplayName()) {
+        $label_is_displayname = 1;
     }
     #==========================================
     # Failsafe boot options
@@ -4675,7 +4678,11 @@ sub setupBootLoaderConfiguration {
             print $FD '}'."\n";
             $title = $this -> quoteLabel ("Install $label");
         } else {
-            $title = $this -> quoteLabel ("$label [ $topic ]");
+            if ($label_is_displayname) {
+                $title = $this -> quoteLabel ("$label");
+            } else {
+                $title = $this -> quoteLabel ("$label [ $topic ]");
+            }
         }
         print $FD 'menuentry "'.$title.'"';
         print $FD ' --class opensuse --class os {'."\n";
@@ -6857,7 +6864,7 @@ sub getStorageSize {
     # return the size of the given disk or disk
     # partition in Kb. If the call fails the function
     # returns 0
-    # --- 
+    # ---
     my $this = shift;
     my $pdev = shift;
     if ((! $pdev) || (! -e $pdev)) {

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -2349,7 +2349,7 @@ function setupBootLoaderS390Grub {
     elif [ -z "$kiwi_oemtitle" ];then
         title=$(makeLabel "$kname [ $gfix ]")
     else
-        title=$(makeLabel "$kiwi_oemtitle [ $gfix ]")
+        title=$(makeLabel "$kiwi_oemtitle")
     fi
     #======================================
     # check for kernel options
@@ -3092,7 +3092,7 @@ function setupBootLoaderGrub2 {
     elif [ -z "$kiwi_oemtitle" ];then
         title=$(makeLabel "$kname [ $gfix ]")
     else
-        title=$(makeLabel "$kiwi_oemtitle [ $gfix ]")
+        title=$(makeLabel "$kiwi_oemtitle")
     fi
     #======================================
     # check for kernel options


### PR DESCRIPTION
If displayname attribute in the description file is used we should
not include any kind of suffix to that value. With this patch
the grub2 menu entry does not include the image type suffix if the
displayname option is used.

Fixes bsc#1029904