### PR TITLE
- Keep Melanox and hyperv kernel modules in the initrd

### DIFF
--- a/system/boot/ix86/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/vmxboot/suse-SLES12/config.xml
@@ -35,10 +35,12 @@
         <file name="drivers/ide/*"/>
         <file name="drivers/md/*"/>
         <file name="drivers/message/fusion/*"/>
+        <file name="drivers/net/ethernet/mellanox/*"/>
         <file name="drivers/net/virtio_net.ko"/>
         <file name="drivers/net/hyperv/hv_netvsc.ko"/>
         <file name="drivers/nvme/*"/>
         <file name="drivers/nvmem/*"/>
+        <file name="drivers/pci/host/pci-hyperv.ko"/>
         <file name="drivers/scsi/*"/>
         <file name="drivers/staging/hv/*"/>
         <file name="drivers/virtio/*"/>


### PR DESCRIPTION
  + Due to jitters in boot on Azure the drivers are not always found, keeping
    then in the initrd avoids the issue in the virtualized environment