### PR TITLE
KIWIImage: add grub2-mkimage prefix option

### DIFF
--- a/modules/KIWIImage.pm
+++ b/modules/KIWIImage.pm
@@ -1814,7 +1814,10 @@ sub createImageLiveCD {
             }
             my $core    = "$CD/EFI/BOOT/$efi_bin";
             my @modules = @efimods;
-            my $core_opts = "-O $efi_fo -o $core -c $bootefi -d $ir_modules";
+            my $core_opts;
+            $core_opts = "-O $efi_fo -o $core -c $bootefi ";
+            $core_opts.= "-p /boot/grub2 ";
+            $core_opts.= "-d $ir_modules";
             $status = KIWIQX::qxx (
                 "$grub2_mkimage $core_opts @modules 2>&1"
             );


### PR DESCRIPTION
grub2-mkimage on openSUSE Leap 42.3 now requires "-p" option.
See also ece8cb9e