### PR TITLE
Sort filesystem listings

### DIFF
--- a/modules/KIWICollect.pm
+++ b/modules/KIWICollect.pm
@@ -2091,7 +2091,7 @@ sub collectProducts {
             $this->logMsg('I', "No products found, skipping");
             next RELEASEPACK;
         }
-        my @r = grep {$_ =~ '\.prod$'} readdir(D);
+        my @r = grep {$_ =~ '\.prod$'} sort(readdir(D));
         closedir D;
 
         # read each product file

--- a/modules/KIWIContainerBuilder.pm
+++ b/modules/KIWIContainerBuilder.pm
@@ -352,7 +352,7 @@ sub __createContainerBundle {
     }
     my @dirlist;
     if (opendir my($dh), $origin) {
-        @dirlist = grep { !/^\.\.?$/x } readdir $dh;
+        @dirlist = grep { !/^\.\.?$/x } sort(readdir $dh);
         closedir $dh;
     } else {
         $kiwi -> failed();

--- a/modules/KIWIRepoMetaHandler.pm
+++ b/modules/KIWIRepoMetaHandler.pm
@@ -114,7 +114,7 @@ sub loadPlugins {
         );
         return ($loaded, $avail);
     }
-    my @plugins = readdir(PLUGINDIR);
+    my @plugins = sort(readdir(PLUGINDIR));
     closedir(PLUGINDIR);
     my %plugins;
     foreach my $p(@plugins) {

--- a/modules/KIWIResult.pm
+++ b/modules/KIWIResult.pm
@@ -486,7 +486,7 @@ sub __sign_with_sha256sum {
         $kiwi -> failed ();
         return;
     }
-    while (my $entry = readdir ($dh)) {
+    while (my $entry = sort(readdir ($dh))) {
         next if $entry eq "." || $entry eq "..";
         next if ! -f "$tmpdir/$entry";
         my $alg = 'sha256';

--- a/modules/KIWIRoot.pm
+++ b/modules/KIWIRoot.pm
@@ -1194,7 +1194,7 @@ sub setup {
         }
         $kiwi -> done();
         my @scriptList = readdir $FD;
-        foreach my $script (@scriptList) {
+        foreach my $script (sort(@scriptList)) {
             if (-f "$root/image/config/$script") {
                 if ($manager -> setupPackageInfo ( $script )) {
                     next;
@@ -1471,7 +1471,7 @@ sub importHostPackageKeys {
     }
     my @rpm_keys = ();
     if (opendir (my $FD,$sigs)) {
-        @rpm_keys = readdir ($FD); closedir ($FD);
+        @rpm_keys = sort(readdir ($FD)); closedir ($FD);
     }
     if (@rpm_keys <= 2) {
         $kiwi -> skipped ();
@@ -1518,7 +1518,7 @@ sub exportHostPackageKeys {
     }
     my @rpm_keys = ();
     if (opendir (my $FD,"$root/rpm-sigs")) {
-        @rpm_keys = readdir ($FD); closedir ($FD);
+        @rpm_keys = sort(readdir ($FD)); closedir ($FD);
     }
     if (@rpm_keys <= 2) {
         return $this;

--- a/modules/KIWIRuntimeChecker.pm
+++ b/modules/KIWIRuntimeChecker.pm
@@ -957,7 +957,7 @@ sub __checkRootDirOutsideImageDescription {
     my @forbidden = ('config.xml', '*.kiwi');
     my $looks_like_description_dir;
     if (opendir (my $FD, $parent_dir)) {
-        my @dir_entries = readdir ($FD);
+        my @dir_entries = sort(readdir ($FD));
         closedir ($FD);
         foreach my $entry (@dir_entries) {
             if ($entry eq 'config.xml' || $entry =~ /\.kiwi$/) {
@@ -1932,7 +1932,7 @@ sub __read_pids {
     my $path = shift;
     my @pids;
     if (opendir (my $FD, $path)) {
-        foreach my $pid (readdir $FD) {
+        foreach my $pid (sort(readdir $FD)) {
             next if $pid !~ /^\d+$/;
             push @pids, $pid;
         }

--- a/modules/KIWIUtil.pm
+++ b/modules/KIWIUtil.pm
@@ -260,7 +260,7 @@ sub splitPathLocal {
     my $rest   = $testlist[1];
     # read current dir to list before descent:
     opendir(DIR, $basepath) or return;
-    my @dirlist = readdir(DIR);
+    my @dirlist = sort(readdir(DIR));
     closedir(DIR);
     $this->{m_collect}->logMsg("I", "Current local directory is $basepath");
     my $atleastonce = 0;


### PR DESCRIPTION
Sort filesystem listings
so that kiwi works in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.