### PR TITLE
Fixup elog shell pid detection

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -7365,8 +7365,8 @@ function startShell {
             return
         fi
         Echo "Starting boot shell on $ELOG_BOOTSHELL"
-        setctsid -f $ELOG_BOOTSHELL /bin/bash -i
-        ELOGSHELL_PID=$(fuser $ELOG_BOOTSHELL | tr -d " ")
+        setctsid $ELOG_BOOTSHELL /bin/bash -i &
+        ELOGSHELL_PID=$!
         echo ELOGSHELL_PID=$ELOGSHELL_PID >> /iprocs
     fi
 }
@@ -7385,7 +7385,7 @@ function killShell {
     fi
     if [ ! -z "$ELOGSHELL_PID" ];then
         Echo "Stopping boot shell"
-        kill $ELOGSHELL_PID &>/dev/null
+        kill -9 $ELOGSHELL_PID &>/dev/null
     fi
     if [ $umountProc -eq 1 ];then
         umount /proc


### PR DESCRIPTION
Startup of the debug shell happened as extra process from
a setctsid call. The lookup of the process was based on
a fuser call on the slelected tty. However it can happen
that another process is also connected to the tty which
does not allow for a stable detection of the debug shell
process. This patch runs the debug shell as sub process
of the calling terminal and uses the sub process pid
This Fixes bsc#1075813