### PR TITLE
Perl 5.26 compatibility: find .kiwirc explicitly in ./

### DIFF
--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -2063,8 +2063,8 @@ sub _new_instance {
     # Read .kiwirc
     #--------------------------------------------
     my $file;
-    if (-f '.kiwirc') {
-        $file = '.kiwirc';
+    if (-f './.kiwirc') {
+        $file = './.kiwirc';
     }
     elsif (($ENV{'HOME'}) && (-f $ENV{'HOME'}.'/.kiwirc')) {
         $file = "$ENV{'HOME'}/.kiwirc";


### PR DESCRIPTION
Since Perl 5.26, "." is no longer part of @INC, thus adding it explicitly
to the .kiwirc path.