### PR TITLE
Fix format convertion for vmdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ install:
     - cpanm -f -n $(cat .perlmodules | tr "\n" " ")
 
 script: make test
+dist: precise

--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -1274,8 +1274,19 @@ sub checkLVMbind {
         return;
     }
     my @UmountStack = @{$this->{UmountStack}};
+    $_ = KIWIQX::qxx ("blkid $sdev 2>/dev/null");
     my $vgname = KIWIQX::qxx ("pvs --noheadings -o vg_name $sdev 2>/dev/null");
     my $result = $? >> 8;
+    if (/LVM2/) {
+        for my $i (0..5) {
+            if ($result == 0) {
+                last;
+            }
+            KIWIQX::qxx ("sleep 5");
+            $vgname = KIWIQX::qxx ("pvs --noheadings -o vg_name $sdev 2>/dev/null");
+            $result = $? >> 8;
+        }
+    }
     if ($result != 0) {
         return $sdev;
     }


### PR DESCRIPTION
This patch fixes bsc#1059715. Calling `pvs --noheadings -o vg_name <device>`
is not sufficient to get the volume name and to determine if LVM is being
used, as it could happen that udev events are not yet processed, thus the
is not yet properly mapped. With this patch blkid is being used to
determine if the type of the requested partition is LVM and if so it proceeds
to a polling strategy to call pvs tool until it succeeds. Timeout is set to
30 seconds.