### PR TITLE
Set serial console configuration for grub for ec2 firmware (bsc#1071135)

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -319,6 +319,7 @@ sub new {
         $type{type}                   = $xmltype -> getTypeName();
         $type{vga}                    = $xmltype -> getVGA();
         $type{volid}                  = $xmltype -> getVolID();
+        $type{format}                 = $xmltype -> getFormat();
         if (! $type{filesystem}) {
             my $fsro = $xmltype -> getFSReadOnly();
             my $fsrw = $xmltype -> getFSReadWrite();
@@ -4610,7 +4611,7 @@ sub setupBootLoaderConfiguration {
 
         # Set serial console mode for ec2* firmwares. This is a hack for
         # Azure images in order to avoid new attributes in XML schema.
-        if ($type->{firmware} =~ m/ec2/) {
+        if ($type->{firmware} =~ m/ec2/ && $type->{format} eq 'vhd-fixed') {
             $console_mode = 'serial'
         }
 

--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -4608,6 +4608,12 @@ sub setupBootLoaderConfiguration {
         # console (console) or the serial terminal (serial)
         my $console_mode = 'graphics';
 
+        # Set serial console mode for ec2* firmwares. This is a hack for
+        # Azure images in order to avoid new attributes in XML schema.
+        if ($type->{firmware} =~ m/ec2/) {
+            $console_mode = 'serial'
+        }
+
         if ($console_mode eq 'console') {
             print $FD "\t".'terminal_input console'."\n";
             print $FD "\t".'terminal_output console'."\n";

--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -4611,7 +4611,7 @@ sub setupBootLoaderConfiguration {
 
         # Set serial console mode for ec2* firmwares. This is a hack for
         # Azure images in order to avoid new attributes in XML schema.
-        if ($type->{firmware} =~ m/ec2/ && $type->{format} eq 'vhd-fixed') {
+        if ($type->{firmware} =~ m/ec2/ || $type->{format} eq 'vhd-fixed') {
             $console_mode = 'serial'
         }
 

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -3162,6 +3162,14 @@ EOF
     else
         echo "GRUB_TERMINAL=console"  >> $inst_default_grub
     fi
+
+    # Set serial console mode for ec2* firmwares. This is a hack for
+    # Azure images in order to avoid new attributes in XML schema.
+    if [[ "$kiwi_firmware" =~ "ec2" ]]; then
+        local serial
+        serial="serial --speed=9600 --unit=0 --word=8 --parity=no --stop=1"
+        echo "GRUB_SERIAL_COMMAND=\"$serial\"" >> $inst_default_grub
+    fi
     #======================================
     # write etc/default/grub_installdevice
     #--------------------------------------

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -3157,19 +3157,19 @@ EOF
     #======================================
     # set terminal mode
     #--------------------------------------
-    if [ -e $unifont ];then
+    if [[ "$kiwi_firmware" =~ "ec2" ]] || [ "$kiwi_format" = 'vhd-fixed' ]; then
+        # Set serial console mode for ec2* firmwares. This is a hack for
+        # Azure images in order to avoid new attributes in XML schema.
+        local serial
+        serial="serial --speed=9600 --unit=0 --word=8 --parity=no --stop=1"
+        echo "GRUB_TERMINAL=serial"  >> $inst_default_grub
+        echo "GRUB_SERIAL_COMMAND=\"$serial\"" >> $inst_default_grub
+    elif [ -e $unifont ];then
         echo "GRUB_TERMINAL=gfxterm"  >> $inst_default_grub
     else
         echo "GRUB_TERMINAL=console"  >> $inst_default_grub
     fi
 
-    # Set serial console mode for ec2* firmwares. This is a hack for
-    # Azure images in order to avoid new attributes in XML schema.
-    if [[ "$kiwi_firmware" =~ "ec2" ]] && [ "$kiwi_format" = 'vhd-fixed' ]; then
-        local serial
-        serial="serial --speed=9600 --unit=0 --word=8 --parity=no --stop=1"
-        echo "GRUB_SERIAL_COMMAND=\"$serial\"" >> $inst_default_grub
-    fi
     #======================================
     # write etc/default/grub_installdevice
     #--------------------------------------

--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -3165,7 +3165,7 @@ EOF
 
     # Set serial console mode for ec2* firmwares. This is a hack for
     # Azure images in order to avoid new attributes in XML schema.
-    if [[ "$kiwi_firmware" =~ "ec2" ]]; then
+    if [[ "$kiwi_firmware" =~ "ec2" ]] && [ "$kiwi_format" = 'vhd-fixed' ]; then
         local serial
         serial="serial --speed=9600 --unit=0 --word=8 --parity=no --stop=1"
         echo "GRUB_SERIAL_COMMAND=\"$serial\"" >> $inst_default_grub

--- a/modules/KIWIProfileFile.pm
+++ b/modules/KIWIProfileFile.pm
@@ -73,6 +73,7 @@ sub new {
         kiwi_displayname
         kiwi_drivers
         kiwi_firmware
+        kiwi_format
         kiwi_fsmountoptions
         kiwi_hwclock
         kiwi_hybrid
@@ -432,6 +433,8 @@ sub __updateXMLType {
         $type -> getInstallBoot();
     $data{kiwi_bootkernel} =
         $type -> getBootKernel();
+    $data{kiwi_format} = 
+        $type -> getFormat();
     $data{kiwi_fsmountoptions} =
         $type -> getFSMountOptions();
     $data{kiwi_bootprofile} =


### PR DESCRIPTION
This commit sets the serial console for grub2 in case an ec2 firmware
is used. This is a hack to enable serial console for Azure images.