### PR TITLE
Fix vmdk disk convertion when using LVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: required
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ install:
     - cpanm -f -n $(cat .perlmodules | tr "\n" " ")
 
 script: make test
+dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -y xsltproc
     - sudo apt-get install -y syslinux
-    - sudo apt-get install -y squashfs-tools
     - echo "deb http://archive.ubuntu.com/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
     - sudo apt-get update
     - sudo apt-get install -y -t trusty tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-sudo: required
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -y xsltproc
     - sudo apt-get install -y syslinux
+    - sudo apt-get install -y squashfs-tools
     - echo "deb http://archive.ubuntu.com/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
     - sudo apt-get update
     - sudo apt-get install -y -t trusty tar

--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -1274,19 +1274,8 @@ sub checkLVMbind {
         return;
     }
     my @UmountStack = @{$this->{UmountStack}};
-    $_ = KIWIQX::qxx ("blkid $sdev 2>/dev/null");
     my $vgname = KIWIQX::qxx ("pvs --noheadings -o vg_name $sdev 2>/dev/null");
     my $result = $? >> 8;
-    if (/LVM2/) {
-        for my $i (0..5) {
-            if ($result == 0) {
-                last;
-            }
-            KIWIQX::qxx ("sleep 5");
-            $vgname = KIWIQX::qxx ("pvs --noheadings -o vg_name $sdev 2>/dev/null");
-            $result = $? >> 8;
-        }
-    }
     if ($result != 0) {
         return $sdev;
     }

--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -1274,8 +1274,19 @@ sub checkLVMbind {
         return;
     }
     my @UmountStack = @{$this->{UmountStack}};
+    $_ = KIWIQX::qxx ("blkid $sdev 2>/dev/null");
     my $vgname = KIWIQX::qxx ("pvs --noheadings -o vg_name $sdev 2>/dev/null");
     my $result = $? >> 8;
+    if (/LVM2/) {
+        for my $i (0..5) {
+            if ($result == 0) {
+                last;
+            }
+            KIWIQX::qxx ("sleep 5");
+            $vgname = KIWIQX::qxx ("pvs --noheadings -o vg_name $sdev 2>/dev/null");
+            $result = $? >> 8;
+        }
+    }
     if ($result != 0) {
         return $sdev;
     }


### PR DESCRIPTION
This patch fixes bsc#1059715. Calling 'pvs --noheadings -o vg_name <device>'
is not sufficient to get the volume name and to determine if LVM is being
used, as it could happen that udev events are not yet processed, thus the
<device> is not yet properly mapped. With this patch blkid is being used to
determine if the type of the requested partition is LVM and if so it proceeds
to a polling strategy to call pvs tool until it succeeds. Timeout is set to
30 seconds.