### PR TITLE
Remove -hfs flag from genisoimage call for big ISOs

### DIFF
--- a/modules/KIWIBoot.pm
+++ b/modules/KIWIBoot.pm
@@ -926,7 +926,7 @@ sub setupInstallCD {
     my $attr = "-R -J -f -pad -joliet-long";
     if (-s $system >= 4294967296) {
         # install image is bigger than 4g, needs extra iso options
-        $attr .= " -udf -hfs -iso-level 3";
+        $attr .= " -udf -iso-level 3";
     }
     $attr .= " -V \"$volid\"";
     $attr .= " -A \"$this->{mbrid}\"";


### PR DESCRIPTION
This commit removes the `-hfs` flag from the genisoimage call on install
media generation. This flag was used together with `-iso-level 3` and
`-udf` when the ISO was exceeding 4G size. Adding `-hfs` in that case
causes genisoimage to complain about missing `-iso-level 3` flag
despite being included to call.

`-hfs` is devoted to hybrid filesystems including HFS, however this was
used only on this particular case, images exceeding 4G, so that I
do not consider it a feature loss, since in most cases it was not
already there. Most likely this was a leftover from mkisofs tool times.

Fixes bsc#1189623

Signed-off-by: David Cassany <dcassany@suse.com>