### PR TITLE
Replace 'ifplugd' with 'auto' in STARTMODE

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -3452,7 +3452,7 @@ function setupDefaultPXENetwork {
     mkdir -p $prefix/etc/sysconfig/network
     cat > $niface < /dev/null
     echo "BOOTPROTO='dhcp'"    >> $niface
-    echo "STARTMODE='ifplugd'" >> $niface
+    echo "STARTMODE='auto'"    >> $niface
     echo "USERCONTROL='no'"    >> $niface
 }
 #======================================


### PR DESCRIPTION
This PR replaces
```
STARTMODE='ifplugd'
```
with
```
STARTMODE='auto'
```
in `/etc/sysconfig/network/ifcfg-ethN` as prepared by Kiwi.

Reason is that `ifplugd` seems to be deprecated on SLE family (at least I could not find it in SLE 12 SP3, while it still exists on Leap 15.0 ), probably replaced by `wicked`. It was already removed from `template/ix86/suse-SLE12-JeOS/config.xml` in commit https://github.com/openSUSE/kiwi/commit/c1c1c602245348f725d41d1457de85aa5a6f3f34 from @schaefi . On openSUSE, `auto`should just work fine, and is apparently the default anyway.

If the SLE machine prepared by Kiwi contains the wrong setting, then it is not completely properly functional after a reboot. For example, it has no link-local IPv6 address.
