### PR TITLE
Fixed GCE image bundler and tarball name

### DIFF
--- a/modules/KIWIImageFormat.pm
+++ b/modules/KIWIImageFormat.pm
@@ -588,6 +588,7 @@ sub createGoogleComputeEngine {
     my $gce_source = $src_dirname."/disk.raw";
     my $boot = $type -> getBootImageDescript();
     my $version = $xml -> getPreferences() -> getVersion();
+    my $arch = KIWIQX::qxx ("uname -m"); chomp $arch;
     my $status;
     my $result;
     my $dist;
@@ -607,7 +608,7 @@ sub createGoogleComputeEngine {
         $kiwi -> failed ();
         return;
     }
-    $target = $xml -> getImageName().$version.".tar.gz";
+    $target = $xml -> getImageName().".".$arch."-".$version.".tar.gz";
     $status = KIWIQX::qxx ("mv $source $gce_source 2>&1");
     $result = $? >> 8;
     my @content;

--- a/modules/KIWIResult.pm
+++ b/modules/KIWIResult.pm
@@ -426,16 +426,14 @@ sub __bundleDisk {
         $format = 'vhdfixed';
     }
     if ($format eq 'gce') {
-        my @archives = glob ("$source/*gce-*.tar.gz");
+        my @archives = glob ("$source/*.tar.gz");
         if (! @archives) {
             $kiwi -> error  ("No GCE archive(s) found");
             $kiwi -> failed ();
             return;
         }
         foreach my $archive (@archives) {
-            if ($archive =~ /$source\/(.*gce-.*)\.tar\.gz/) {
-                return $this -> __bundleExtension ('tar.gz', $1);
-            }
+            return $this -> __bundleExtension ('tar.gz');
         }
     }
     if ($format eq 'vagrant') {


### PR DESCRIPTION
The GCE bundler still looks for the old name format and
failed to find the image result. In addition the present
name format for the tarball is missing the architecture
information and did not follow pattern we use in kiwi-ng.
This Fixes bsc#1126217