### PR TITLE
Fix Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ install:
     - cpanm -f -n $(cat .perlmodules | tr "\n" " ")
 
 script: make test
+dist: precise


### PR DESCRIPTION
This commit forces Travis to make use of Ubuntu Precise as the
build env, since by default it has been upgraded to Trusty and
some tests were failing due to this change.