### PR TITLE
Fixed blocksize setup in losetup

### DIFF
--- a/modules/KIWIGlobals.pm
+++ b/modules/KIWIGlobals.pm
@@ -170,7 +170,7 @@ sub loop_setup {
     my $kiwi = $this->{kiwi};
     my $locator = KIWILocator -> instance();
     my $losetup_exec = $locator -> getExecPath("losetup");
-    my $logical_sector_size = '';
+    my $logical_block_size = '';
     if (! $losetup_exec) {
         $kiwi -> error("losetup not found on build system");
         $kiwi -> failed();
@@ -181,11 +181,11 @@ sub loop_setup {
         my $blocksize = $bldType -> getTargetBlockSize();
         my $default_blocksize = $this -> getKiwiConfigEntry('DiskSectorSize');
         if (($blocksize) && ($blocksize != $default_blocksize)) {
-            $logical_sector_size = "-L $blocksize";
+            $logical_block_size = "--logical-blocksize $blocksize";
         }
     }
     my $result = KIWIQX::qxx (
-        "$losetup_exec $logical_sector_size -f --show $source 2>&1"
+        "$losetup_exec $logical_block_size -f --show $source 2>&1"
     );
     my $status = $? >> 8;
     if ($status != 0) {

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -11625,11 +11625,11 @@ function backupGPT {
 function loop_setup {
     local IFS=$IFS_ORIG
     local target="$@"
-    local logical_sector_size
+    local logical_block_size
     if [ ! -z "$kiwi_target_blocksize" ];then
-        logical_sector_size="-L $kiwi_target_blocksize"
+        logical_block_size="--logical-blocksize $kiwi_target_blocksize"
     fi
-    local loop=$(losetup $logical_sector_size -f --show "$target")
+    local loop=$(losetup $logical_block_size -f --show "$target")
     if [ ! -e "$loop" ];then
         return 1
     fi


### PR DESCRIPTION
The -L option was used to set the blocksize value for losetup
However there is an option name clash between suse util-linux
and upstream which now leads to the problem that option -L
has changed its meaning and actually means --nooverlap which
completely breaks the call in kiwi. This patch changes the
call to use the long form --logical-blocksize.
This Fixes bsc#1066873