### PR TITLE
Avoid race conditions because of using 'udevadm settle' command

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -2406,7 +2406,14 @@ sub setupBootDisk {
             #==========================================
             # Create loop device mapping table
             #------------------------------------------
-            %deviceMap = $this -> setLoopDeviceMap ($this->{loop});
+            my $it = 0;
+            while (!keys %deviceMap) {
+                if ($it++ >= 5){
+                    $kiwi -> error ("Couldn't set loop device map");
+                }
+                %deviceMap = $this -> setLoopDeviceMap ($this->{loop});
+                sleep 2;
+            }
         } else {
             #==========================================
             # Create disk device mapping table


### PR DESCRIPTION
This commit fixes bsc#1070587. With this patch kiwi tries to populate
the device map when using loop devices for 10 seconds and fails
if after that time no devices are found.