### PR TITLE
- Keep Infiniband drivers in the initrd

### DIFF
--- a/system/boot/ix86/vmxboot/suse-SLES12/config.xml
+++ b/system/boot/ix86/vmxboot/suse-SLES12/config.xml
@@ -33,6 +33,7 @@
         <file name="drivers/hid/*"/>
         <file name="drivers/hv/*"/>
         <file name="drivers/ide/*"/>
+        <file name="drivers/infiniband/hw/*"/>
         <file name="drivers/md/*"/>
         <file name="drivers/message/fusion/*"/>
         <file name="drivers/net/ethernet/mellanox/*"/>


### PR DESCRIPTION
  + When building a VM that is intended for a host that has PCI pass through
    of IB hardware we need the IB drivers in the initrd to get the network
    detected properly