### PR TITLE
Try up to 5 retries of wicked dhcp query

### DIFF
--- a/modules/KIWILinuxRC.sh
+++ b/modules/KIWILinuxRC.sh
@@ -5162,11 +5162,16 @@ function setupNetworkWicked {
         # try DHCP_DISCOVER on all interfaces
         if setIPLinkUp $try_iface; then
             dhcp_info=/var/run/wicked/wicked-${try_iface}.info
-            $wicked_dhcp4 --debug all \
-                --test --test-output $dhcp_info $try_iface
-            if [ $? = 0 ] && [ -s $dhcp_info ];then
-                DHCPCD_STARTED="$DHCPCD_STARTED $try_iface"
-            fi
+            for dhcp_retry in `seq 1 5` ; do
+                $wicked_dhcp4 --debug all \
+                    --test --test-output $dhcp_info $try_iface
+                if [ $? = 0 ] && [ -s $dhcp_info ];then
+                    DHCPCD_STARTED="$DHCPCD_STARTED $try_iface"
+                    break
+                fi
+                Echo "Retrying DHCP query"
+                sleep 2
+            done
         fi
     done
     if [ -z "$DHCPCD_STARTED" ];then


### PR DESCRIPTION
In some devices it appears waiting for link and couple more seconds is not enough and wicked dhcp call fails. tcpdump showed that DHCP request is not sent, so retry whole dhcp query up to 5 times in order to get the IP address.