### PR TITLE
Do not support installation stick without boot partition

### DIFF
--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -184,6 +184,9 @@ sub createChecks {
     if (! $this -> __hasContainerName()) {
         return;
     }
+    if (! $this -> __hasValidInstallStickSetup()) {
+        return;
+    }
     return 1;
 }
 
@@ -268,6 +271,9 @@ sub prepareChecks {
         return;
     }
     if (! $this -> __hasContainerName()) {
+        return;
+    }
+    if (! $this -> __hasValidInstallStickSetup()) {
         return;
     }
     return 1;
@@ -1948,6 +1954,34 @@ sub __here_format {
     $message =~ s/ {4}//g;
     $message.= "\n";
     return $message;
+}
+
+#==========================================
+# __hasValidInstallStickSetup
+#------------------------------------------
+sub __hasValidInstallStickSetup {
+    # ...
+    # Check if installstick="true" is set together with
+    # bootpartition="false" in type section. 
+    # This is a not supported combination
+    # ---
+    my $this = shift;
+    my $kiwi = $this->{kiwi};
+    my $xml = $this->{xml};
+    my $bldType = $xml -> getImageType();
+    my $bootpart = $bldType -> getBootPartition();
+    my $installstick = $bldType -> getInstallStick();
+    if ($bootpart eq 'false' && $installstick eq 'true') {
+        my $msg = "The use of a raw image as the installation media ";
+        $msg.= "(installstick=\"true\") without a boot partition ";
+        $msg.= "is not supported. Alternatively, it is possible build ";
+        $msg.= "an hybrid installation ISO (installiso=\"true\" ";
+        $msg.= "hybrid=\"true\") which can be also used as a raw image.";
+        $kiwi -> error($msg);
+        $kiwi -> failed();
+        return;
+    }
+    return 1;
 }
 
 1;


### PR DESCRIPTION
Installation stick bootloader configuration fails for the installation image (installstick="true") if the image is not configured to use a boot partition. Given the fact the same functionality can be achieved building installation hybrid ISOs this specific configuration is not supported.

This commit adds a runtime check to ensure this combination is not set in the description file.

Fixes bsc#1107906