### PR TITLE
Revert "Fixup kiwi-tools requirement"

### DIFF
--- a/rpm/kiwi.spec
+++ b/rpm/kiwi.spec
@@ -85,9 +85,7 @@ BuildRequires:  zypper
 Requires:       perl >= %{perl_version}
 Requires:       checkmedia
 Requires:       coreutils
-%if %{with kiwitools}
 Requires:       kiwi-tools >= %{version}
-%endif
 Requires:       libxslt
 Requires:       perl-Class-Singleton
 Requires:       perl-Config-IniFiles >= 2.49


### PR DESCRIPTION
This reverts commit 48011560e322266ca7eb55601af35895a24bcbf5. Former
kiwi should kiwi-tools package even if it does not define it in spec. In
those cases it will be provided by python-kiwi package. The requirement
should not be effected by the kiwitools conditional.

Fixes bsc#1118306