### PR TITLE
Set SERVER variable as expected by netboot code

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -7643,6 +7643,8 @@ function fetchFile {
     #--------------------------------------
     if [ ! -z $kiwiserver ];then
         host=$kiwiserver
+    elif [ ! -z $SERVER ];then 
+        host="$SERVER"
     fi
     if [ -z "$host" ]; then
         systemException "No source server specified" "reboot"
@@ -7658,6 +7660,8 @@ function fetchFile {
     #--------------------------------------
     if [ ! -z $kiwiservertype ]; then
         type=$kiwiservertype
+    elif [ ! -z $SERVERTYPE ]; then
+        type="$SERVERTYPE"
     fi
     if [ -z "$type" ]; then
         type="tftp"
@@ -7908,12 +7912,16 @@ function putFile {
     fi
     if [ ! -z $kiwiserver ];then
         host=$kiwiserver
+    elif [ ! -z $SERVER ];then 
+        host="$SERVER"
     fi
     if test -z "$host"; then
         systemException "No server specified" "reboot"
     fi
     if [ ! -z $kiwiservertype ]; then
         type=$kiwiservertype
+    elif [ ! -z $SERVERTYPE ]; then
+        type="$SERVERTYPE"
     fi
     if test -z "$type"; then
         type="tftp"


### PR DESCRIPTION
This commit sets $host from $SERVER variable if present and no
$kiwiserver is given from the command line.

The same criteria applies for $type and $SERVERTYPE variables.

Fixes bsc#1133537