### PR TITLE
Return 'string' instead of an object

### DIFF
--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -1031,7 +1031,7 @@ sub setupBTRFSSubVolumes {
         }
     }
     if (! %phash) {
-        return $this;
+        return $path;
     }
     $kiwi -> info ("Creating btrfs pool\n");
     my $data = KIWIQX::qxx ('btrfs subvolume create '.$path.'/@ 2>&1');
@@ -1108,7 +1108,7 @@ sub setupBTRFSSubVolumes {
         $kiwi -> failed();
         return;
     }
-    return $this;
+    return $path;
 }
 
 #==========================================


### PR DESCRIPTION
Commit e75ae3af3588a90db0b6d544fa2f8a7eb866e5e9 changed the returned value
of setupBTRFSSubVolumes to an object resulting in an error to create
the image on btrfs.